### PR TITLE
Move max_coagpair

### DIFF
--- a/src/mam4xx/aero_config.hpp
+++ b/src/mam4xx/aero_config.hpp
@@ -58,6 +58,9 @@ public:
 
   /// Returns the number of gas ids. This is the number of enums in mam4::GasId.
   static constexpr int num_gas_ids() { return 3; }
+
+  /// Returns the number of aging pairs
+  static constexpr int max_agepair() { return 1; }
 };
 
 /// MAM4 column-wise prognostic aerosol fields (also used for tendencies).

--- a/src/mam4xx/aging.hpp
+++ b/src/mam4xx/aging.hpp
@@ -37,7 +37,6 @@ public:
   static constexpr Real n_so4_monolayers_pcage = 8.0;
   static constexpr Real dr_so4_monolayers_pcage =
       n_so4_monolayers_pcage * 4.76e-10;
-  static constexpr int max_agepair = 1;
 
   // validate -- validates the given atmospheric state and prognostics against
   // assumptions made by this implementation, returning true if the states are
@@ -73,9 +72,9 @@ void mam_pcarbon_aging_frac(
                                                  // mixing ratio due to
                                                  // condensation [mol/mol]
     Real qaer_del_coag_in[AeroConfig::num_aerosol_ids()]
-                         [Aging::max_agepair], // change of aerosol mass
-                                               // mixing ratio due to
-                                               // coagulation
+                         [AeroConfig::max_agepair()], // change of aerosol mass
+                                                      // mixing ratio due to
+                                                      // coagulation
     Real &xferfrac_pcage, // fraction of aged pom/bc transferred to accum
                           // [unitless]
     Real
@@ -246,12 +245,12 @@ void mam_pcarbon_aging_1subarea(
                       [AeroConfig::num_modes()], // change of aerosol mass
                                                  // mixing ratio due to
                                                  // coagulation [mol/mol]
-    Real
-        qaer_del_coag_in[AeroConfig::num_aerosol_ids()]
-                        [Aging::max_agepair]) { //  change of aerosol mass
-                                                //  mixing ratio due to
-                                                //  coagulation from subrountine
-                                                //  mam_coag_1subarea [mol/mol]
+    Real qaer_del_coag_in[AeroConfig::num_aerosol_ids()]
+                         [AeroConfig::max_agepair()]) { //  change of aerosol
+                                                        //  mass
+                                                        //  mixing ratio due to
+  //  coagulation from subrountine
+  //  mam_coag_1subarea [mol/mol]
 
   Real xferfrac_pcage, frac_cond, frac_coag;
 
@@ -361,7 +360,7 @@ void aerosol_aging_rates_1box(const int k, const AeroConfig &aero_config,
   //  Real qaer_cur[AeroConfig::num_aerosol_ids()][AeroConfig::num_modes()],
   Real qaer_del_cond[num_aer][num_mode];
   Real qaer_del_coag[num_aer][num_mode];
-  Real qaer_del_coag_in[num_aer][Aging::max_agepair];
+  Real qaer_del_coag_in[num_aer][AeroConfig::max_agepair()];
 
   // Get prognostic fields
   // Aerosol mass

--- a/src/mam4xx/coagulation.hpp
+++ b/src/mam4xx/coagulation.hpp
@@ -31,9 +31,6 @@ public:
   // Todo: This should be resolved back to Aging
   static constexpr int i_agepair_pca = 0;
 
-  // Todo: This should be resolved back to Aging
-  static constexpr int max_agepair = 1;
-
   // process-specific configuration data (if any)
   struct Config {
     Config() {}
@@ -858,7 +855,7 @@ void mam_coag_aer_update(
     Real qaer_bgn[AeroConfig::num_aerosol_ids()][AeroConfig::num_modes()],
     Real qaer_end[AeroConfig::num_aerosol_ids()][AeroConfig::num_modes()],
     Real qaer_del_coag_out[AeroConfig::num_aerosol_ids()]
-                          [Coagulation::max_agepair]) {
+                          [AeroConfig::max_agepair()]) {
 
   const int num_aer = AeroConfig::num_aerosol_ids();
   const int num_mode = AeroConfig::num_modes();
@@ -1048,7 +1045,7 @@ void mam_coag_1subarea(
     Real qnum_cur[AeroConfig::num_modes()],
     Real qaer_cur[AeroConfig::num_aerosol_ids()][AeroConfig::num_modes()],
     Real qaer_del_coag_out[AeroConfig::num_aerosol_ids()]
-                          [Coagulation::max_agepair]) {
+                          [AeroConfig::max_agepair()]) {
 
   const int num_aer = AeroConfig::num_aerosol_ids();
   const int num_mode = AeroConfig::num_modes();
@@ -1160,7 +1157,7 @@ void coagulation_rates_1box(const int k, const AeroConfig &aero_config,
   }
 
   Real qaer_del_coag_out[AeroConfig::num_aerosol_ids()]
-                        [Coagulation::max_agepair];
+                        [AeroConfig::max_agepair()];
 
   mam_coag_1subarea(dt, temp, pmid, aircon, dgn_a, dgn_awet, wet_density,
                     qnum_cur, qaer_cur, qaer_del_coag_out);

--- a/src/tests/mam4_aging_unit_tests.cpp
+++ b/src/tests/mam4_aging_unit_tests.cpp
@@ -26,6 +26,12 @@ TEST_CASE("test_constructor", "mam4_aging_process") {
   REQUIRE(process.aero_config() == mam4_config);
 }
 
+TEST_CASE("test_aging_pairs", "mam4_aging_pairs") {
+  // mam4 aging assumes that max_agepair is 1
+  mam4::AeroConfig mam4_config;
+  REQUIRE(mam4_config.max_agepair() == 1);
+}
+
 TEST_CASE("test_compute_tendencies", "mam4_aging_process") {
   ekat::Comm comm;
 
@@ -205,7 +211,8 @@ TEST_CASE("mam4_pcarbon_aging_1subarea", "mam4_aging_process") {
   Real qaer_cur[AeroConfig::num_aerosol_ids()][AeroConfig::num_modes()];
   Real qaer_del_cond[AeroConfig::num_aerosol_ids()][AeroConfig::num_modes()];
   Real qaer_del_coag[AeroConfig::num_aerosol_ids()][AeroConfig::num_modes()];
-  Real qaer_del_coag_in[AeroConfig::num_aerosol_ids()][Aging::max_agepair];
+  Real qaer_del_coag_in[AeroConfig::num_aerosol_ids()]
+                       [AeroConfig::max_agepair()];
 
   // Fill all arrays with zeros
   for (int imode = 0; imode < AeroConfig::num_modes(); ++imode) {
@@ -224,7 +231,7 @@ TEST_CASE("mam4_pcarbon_aging_1subarea", "mam4_aging_process") {
   }
 
   for (int ispec = 0; ispec < AeroConfig::num_aerosol_ids(); ++ispec) {
-    for (int imode = 0; imode < Aging::max_agepair; ++imode) {
+    for (int imode = 0; imode < AeroConfig::max_agepair(); ++imode) {
       qaer_del_coag_in[ispec][imode] = 0.0;
     }
   }
@@ -250,7 +257,7 @@ TEST_CASE("mam4_pcarbon_aging_1subarea", "mam4_aging_process") {
   }
 
   for (int ispec = 0; ispec < AeroConfig::num_aerosol_ids(); ++ispec) {
-    for (int imode = 0; imode < Aging::max_agepair; ++imode) {
+    for (int imode = 0; imode < AeroConfig::max_agepair(); ++imode) {
       REQUIRE(qaer_del_coag_in[ispec][imode] == 0.0);
     }
   }

--- a/src/tests/mam4_coagulation_unit_tests.cpp
+++ b/src/tests/mam4_coagulation_unit_tests.cpp
@@ -26,6 +26,12 @@ TEST_CASE("test_constructor", "mam4_coagulation_process") {
   REQUIRE(process.aero_config() == mam4_config);
 }
 
+TEST_CASE("test_aging_pairs", "mam4_aging_pairs") {
+  // mam4 coagulation assumes that max_agepair is 1
+  mam4::AeroConfig mam4_config;
+  REQUIRE(mam4_config.max_agepair() == 1);
+}
+
 TEST_CASE("bm0ij_data", "mam4_cagulation_process") {
 
   // Here we test a few values returned directly from fortran with those

--- a/src/validation/aging/mam_pcarbon_aging_1subarea.cpp
+++ b/src/validation/aging/mam_pcarbon_aging_1subarea.cpp
@@ -70,10 +70,10 @@ void mam_pcarbon_aging_1subarea(Ensemble *ensemble) {
     Real qaer_cur_c[num_aero][num_modes];
     Real qaer_del_cond_c[num_aero][num_modes];
     Real qaer_del_coag_c[num_aero][num_modes];
-    Real qaer_del_coag_in_c[num_aero][Aging::max_agepair];
+    Real qaer_del_coag_in_c[num_aero][AeroConfig::max_agepair()];
 
     int n = 0;
-    for (int imode = 0; imode < Aging::max_agepair; ++imode) {
+    for (int imode = 0; imode < AeroConfig::max_agepair(); ++imode) {
       for (int ispec = 0; ispec < num_aero; ++ispec) {
         qaer_del_coag_in_c[ispec][imode] = qaer_del_coag_in_f[n];
         n += 1;
@@ -96,7 +96,7 @@ void mam_pcarbon_aging_1subarea(Ensemble *ensemble) {
         qaer_del_coag_in_c);
 
     n = 0;
-    for (int imode = 0; imode < Aging::max_agepair; ++imode) {
+    for (int imode = 0; imode < AeroConfig::max_agepair(); ++imode) {
       for (int ispec = 0; ispec < num_aero; ++ispec) {
         qaer_del_coag_in_f[n] = qaer_del_coag_in_c[ispec][imode];
         n += 1;

--- a/src/validation/aging/mam_pcarbon_aging_frac.cpp
+++ b/src/validation/aging/mam_pcarbon_aging_frac.cpp
@@ -45,7 +45,7 @@ void mam_pcarbon_aging_frac(Ensemble *ensemble) {
 
     Real qaer_cur_c[num_aero][num_modes];
     Real qaer_del_cond_c[num_aero][num_modes];
-    Real qaer_del_coag_in_c[num_aero][Aging::max_agepair];
+    Real qaer_del_coag_in_c[num_aero][AeroConfig::max_agepair()];
 
     int n = 0;
     for (int imode = 0; imode < num_modes; ++imode) {
@@ -57,7 +57,7 @@ void mam_pcarbon_aging_frac(Ensemble *ensemble) {
     }
 
     n = 0;
-    for (int imode = 0; imode < Aging::max_agepair; ++imode) {
+    for (int imode = 0; imode < AeroConfig::max_agepair(); ++imode) {
       for (int ispec = 0; ispec < num_aero; ++ispec) {
         qaer_del_coag_in_c[ispec][imode] = qaer_del_coag_in_f[n];
         n += 1;
@@ -82,7 +82,7 @@ void mam_pcarbon_aging_frac(Ensemble *ensemble) {
     }
 
     n = 0;
-    for (int imode = 0; imode < Aging::max_agepair; ++imode) {
+    for (int imode = 0; imode < AeroConfig::max_agepair(); ++imode) {
       for (int ispec = 0; ispec < num_aero; ++ispec) {
         qaer_del_coag_in_f[n] = qaer_del_coag_in_c[ispec][imode];
         n += 1;

--- a/src/validation/coagulation/coag_1subarea.cpp
+++ b/src/validation/coagulation/coag_1subarea.cpp
@@ -68,7 +68,7 @@ void coag_1subarea(Ensemble *ensemble) {
 
     const int num_modes = AeroConfig::num_modes();
     const int num_aero = AeroConfig::num_aerosol_ids();
-    const int max_agepair = Coagulation::max_agepair;
+    const int max_agepair = AeroConfig::max_agepair();
     Real qaer_cur_c[num_aero][num_modes];
     int n = 0;
     for (int imode = 0; imode < num_modes; ++imode) {

--- a/src/validation/coagulation/coag_aer_update.cpp
+++ b/src/validation/coagulation/coag_aer_update.cpp
@@ -48,7 +48,7 @@ void coag_aer_update(Ensemble *ensemble) {
 
     const int num_modes = AeroConfig::num_modes();
     const int num_aero = AeroConfig::num_aerosol_ids();
-    const int max_agepair = Coagulation::max_agepair;
+    const int max_agepair = AeroConfig::max_agepair();
 
     Real qaer_bgn_c[num_aero][num_modes];
     Real qaer_end_c[num_aero][num_modes];


### PR DESCRIPTION
This PR ties up some loose ends from coagulation and aging. In particular, the variable max_coagpair which defines the maximum number of coagulation pairs is now defined in aero_config.hpp. Additionally,  a unit test is added for both the aging and coagulation classes to guarantee that max_coagpair is not changed to be inconsistent with the value expected in both of those classes. 