### PR TITLE
Add a format style for .clang-format.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+---
+BasedOnStyle: LLVM


### PR DESCRIPTION
This sets LLVM style since that is what the programming docs suggest as a coding style for mam4xx. Note that Haero used the Google style.