### PR TITLE
Adds a `make memcheck` target that runs tests with Valgrind.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ endif()
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 option(ENABLE_SKYWALKER "Enable Skywalker cross validation" ON)
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+
 # Blessed version of clang-format.
 set(CLANG_FORMAT_VERSION 14)
 
@@ -88,27 +90,9 @@ if (ENABLE_COVERAGE)
     COMMENT "Generating coverage report (coverage.info)")
 endif()
 
-# Support for valgrind -- Linux only.
-if (UNIX AND NOT APPLE)
-  find_package(Valgrind QUIET)
-  if (VALGRIND_FOUND)
-    set(VALGRIND_FOUND 1) # regularize this value
-    include_directories(${VALGRIND_INCLUDE_DIR})
-    set(MEMORYCHECK_COMMAND ${VALGRIND_PROGRAM})
-    # Add "--gen-suppressions=all" to MEMORYCHECK_COMMAND_OPTIONS to generate
-    # suppressions for Valgrind's false positives. The suppressions show up
-    # right in the MemoryChecker.*.log files.
-    set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=definite,possible --track-origins=yes --error-exitcode=1 --trace-children=yes --suppressions=${PROJECT_SOURCE_DIR}/tools/valgrind/scasm.supp" CACHE STRING "Options passed to Valgrind." FORCE)
-
-    # make memcheck target
-    add_custom_target(memcheck ctest -T memcheck -j ${NUMBER_OF_CORES} USES_TERMINAL)
-  else()
-    set(VALGRIND_FOUND 0)
-  endif()
-else()
-  # Valgrind doesn't work on Macs.
-  set(VALGRIND_FOUND 0)
-endif()
+# Support for valgrind (Linux only)
+include(add_memcheck_target)
+add_memcheck_target()
 
 # Testing
 include(CTest)

--- a/cmake/add_memcheck_target.cmake
+++ b/cmake/add_memcheck_target.cmake
@@ -1,0 +1,25 @@
+# This macro adds a "make memcheck" target that runs Valgrind on all tests.
+# It only works on Linux.
+macro(add_memcheck_target)
+  if (UNIX AND NOT APPLE)
+    find_program(VALGRIND valgrind)
+    if (NOT VALGRIND MATCHES "-NOTFOUND")
+      message(STATUS "Valgrind found. Enabling `make memcheck`")
+      set(VALGRIND_FOUND 1)
+      set(CTEST_MEMORYCHECK_COMMAND ${VALGRIND})
+      # Add "--gen-suppressions=all" to MEMORYCHECK_COMMAND_OPTIONS to generate
+      # suppressions for Valgrind's false positives. The suppressions show up
+      # right in the MemoryChecker.*.log files.
+      set(CTEST_MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=definite,possible --track-origins=yes --error-exitcode=1 --trace-children=yes --suppressions=${PROJECT_SOURCE_DIR}/tools/valgrind/scasm.supp" CACHE STRING "Options passed to Valgrind." FORCE)
+
+      # make memcheck target
+      add_custom_target(memcheck ctest -T memcheck -j USES_TERMINAL)
+    else()
+      set(VALGRIND_FOUND 0)
+    endif()
+  else()
+    # Valgrind doesn't work on Macs.
+    set(VALGRIND_FOUND 0)
+  endif()
+
+endmacro()


### PR DESCRIPTION
I considered having our CI tests run with Valgrind/memcheck, but some of the cross-validation tests take a very long time with this. If running tests with Valgrind is interesting to us, we might consider altering some of the larger cross-validation tests, like `run_vehkamaki2002_fig8`, which generates a contour plot of the nucleation rate as a function of 2 variables.