### PR TITLE
comment unused variable in `find_renaming_pairs.cpp` to fix autotester fails

### DIFF
--- a/src/validation/rename/find_renaming_pairs.cpp
+++ b/src/validation/rename/find_renaming_pairs.cpp
@@ -30,7 +30,7 @@ void find_renaming_pairs(Ensemble *ensemble) {
     Real diameter_cutoff[nmodes];
     Real ln_dia_cutoff[nmodes];
     Real diameter_threshold[nmodes];
-    Real mass_2_vol[naerosol_species];
+    // Real mass_2_vol[naerosol_species];
     Real mean_std_dev[nmodes];
 
     rename::find_renaming_pairs(dest_mode_of_mode,    // in
@@ -46,10 +46,10 @@ void find_renaming_pairs(Ensemble *ensemble) {
     // We use MW from rename-mam4.
     Real molecular_weight_rename[naerosol_species] = {
         150, 115, 150, 12, 58.5, 135, 250092}; // [kg/kmol]
-    for (int iaero = 0; iaero < naerosol_species; ++iaero) {
-      mass_2_vol[iaero] =
-          molecular_weight_rename[iaero] / aero_species(iaero).density;
-    }
+    // for (int iaero = 0; iaero < naerosol_species; ++iaero) {
+    //   mass_2_vol[iaero] =
+    //       molecular_weight_rename[iaero] / aero_species(iaero).density;
+    // }
 
     // We do not use sz_factor in rename-mam4xx; however, rename-mam4 does.
     // We only computes sz_factor for validation proposes


### PR DESCRIPTION
Looks like `mass_2_vol` is set but unused and the warning -> error is crashing the autotester. This should fix it up.