### PR TITLE
fixes for cuda

### DIFF
--- a/src/kohler.hpp
+++ b/src/kohler.hpp
@@ -76,9 +76,10 @@ PackType surface_tension_water_air<PackType>(const PackType T) {
 */
 template <typename ScalarType> KOKKOS_INLINE_FUNCTION
 ScalarType kelvin_coefficient(const ScalarType T=Constants::triple_pt_h2o) {
+  const Real density_h2o = Constants::density_h2o;
+  const Real r_gas_h2o_vapor = Constants::r_gas_h2o_vapor;
   return 2*surface_tension_water_air(T) /
-    (Constants::r_gas_h2o_vapor * T *
-     Constants::density_h2o);
+    (r_gas_h2o_vapor * T * density_h2o);
 }
 
 /** @brief Struct that represents the Kohler polynomial.
@@ -329,9 +330,12 @@ struct KohlerSolver {
     PackType wet_radius_left(0.9*dry_radius_microns);
     PackType wet_radius_right(50*dry_radius_microns);
     PackType wet_radius_init(25*dry_radius_microns);
+    const Real triple_pt_h2o = Constants::triple_pt_h2o;
+    const PackType default_T(triple_pt_h2o);
     const auto kpoly = polynomial_type(relative_humidity,
                                        hygroscopicity,
-                                       dry_radius_microns);
+                                       dry_radius_microns,
+                                       default_T);
     auto solver = SolverType(wet_radius_init,
                              wet_radius_left,
                              wet_radius_right,

--- a/src/tests/mam4_kohler_unit_tests.cpp
+++ b/src/tests/mam4_kohler_unit_tests.cpp
@@ -139,7 +139,9 @@ TEST_CASE("kohler_verificiation", "") {
     Kokkos::parallel_for("KohlerVerification::test_properties",
       num_packs,
       KOKKOS_LAMBDA (const int i) {
-        const auto kpoly = KohlerPolynomial<PackType>(rh(i), hyg(i), rdry(i));
+        const Real mam4_default_temperature = Constants::triple_pt_h2o;
+        const auto kpoly = KohlerPolynomial<PackType>(rh(i), hyg(i), rdry(i),
+          PackType(mam4_default_temperature));
         k_of_zero(i) = kpoly(PackType(0));
         k_of_rdry(i) = kpoly(rdry(i));
         k_of_25rdry(i) = kpoly(25*rdry(i));


### PR DESCRIPTION
Having to manually copy as `const Real phys_const = Constants::phys_const` seems like a language/compiler failure, but it seems necessary, given #22 and this PR.

This PR does not include the new clang-format LLVM style.   I'll do that separately.  For now, this builds, runs, and tests pass with cuda 11.7 & gcc 11.2.

Closes #21