### PR TITLE
Explicitly specifying ubuntu-22.04 as CI environment.

### DIFF
--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -16,7 +16,7 @@ jobs:
     # A build matrix storing all desired configurations.
     strategy:
       matrix:
-        os: [ubuntu-latest] #, macos-latest]
+        os: [ubuntu-22.04] #, macos-latest]
         build-type: [Debug, Release]
         fp-precision: [single, double]
         pack-size: [1, 4]


### PR DESCRIPTION
Because it's not clear what is meant by `ubuntu-latest`, this commit sets the image to use the Ubuntu 22.04 release. This gives us a bit more stability and transparency in our testing environment.