### PR TITLE
Fixing a possible race condition in uploading code coverage reports.

### DIFF
--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -116,6 +116,7 @@ jobs:
         make coverage
 
     - name: Uploading coverage report to codecov.io
+      if: ${{ (contains(matrix.os, 'ubuntu')) && (matrix.build-type == 'Debug') && (matrix.fp-precision == 'double') }}
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true


### PR DESCRIPTION
This PR makes it so only one of our builds attempts to upload code coverage reports.