### PR TITLE
Non zero validation exits

### DIFF
--- a/src/validation/calcsize/calcsize_driver.cpp
+++ b/src/validation/calcsize/calcsize_driver.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
   Settings settings = ensemble->settings();
   if (!settings.has("function")) {
     std::cerr << "No function specified in mam4xx.settings!" << std::endl;
-    exit(0);
+    exit(1);
   }
 
   // Dispatch to the requested function.

--- a/src/validation/gasaerexch/gasaerexch_uptkrates_1box1gas.cpp
+++ b/src/validation/gasaerexch/gasaerexch_uptkrates_1box1gas.cpp
@@ -16,22 +16,22 @@ void test_gasaerexch_uptkrates_1box1gas_process(const Input &input,
   if (!input.has("temp")) {
     std::cerr << "Required name: "
               << "temp" << std::endl;
-    exit(0);
+    exit(1);
   }
   if (!input.has_array("dgncur_awet")) {
     std::cerr << "Required name: "
               << "dgncur_awet" << std::endl;
-    exit(0);
+    exit(1);
   }
   if (!input.has_array("lnsg")) {
     std::cerr << "Required name: "
               << "lnsg" << std::endl;
-    exit(0);
+    exit(1);
   }
   if (!input.has_array("aernum")) {
     std::cerr << "Required name: "
               << "aernum" << std::endl;
-    exit(0);
+    exit(1);
   }
   const bool has_mw_gas = input.has("mw_gas");
   const bool has_pmid = input.has("pmid");

--- a/src/validation/gasaerexch/skywkr_gasaerexch_timestepping.cpp
+++ b/src/validation/gasaerexch/skywkr_gasaerexch_timestepping.cpp
@@ -165,12 +165,12 @@ int main(int argc, char **argv) {
   Settings settings = ensemble->settings();
   if (!settings.has("mam_subr_name")) {
     std::cerr << "No function specified in mam4xx.mam_subr_name!" << std::endl;
-    exit(0);
+    exit(1);
   }
   if (settings.get("mam_subr_name") != "mam_gasaerexch_1subarea") {
     std::cerr << "mam4xx.mam_subr_name not `mam_gasaerexch_1subarea` "
               << std::endl;
-    exit(0);
+    exit(1);
   }
 
   const int h2so4 = static_cast<int>(mam4::GasId::H2SO4);

--- a/src/validation/nucleation/nucleation_driver.cpp
+++ b/src/validation/nucleation/nucleation_driver.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
   Settings settings = ensemble->settings();
   if (!settings.has("function")) {
     std::cerr << "No function specified in mam4xx.settings!" << std::endl;
-    exit(0);
+    exit(1);
   }
 
   // Dispatch to the requested function.


### PR DESCRIPTION
This pull request changes exit(0) to exit(1) in places where we would like ctest to catch errors in the validation input files.