### PR TITLE
Update resource groups and add retry to pipelines.

### DIFF
--- a/.github/pnnl-ci/README.md
+++ b/.github/pnnl-ci/README.md
@@ -21,7 +21,7 @@ The possible  GPU architectures are:
 For some reason only the HPC runners are configured to run at the moment, and so all stages will share that base configuration.
 ## Rebuilding HAERO in CI
 
-You can either add "[hearo-rebuild]" directly to your commit message, or go to https://code.pnnl.gov/e3sm/eagles/mam4xx and trigger the rebuild pipeline manually once you have pushed to your branch.
+You can either add `[hearo-rebuild]` or `[rebuild-haero]` directly to your commit message, or go to https://code.pnnl.gov/e3sm/eagles/mam4xx and trigger the rebuild pipeline manually once you have pushed to your branch.
 
 Make sure you either push to GitHub and have the mirror update first, or just push to the GitLab directly.
 

--- a/.github/pnnl-ci/pnnl.gitlab-ci.yml
+++ b/.github/pnnl-ci/pnnl.gitlab-ci.yml
@@ -71,6 +71,8 @@ variables:
   rules:
     - if: '$CI_COMMIT_TITLE =~ /\[haero-rebuild\]/'
       when: always
+    - if: '$CI_COMMIT_TITLE =~ /\[rebuild-haero\]/'
+      when: always
     - when: manual
   allow_failure: true
   variables:

--- a/README.md
+++ b/README.md
@@ -144,12 +144,11 @@ there into the CI pipelines. Since CI pipelines all share the same HAERO build, 
 sure that you do not attempt to re-build on top of another developer.
 
 In order to rebuild HAERO in PNNL CI, either:
-- Add `[haero-rebuild]` somewhere into your commit message when pushing to a PR
+- Add `[haero-rebuild]` or `[rebuild-haero]` somewhere into your commit message when pushing to a PR
 - Log onto the PNNL GitLab, and manually trigger the pipeline yourself.
 
-Pushing with the commit message `[haero-rebuild]` will build HAERO and run tests,
-however if you trigger the rebuild manually, you may have to re-run the pipeline again
-to update the GitHub PR with the correct status.
+Pushing with the commit message `[haero-rebuild]` or `[rebuild-haero]` will build HAERO and run tests,
+however if you trigger the rebuild manually, you may have to re-run the pipeline again as tests may have already completed.
 
 ## Generating Documentation
 


### PR DESCRIPTION
cc @pressel @jeff-cohere 

It seems like sometimes when pipelines run concurrently across different PRs/commits, that sometimes runners fail. This ensures that there are only 2 total resource groups, so only 2 runners will ever be used at a time.

This slows CI down a little but should make things easier as there will be fewer false negatives. I also configured the dependency relationship for jobs a little so that pipelines run faster.

I still think it would be worthwhile just to buy a few more runners, but this should work.