### PR TITLE
This PR temporarily disables the new Kohler unit tests (see #18).

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -18,5 +18,5 @@ CreateUnitTest(mam4_gasaerexch_unit_tests mam4_gasaerexch_unit_tests.cpp)
 target_compile_options(mam4_nucleation_unit_tests PRIVATE -Werror)
 target_compile_options(mam4_gasaerexch_unit_tests PRIVATE -Werror)
 
-EkatCreateUnitTest(mam4_kohler_unit_tests mam4_kohler_unit_tests.cpp
-  LIBS mam4xx_tests ${HAERO_LIBRARIES})
+#EkatCreateUnitTest(mam4_kohler_unit_tests mam4_kohler_unit_tests.cpp
+#  LIBS mam4xx_tests ${HAERO_LIBRARIES})


### PR DESCRIPTION
A lack of auto-testing is hurting us right now. Things will get better once we are able to open up the Haero repo.

See issue #18 for details.