### PR TITLE
Add common gas density function

### DIFF
--- a/src/mam4xx/conversions.hpp
+++ b/src/mam4xx/conversions.hpp
@@ -319,10 +319,9 @@ mean_particle_volume_from_diameter(Real geom_diam, Real mean_std_dev) {
 /// @param [in] P pressure [Pa]
 /// @param [in] R gas constant [J/K/kg]
 /// @return density [kg/m3]
-KOKKOS_INLINE_FUNCTION Real
-density_of_ideal_gas(const Real T, const Real P,
-  const Real R = Constants::r_gas_dry_air) {
-  return P / (R*T);
+KOKKOS_INLINE_FUNCTION Real density_of_ideal_gas(
+    const Real T, const Real P, const Real R = Constants::r_gas_dry_air) {
+  return P / (R * T);
 }
 
 } // namespace mam4::conversions

--- a/src/tests/conversions_unit_tests.cpp
+++ b/src/tests/conversions_unit_tests.cpp
@@ -132,7 +132,7 @@ TEST_CASE("conversions", "") {
     logger.info("qv0 init = {}, Tv0 init = {}, calc temp = {}, calc vtemp = {}",
                 qv0, Tv0, temp, vtemp);
     logger.info("rho_dry = {}, rho_wet = {}", rho_dry, rho_wet);
-    REQUIRE( rho_dry > rho_wet );
+    REQUIRE(rho_dry > rho_wet);
     REQUIRE(FloatingPoint<Real>::equiv(Tv0, vtemp, tol));
   }
 


### PR DESCRIPTION
Lots of processes require air density, either dry or total.   This PR adds a common function to compute that quantity.

The common use case will be using this function with the views of temperature and pressure contained in a `haero::Atmosphere` instance.