### PR TITLE
aging - validation tests update

### DIFF
--- a/src/validation/aging/CMakeLists.txt
+++ b/src/validation/aging/CMakeLists.txt
@@ -13,10 +13,10 @@ target_link_libraries(aging_driver skywalker;validation;${HAERO_LIBRARIES})
 
 # Copy some Python scripts from mam_x_validation to our binary directory.
 foreach(script
-        compare_aging_validation.py
+        compare_mam4xx_mam4.py
         )
   configure_file(
-    ${AGING_VALIDATION_DIR}/${script}
+    ${MAM_X_VALIDATION_DIR}/scripts/${script}
     ${CMAKE_CURRENT_BINARY_DIR}/${script}
     COPYONLY
   )
@@ -24,13 +24,18 @@ endforeach()
 
 # Run the driver in several configurations to produce datasets.
 
-# Aging
-foreach (input
-         pcarbon_aging_frac
-         pcarbon_aging_1subarea
-         )
+set(TEST_LIST
+    pcarbon_aging_frac
+    pcarbon_aging_1subarea
+    )
 
+#set(DEFAULT_TOL 1e-9)
+
+set(ERROR_THRESHOLDS 8e-5 4e-4)
+
+foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place; is the skywalker file produced by fortran code?
+  
   configure_file(
     ${AGING_VALIDATION_DIR}/mam_${input}.py
     ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
@@ -40,9 +45,11 @@ foreach (input
   # add a test to run the skywalker driver
   add_test(run_${input} aging_driver ${AGING_VALIDATION_DIR}/${input}.yaml)
 
-  # add a test to validate mam4xx's results against the baseline.
-  add_test(validate_${input} python3 compare_aging_validation.py mam4xx_${input}.py mam_${input}.py)
-  set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input} )
+   # add a test to validate mam4xx's results against the baseline.
+  # Select a threshold error slightly bigger than the largest relative error for the threshold error.
+  # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
+  add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
 
 endforeach()
 


### PR DESCRIPTION
After PR #148 we need to update error tolerances in aging. I used the python ``compare_mam4xx_mam4.py`` script from [mam_x_validation/scripts](https://github.com/eagles-project/mam_x_validation/blob/36a3f9e9351fa46b0438158f8e7c29521c7cc35d/scripts/compare_mam4xx_mam4.py) to compute and check the L1/L2/Linf norms.  Threshold errors are set to smaller error that make the test pass. 



