### PR TITLE
Switching from CreateUnitTest -> EkatCreateUnitTest.

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(create_unit_test)
+include(EkatCreateUnitTest)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mam4_test_config.hpp.in
   ${CMAKE_CURRENT_SOURCE_DIR}/mam4_test_config.hpp
@@ -16,13 +16,20 @@ target_include_directories(mam4xx_tests PUBLIC ${HAERO_INCLUDE_DIRS})
 target_link_libraries(mam4xx_tests ${HAERO_LIBRARIES})
 target_link_libraries(mam4xx_tests mam4xx)
 
-CreateUnitTest(utils_unit_tests utils_unit_tests.cpp)
-CreateUnitTest(mam4_nucleation_unit_tests mam4_nucleation_unit_tests.cpp)
-CreateUnitTest(mam4_gasaerexch_unit_tests mam4_gasaerexch_unit_tests.cpp)
-CreateUnitTest(mam4_coagulation_unit_tests mam4_coagulation_unit_tests.cpp)
-CreateUnitTest(mam4_calcsize_unit_tests mam4_calcsize_unit_tests.cpp)
-CreateUnitTest(mam4_rename_unit_tests mam4_rename_unit_tests.cpp)
-CreateUnitTest(mam4_aging_unit_tests mam4_aging_unit_tests.cpp)
+EkatCreateUnitTest(utils_unit_tests utils_unit_tests.cpp
+  LIBS mam4xx ${HAERO_LIBRARIES})
+EkatCreateUnitTest(mam4_nucleation_unit_tests mam4_nucleation_unit_tests.cpp
+  LIBS mam4xx ${HAERO_LIBRARIES})
+EkatCreateUnitTest(mam4_gasaerexch_unit_tests mam4_gasaerexch_unit_tests.cpp
+  LIBS mam4xx ${HAERO_LIBRARIES})
+EkatCreateUnitTest(mam4_coagulation_unit_tests mam4_coagulation_unit_tests.cpp
+  LIBS mam4xx ${HAERO_LIBRARIES})
+EkatCreateUnitTest(mam4_calcsize_unit_tests mam4_calcsize_unit_tests.cpp
+  LIBS mam4xx ${HAERO_LIBRARIES})
+EkatCreateUnitTest(mam4_rename_unit_tests mam4_rename_unit_tests.cpp
+  LIBS mam4xx ${HAERO_LIBRARIES})
+EkatCreateUnitTest(mam4_aging_unit_tests mam4_aging_unit_tests.cpp
+  LIBS mam4xx ${HAERO_LIBRARIES})
 
 target_compile_options(utils_unit_tests PRIVATE -Werror)
 target_compile_options(mam4_nucleation_unit_tests PRIVATE -Werror)
@@ -41,7 +48,8 @@ endif ()
 EkatCreateUnitTest(aero_modes_unit_tests aero_modes_tests.cpp
   LIBS mam4xx ${HAERO_LIBRARIES})
 
-CreateUnitTest(aero_config_unit_tests aero_config_unit_tests.cpp)
+EkatCreateUnitTest(aero_config_unit_tests aero_config_unit_tests.cpp
+  LIBS mam4xx ${HAERO_LIBRARIES})
 
 # FIXME: Temporarily disabling the mode_averages tests for single-precision
 # FIXME: builds so we can proceed with our un-Packed version of mam4xx.


### PR DESCRIPTION
See [this Haero issue](https://github.com/eagles-project/haero/issues/435) for details. We're getting rid of the `CreateUnitTest` CMake function in favor of `EkatCreateUnitTest`, since the former was developed when Haero was the primary deliverable (and no longer has all the contextual information it needs to serve its original purpose).