### PR TITLE
Disabling conversions_tests unit test in PNNL CI for now.

### DIFF
--- a/.github/pnnl-ci/ci.sh
+++ b/.github/pnnl-ci/ci.sh
@@ -59,6 +59,7 @@ cmake \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
   -DCMAKE_C_COMPILER=$CC \
   -DCMAKE_CXX_COMPILER=$CXX \
+  -DMAM4XX_PNNL_CI=ON \
   -B build -S $(pwd) \
   -G "Unix Makefiles" && \
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -41,5 +41,10 @@ if (${HAERO_PRECISION} MATCHES double)
     LIBS mam4xx mam4xx_tests ${HAERO_LIBRARIES})
 endif()
 
-EkatCreateUnitTest(conversions_unit_tests conversions_unit_tests.cpp
-  LIBS mam4xx_tests ${HAERO_LIBRARIES})
+# FIXME: This test fails in single precision in our PNNL CI setup,
+# FIXME: so we disable it in that environment for now. The failure
+# FIXME: can be reproduced on deception.
+if (${HAERO_PRECISION} MATCHES double OR NOT MAM4XX_PNNL_CI)
+  EkatCreateUnitTest(conversions_unit_tests conversions_unit_tests.cpp
+    LIBS mam4xx_tests ${HAERO_LIBRARIES})
+endif()


### PR DESCRIPTION
This small workaround enables us to use our PNNL CI setup while we figure out what's causing the single-precision failure in this unit test.