### PR TITLE
move `cmake_minimum_required` to v3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.12.0)
+cmake_minimum_required (VERSION 3.17.0)
 
 message(STATUS "Configuring with build type: ${CMAKE_BUILD_TYPE}")
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ implementation of the MAM4 modal aerosol model (with 4 fixed modes).
 
 To build MAM4xx, you need:
 
-* [CMake v3.12+](https://cmake.org/)
+* [CMake v3.17+](https://cmake.org/)
 * GNU Make
 * reliable C and C++ compilers
 * optionally, a working MPI installation (like [OpenMPI](https://www.open-mpi.org/)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,7 @@ MAM4xx builds and runs on the following platforms:
 
 To build MAM4xx, you need:
 
-* [CMake v3.12+](https://cmake.org/)
+* [CMake v3.17+](https://cmake.org/)
 * GNU Make
 * reliable C and C++ compilers
 * optionally, a working MPI installation (like [OpenMPI](https://www.open-mpi.org/)


### PR DESCRIPTION
In reference to issue #137, this PR updates the cmake minimum required version to v3.17 and also updates the documentation in the `README` and `docs/installation.md`.