### PR TITLE
Add tendencies to gas/aerosol exchange.

### DIFF
--- a/src/mam4xx/aero_config.hpp
+++ b/src/mam4xx/aero_config.hpp
@@ -64,30 +64,23 @@ public:
   /// Creates a container for prognostic variables on the specified number of
   /// vertical levels.
   explicit Prognostics(int num_levels) : nlev_(num_levels) {
-    del_h2so4_aeruptk = ColumnView("del_h2so4_aeruptk", num_levels);
     for (int mode = 0; mode < AeroConfig::num_modes(); ++mode) {
       n_mode_i[mode] = ColumnView("n_mode_i", num_levels);
       n_mode_c[mode] = ColumnView("n_mode_c", num_levels);
-      qnum_del_cond[mode] = ColumnView("qnum_del_cond", num_levels);
       Kokkos::deep_copy(n_mode_i[mode], 0.0);
       Kokkos::deep_copy(n_mode_c[mode], 0.0);
-      Kokkos::deep_copy(qnum_del_cond[mode], 0.0);
       for (int spec = 0; spec < AeroConfig::num_aerosol_ids(); ++spec) {
         q_aero_i[mode][spec] = ColumnView("q_aero_i", num_levels);
         q_aero_c[mode][spec] = ColumnView("q_aero_c", num_levels);
-        qaer_del_cond[spec][mode] = ColumnView("qaer_del_cond", num_levels);
         Kokkos::deep_copy(q_aero_i[mode][spec], 0.0);
         Kokkos::deep_copy(q_aero_c[mode][spec], 0.0);
-        Kokkos::deep_copy(qaer_del_cond[spec][mode], 0.0);
       }
     }
     for (int gas = 0; gas < AeroConfig::num_gas_ids(); ++gas) {
       q_gas[gas] = ColumnView("q_gas", num_levels);
       q_gas_avg[gas] = ColumnView("q_gas_avg", num_levels);
-      qgas_del_cond[gas] = ColumnView("qgas_del_cond", num_levels);
       Kokkos::deep_copy(q_gas[gas], 0.0);
       Kokkos::deep_copy(q_gas_avg[gas], 0.0);
-      Kokkos::deep_copy(qgas_del_cond[gas], 0.0);
       for (int mode = 0; mode < AeroConfig::num_modes(); ++mode) {
         uptkaer[gas][mode] = ColumnView("uptake_rate", num_levels);
         Kokkos::deep_copy(uptkaer[gas][mode], 0.0);
@@ -126,19 +119,6 @@ public:
   /// Uptate Rate for each gas species and each mode.
   /// Gas to aerosol mass transfer rate (1/s)
   ColumnView uptkaer[AeroConfig::num_gas_ids()][AeroConfig::num_modes()];
-
-  /// Aerosol number mix ratio changes over time step (#/kmol/s)
-  ColumnView qnum_del_cond[AeroConfig::num_modes()];
-
-  /// Aerosol mass mix ratio changes over time step (mol/mol/s)
-  ColumnView qaer_del_cond[AeroConfig::num_aerosol_ids()]
-                          [AeroConfig::num_modes()];
-
-  /// Current gas mix ratios changes over time step (mol/mol/s)
-  ColumnView qgas_del_cond[AeroConfig::num_gas_ids()];
-
-  /// H2SO4 mix ratios changes over time step (mol/mol/s)
-  ColumnView del_h2so4_aeruptk;
 
   KOKKOS_INLINE_FUNCTION
   int num_levels() const { return nlev_; }
@@ -193,6 +173,7 @@ public:
   using ColumnView = haero::ColumnView;
 
   explicit Diagnostics(int num_levels) : nlev_(num_levels) {
+    del_h2so4_aeruptk = ColumnView("del_h2so4_aeruptk", num_levels);
     for (int mode = 0; mode < AeroConfig::num_modes(); ++mode) {
       hygroscopicity[mode] = ColumnView("hygroscopicity", num_levels);
       Kokkos::deep_copy(hygroscopicity[mode], 0.0);
@@ -208,6 +189,16 @@ public:
           ColumnView("wet_geometric_mean_diameter_cloudeborne", num_levels);
       Kokkos::deep_copy(wet_geometric_mean_diameter_i[mode], 0.0);
       Kokkos::deep_copy(wet_geometric_mean_diameter_c[mode], 0.0);
+      qnum_del_cond[mode] = ColumnView("qnum_del_cond", num_levels);
+      Kokkos::deep_copy(qnum_del_cond[mode], 0.0);
+      for (int spec = 0; spec < AeroConfig::num_aerosol_ids(); ++spec) {
+        qaer_del_cond[spec][mode] = ColumnView("qaer_del_cond", num_levels);
+        Kokkos::deep_copy(qaer_del_cond[spec][mode], 0.0);
+      }
+    }
+    for (int gas = 0; gas < AeroConfig::num_gas_ids(); ++gas) {
+      qgas_del_cond[gas] = ColumnView("qgas_del_cond", num_levels);
+      Kokkos::deep_copy(qgas_del_cond[gas], 0.0);
     }
     uptkrate_h2so4 = ColumnView("uptkrate_h2so4", num_levels);
     Kokkos::deep_copy(uptkrate_h2so4, 0.0);
@@ -251,6 +242,19 @@ public:
 
   /// Number of time substeps needed to converge in mam_soaexch_advance_in_time
   haero::DeviceType::view_1d<int> num_substeps;
+
+  /// Aerosol number mix ratio changes over time step (#/kmol/s)
+  ColumnView qnum_del_cond[AeroConfig::num_modes()];
+
+  /// Aerosol mass mix ratio changes over time step (mol/mol/s)
+  ColumnView qaer_del_cond[AeroConfig::num_aerosol_ids()]
+                          [AeroConfig::num_modes()];
+
+  /// Current gas mix ratios changes over time step (mol/mol/s)
+  ColumnView qgas_del_cond[AeroConfig::num_gas_ids()];
+
+  /// H2SO4 mix ratios changes over time step (mol/mol/s)
+  ColumnView del_h2so4_aeruptk;
 
 private:
   int nlev_;

--- a/src/mam4xx/aero_config.hpp
+++ b/src/mam4xx/aero_config.hpp
@@ -117,7 +117,7 @@ public:
   ColumnView q_gas_avg[AeroConfig::num_gas_ids()];
 
   /// Uptate Rate for each gas species and each mode.
-  /// Gas to aerosol mass transfer rate (1/s)
+  /// i.e. Gas to aerosol mass transfer rate (1/s)
   ColumnView uptkaer[AeroConfig::num_gas_ids()][AeroConfig::num_modes()];
 
   KOKKOS_INLINE_FUNCTION
@@ -173,7 +173,6 @@ public:
   using ColumnView = haero::ColumnView;
 
   explicit Diagnostics(int num_levels) : nlev_(num_levels) {
-    del_h2so4_aeruptk = ColumnView("del_h2so4_aeruptk", num_levels);
     for (int mode = 0; mode < AeroConfig::num_modes(); ++mode) {
       hygroscopicity[mode] = ColumnView("hygroscopicity", num_levels);
       Kokkos::deep_copy(hygroscopicity[mode], 0.0);
@@ -189,16 +188,6 @@ public:
           ColumnView("wet_geometric_mean_diameter_cloudeborne", num_levels);
       Kokkos::deep_copy(wet_geometric_mean_diameter_i[mode], 0.0);
       Kokkos::deep_copy(wet_geometric_mean_diameter_c[mode], 0.0);
-      qnum_del_cond[mode] = ColumnView("qnum_del_cond", num_levels);
-      Kokkos::deep_copy(qnum_del_cond[mode], 0.0);
-      for (int spec = 0; spec < AeroConfig::num_aerosol_ids(); ++spec) {
-        qaer_del_cond[spec][mode] = ColumnView("qaer_del_cond", num_levels);
-        Kokkos::deep_copy(qaer_del_cond[spec][mode], 0.0);
-      }
-    }
-    for (int gas = 0; gas < AeroConfig::num_gas_ids(); ++gas) {
-      qgas_del_cond[gas] = ColumnView("qgas_del_cond", num_levels);
-      Kokkos::deep_copy(qgas_del_cond[gas], 0.0);
     }
     uptkrate_h2so4 = ColumnView("uptkrate_h2so4", num_levels);
     Kokkos::deep_copy(uptkrate_h2so4, 0.0);
@@ -242,19 +231,6 @@ public:
 
   /// Number of time substeps needed to converge in mam_soaexch_advance_in_time
   haero::DeviceType::view_1d<int> num_substeps;
-
-  /// Aerosol number mix ratio changes over time step (#/kmol/s)
-  ColumnView qnum_del_cond[AeroConfig::num_modes()];
-
-  /// Aerosol mass mix ratio changes over time step (mol/mol/s)
-  ColumnView qaer_del_cond[AeroConfig::num_aerosol_ids()]
-                          [AeroConfig::num_modes()];
-
-  /// Current gas mix ratios changes over time step (mol/mol/s)
-  ColumnView qgas_del_cond[AeroConfig::num_gas_ids()];
-
-  /// H2SO4 mix ratios changes over time step (mol/mol/s)
-  ColumnView del_h2so4_aeruptk;
 
 private:
   int nlev_;

--- a/src/mam4xx/aero_config.hpp
+++ b/src/mam4xx/aero_config.hpp
@@ -127,17 +127,17 @@ public:
   /// Gas to aerosol mass transfer rate (1/s)
   ColumnView uptkaer[AeroConfig::num_gas_ids()][AeroConfig::num_modes()];
 
-  /// Aerosol number mix ratio changes over time step (#/kmol/t)
+  /// Aerosol number mix ratio changes over time step (#/kmol/s)
   ColumnView qnum_del_cond[AeroConfig::num_modes()];
 
-  /// Aerosol mass mix ratio changes over time step (mol/mol/t)
+  /// Aerosol mass mix ratio changes over time step (mol/mol/s)
   ColumnView qaer_del_cond[AeroConfig::num_aerosol_ids()]
                           [AeroConfig::num_modes()];
 
-  /// Current gas mix ratios changes over time step (mol/mol/t)
+  /// Current gas mix ratios changes over time step (mol/mol/s)
   ColumnView qgas_del_cond[AeroConfig::num_gas_ids()];
 
-  /// H2SO4 mix ratios changes over time step (mol/mol/t)
+  /// H2SO4 mix ratios changes over time step (mol/mol/s)
   ColumnView del_h2so4_aeruptk;
 
   KOKKOS_INLINE_FUNCTION

--- a/src/mam4xx/gasaerexch.hpp
+++ b/src/mam4xx/gasaerexch.hpp
@@ -719,22 +719,16 @@ void gas_aerosol_uptake_rates_1box(
       dgn_awet, alnsg_aer, uptk_rate_factor, uptkaer, uptkrate_h2so4, niter_out,
       g0_soa_out);
 
-  for (int i = 0; i < num_mode; ++i) {
-    diags.qnum_del_cond[i](k) = (qnum_cur[i] - qnum_sv1[i]) / dt;
-  }
-  for (int i = 0; i < num_aer; ++i) {
-    for (int j = 0; j < num_mode; ++j) {
-      diags.qaer_del_cond[i][j](k) = (qaer_cur[i][j] - qaer_sv1[i][j]) / dt;
-    }
-  }
-  for (int i = 0; i < num_gas; ++i) {
-    diags.qgas_del_cond[i](k) +=
-        (qgas_cur[i] - (qgas_sv1[i] + qgas_netprod_otrproc[i] * dt)) / dt;
-  }
-  diags.del_h2so4_aeruptk(k) =
-      (qgas_cur[igas_h2so4] -
-       (qgas_sv1[igas_h2so4] + qgas_netprod_otrproc[igas_h2so4] * dt)) /
-      dt;
+  for (int i = 0; i < num_mode; ++i)
+    tends.n_mode_i[i](k) = (qnum_cur[i] - qnum_sv1[i]) / dt;
+
+  for (int i = 0; i < num_aer; ++i)
+    for (int j = 0; j < num_mode; ++j)
+      tends.q_aero_i[i][j](k) = (qaer_cur[i][j] - qaer_sv1[i][j]) / dt;
+
+  for (int g = 0; g < num_gas; ++g)
+    tends.q_gas[g](k) +=
+        (qgas_cur[g] - (qgas_sv1[g] + qgas_netprod_otrproc[g] * dt)) / dt;
 
   for (int g = 0; g < num_gas; ++g) {
     progs.q_gas[g](k) = qgas_cur[g];

--- a/src/mam4xx/gasaerexch.hpp
+++ b/src/mam4xx/gasaerexch.hpp
@@ -722,9 +722,9 @@ void gas_aerosol_uptake_rates_1box(
   for (int i = 0; i < num_mode; ++i)
     tends.n_mode_i[i](k) = (qnum_cur[i] - qnum_sv1[i]) / dt;
 
-  for (int i = 0; i < num_aer; ++i)
-    for (int j = 0; j < num_mode; ++j)
-      tends.q_aero_i[i][j](k) = (qaer_cur[i][j] - qaer_sv1[i][j]) / dt;
+  for (int n = 0; n < num_mode; ++n)
+    for (int g = 0; g < num_aer; ++g)
+      tends.q_aero_i[n][g](k) = (qaer_cur[g][n] - qaer_sv1[g][n]) / dt;
 
   for (int g = 0; g < num_gas; ++g)
     tends.q_gas[g](k) +=

--- a/src/mam4xx/gasaerexch.hpp
+++ b/src/mam4xx/gasaerexch.hpp
@@ -720,18 +720,18 @@ void gas_aerosol_uptake_rates_1box(
       g0_soa_out);
 
   for (int i = 0; i < num_mode; ++i) {
-    tends.qnum_del_cond[i](k) = (qnum_cur[i] - qnum_sv1[i]) / dt;
+    diags.qnum_del_cond[i](k) = (qnum_cur[i] - qnum_sv1[i]) / dt;
   }
   for (int i = 0; i < num_aer; ++i) {
     for (int j = 0; j < num_mode; ++j) {
-      tends.qaer_del_cond[i][j](k) = (qaer_cur[i][j] - qaer_sv1[i][j]) / dt;
+      diags.qaer_del_cond[i][j](k) = (qaer_cur[i][j] - qaer_sv1[i][j]) / dt;
     }
   }
   for (int i = 0; i < num_gas; ++i) {
-    tends.qgas_del_cond[i](k) +=
+    diags.qgas_del_cond[i](k) +=
         (qgas_cur[i] - (qgas_sv1[i] + qgas_netprod_otrproc[i] * dt)) / dt;
   }
-  tends.del_h2so4_aeruptk(k) =
+  diags.del_h2so4_aeruptk(k) =
       (qgas_cur[igas_h2so4] -
        (qgas_sv1[igas_h2so4] + qgas_netprod_otrproc[igas_h2so4] * dt)) /
       dt;


### PR DESCRIPTION
Looking at the mam_refactor code, these are the arrays that are used by other processes. The computation is just the difference of before and after concentrations but a division by the time step size was added to make it a tendency.