### PR TITLE
remove non-ascii characters from mam4xx

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To build MAM4xx:
    `make test`.
 5. To install the model to the location indicated by `PREFIX` in your
    `config.sh` script, type `make install`. By default, products are installed
-   in `include`, `lib`, `bin`, and `share` ѕubdirectories within your build
+   in `include`, `lib`, `bin`, and `share` subdirectories within your build
    directory.
 
 ### Making code changes and rebuilding

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -92,7 +92,7 @@ After you've configured MAM4xx, you can build it:
 5. To install the model to the location indicated by `PREFIX` in your
    `config.sh` script (or `CMAKE_INSTALL_PREFIX`, if you specified it manually),
    type `make install`. By default, products are installed in `include`, `lib`,
-   `bin`, and `share` ѕubdirectories within your build directory.
+   `bin`, and `share` subdirectories within your build directory.
 
 ## Making code changes and rebuilding
 

--- a/src/mam4xx/aero_modes.hpp
+++ b/src/mam4xx/aero_modes.hpp
@@ -262,7 +262,7 @@ bool mode_contains_species(ModeIndex mode, AeroId aero_id) {
 }
 
 // Identifiers for gas species in MAM4, specified in the same order as they
-// appear in the set_gaѕ_and_aer_names_and_indices subroutine within the
+// appear in the set_gas_and_aer_names_and_indices subroutine within the
 // modal_aero_microp_species F90 module (assuming nsoa == 1). It looks like MAM4
 // only tracks SOAG and H2SO4. We keep NH3 around because ternary nucleation
 // requires it, is already ported, and may be required in the future.

--- a/src/mam4xx/kerminen2002.hpp
+++ b/src/mam4xx/kerminen2002.hpp
@@ -18,8 +18,8 @@ using haero::log;
 using haero::square;
 
 /// The functions in this file implement parameterizations described in
-/// Kerminen and Kulmala, Analytical formulae connecting the “real” and the
-/// “apparent” nucleation rate and the nuclei number concentration for
+/// Kerminen and Kulmala, Analytical formulae connecting the "real" and the
+/// "apparent" nucleation rate and the nuclei number concentration for
 /// atmospheric nucleation events, Aerosol Science 33 (2002).
 ///
 /// The parameterization has been adapted for systems whose aerosol particles

--- a/src/mam4xx/merikanto2007.hpp
+++ b/src/mam4xx/merikanto2007.hpp
@@ -60,7 +60,7 @@ Kokkos::pair<Real, Real> valid_xi_nh3_range() {
 
 /// Computes the logarithm of the ternary nucleation rate [cm-3 s-1] as
 /// parameterized by Merikanto et al (2007), eq 8.
-/// @param [in] temp The atmospherіc temperature [K]
+/// @param [in] temp The atmospheric temperature [K]
 /// @param [in] rel_hum The relative humidity [-]
 /// @param [in] c_h2so4 The number concentration of H2SO4 gas [cm-3]
 /// @param [in] xi_nh3 The molar mixing ratio of NH3 [ppt]
@@ -168,7 +168,7 @@ Real onset_temperature(Real rel_hum, Real c_h2so4, Real xi_nh3) {
 /// Computes the radius of a critical cluster [nm] as parameterized in Merikanto
 /// et al (2007), eq 11.
 /// @param [in] log_J The logarithm of the nucleation rate ["log (cm-3 s-1)"]
-/// @param [in] temp The atmospherіc temperature [K]
+/// @param [in] temp The atmospheric temperature [K]
 /// @param [in] c_h2so4 The number concentration of H2SO4 gas [cm-3]
 /// @param [in] xi_nh3 The molar mixing ratio of NH3 [ppt]
 KOKKOS_INLINE_FUNCTION
@@ -194,7 +194,7 @@ Real critical_radius(Real log_J, Real temp, Real c_h2so4, Real xi_nh3) {
 /// Computes the total number of molecules in a critical cluster as
 /// parameterized in Merikanto et al (2007), eq 12.
 /// @param [in] log_J The logarithm of the nucleation rate ["log (cm-3 s-1)"]
-/// @param [in] temp The atmospherіc temperature [K]
+/// @param [in] temp The atmospheric temperature [K]
 /// @param [in] c_h2so4 The number concentration of H2SO4 gas [cm-3]
 /// @param [in] xi_nh3 The molar mixing ratio of NH3 [ppt]
 KOKKOS_INLINE_FUNCTION
@@ -219,7 +219,7 @@ Real num_critical_molecules(Real log_J, Real temp, Real c_h2so4, Real xi_nh3) {
 /// Computes the total number of H2SO4 molecules in a critical cluster as
 /// parameterized in Merikanto et al (2007), eq 13.
 /// @param [in] log_J The logarithm of the nucleation rate ["log (cm-3 s-1)"]
-/// @param [in] temp The atmospherіc temperature [K]
+/// @param [in] temp The atmospheric temperature [K]
 /// @param [in] c_h2so4 The number concentration of H2SO4 gas [cm-3]
 /// @param [in] xi_nh3 The molar mixing ratio of NH3 [ppt]
 KOKKOS_INLINE_FUNCTION
@@ -244,7 +244,7 @@ Real num_h2so4_molecules(Real log_J, Real temp, Real c_h2so4, Real xi_nh3) {
 /// Computes the total number of NH3 molecules in a critical cluster as
 /// parameterized in Merikanto et al (2007), eq 14.
 /// @param [in] log_J The logarithm of the nucleation rate ["log (cm-3 s-1)"]
-/// @param [in] temp The atmospherіc temperature [K]
+/// @param [in] temp The atmospheric temperature [K]
 /// @param [in] c_h2so4 The number concentration of H2SO4 gas [cm-3]
 /// @param [in] xi_nh3 The molar mixing ratio of NH3 [ppt]
 KOKKOS_INLINE_FUNCTION

--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -34,7 +34,7 @@ namespace nucleation {
 // Wang, M. and J.E. Penner, 2008,
 // Aerosol indirect forcing in a global model with particle nucleation,
 // Atmos. Chem. Phys. Discuss., 8, 13943-13998
-// Atmos. Chem. Phys.  9, 239–260, 2009
+// Atmos. Chem. Phys.  9, 239-260, 2009
 //--------------------------------------------------------
 KOKKOS_INLINE_FUNCTION
 void pbl_nuc_wang2008(Real so4vol, Real pi, int pbl_nuc_wang2008_user_choice,
@@ -121,7 +121,7 @@ void pbl_nuc_wang2008(Real so4vol, Real pi, int pbl_nuc_wang2008_user_choice,
 //-----------------------------------------------------------------
 // calculates binary nucleation rate and critical cluster size
 // using the parameterization in
-//     vehkamäki, h., m. kulmala, i. napari, k.e.j. lehtinen,
+//     vehkam\"aki, h., m. kulmala, i. napari, k.e.j. lehtinen,
 //        c. timmreck, m. noppel and a. laaksonen, 2002,
 //        an improved parameterization for sulfuric acid-water nucleation
 //        rates for tropospheric and stratospheric conditions,
@@ -148,22 +148,22 @@ void binary_nuc_vehk2002(Real temp, Real rh, Real so4vol, Real &ratenucl,
   // real(wp), intent(out) :: radius_cluster   ! the radius of cluster (nm)
 
   // calc sulfuric acid mole fraction in critical cluster
-  // following eq. (11) in Vehkamäki et al. (2002)
+  // following eq. (11) in Vehkam\"aki et al. (2002)
   Real x_crit = vehkamaki2002::h2so4_critical_mole_fraction(so4vol, temp, rh);
 
   // calc nucleation rate
-  // following eq. (12) in Vehkamäki et al. (2002)
+  // following eq. (12) in Vehkam\"aki et al. (2002)
   rateloge = log(vehkamaki2002::nucleation_rate(so4vol, temp, rh, x_crit));
   ratenucl = exp(min(rateloge, log(1e38)));
 
   // calc number of molecules in critical cluster
-  // following eq. (13) in Vehkamäki et al. (2002)
+  // following eq. (13) in Vehkam\"aki et al. (2002)
   cnum_tot = vehkamaki2002::num_critical_molecules(so4vol, temp, rh, x_crit);
 
   cnum_h2so4 = cnum_tot * x_crit;
 
   // calc radius (nm) of critical cluster
-  // following eq. (14) in Vehkamäki et al. (2002)
+  // following eq. (14) in Vehkam\"aki et al. (2002)
   radius_cluster = vehkamaki2002::critical_radius(x_crit, cnum_tot);
 }
 
@@ -219,7 +219,7 @@ void ternary_nuc_merik2007(Real t, Real rh, Real c2, Real c3, Real &j_log,
 //   rates at tropospheric conditions,
 //   j. geophys. res., 112, d15207, doi:10.1029/2006jd0027977
 //
-// * vehkamäki, h., m. kulmala, i. napari, k.e.j. lehtinen,
+// * vehkam\"aki, h., m. kulmala, i. napari, k.e.j. lehtinen,
 //   c. timmreck, m. noppel and a. laaksonen, 2002,
 //   an improved parameterization for sulfuric acid-water nucleation
 //   rates for tropospheric and stratospheric conditions,
@@ -228,7 +228,7 @@ void ternary_nuc_merik2007(Real t, Real rh, Real c2, Real c3, Real &j_log,
 // * Wang, M. and J.E. Penner, 2008,
 //   Aerosol indirect forcing in a global model with particle nucleation,
 //   Atmos. Chem. Phys. Discuss., 8, 13943-13998
-//   Atmos. Chem. Phys.  9, 239–260, 2009
+//   Atmos. Chem. Phys.  9, 239-260, 2009
 KOKKOS_INLINE_FUNCTION
 void mer07_veh02_wang08_nuc_1box(int newnuc_method_user_choice,
                                  int &newnuc_method_actual,        // in, out

--- a/src/mam4xx/vehkamaki2002.hpp
+++ b/src/mam4xx/vehkamaki2002.hpp
@@ -18,7 +18,7 @@ using haero::log;
 using haero::square;
 
 /// The functions in this file implement parameterizations described in
-/// Vehkamaki et al, An improved parameterization for sulfuric acid–water /
+/// Vehkamaki et al, An improved parameterization for sulfuric acid-water /
 /// nucleation rates for tropospheric and stratospheric conditions,
 /// Journal of Geophysical Research 107 (2002). Also included are corrections
 /// described in Vehkamaki et al, Correction to "An improved...",
@@ -53,7 +53,7 @@ Kokkos::pair<Real, Real> valid_c_h2so4_range() {
 /// Computes the mole fraction of sulfuric acid in a critical cluster as
 /// parameterized by Vehkmaki et al (2002), eq 11.
 /// @param [in] c_h2so4 The number concentration of H2SO4 gas [cm-3]
-/// @param [in] temp The atmospherіc temperature [K]
+/// @param [in] temp The atmospheric temperature [K]
 /// @param [in] rel_hum The relative humidity [-]
 KOKKOS_INLINE_FUNCTION
 Real h2so4_critical_mole_fraction(Real c_h2so4, Real temp, Real rel_hum) {
@@ -70,7 +70,7 @@ Real h2so4_critical_mole_fraction(Real c_h2so4, Real temp, Real rel_hum) {
 /// Computes the binary nucleation rate [m-3 s-1] as parameterized by
 /// Vehkmaki et al (2002), eq 12.
 /// @param [in] c_h2so4 The number concentration of H2SO4 gas [cm-3]
-/// @param [in] temp The atmospherіc temperature [K]
+/// @param [in] temp The atmospheric temperature [K]
 /// @param [in] rel_hum The relative humidity [-]
 /// @param [in] x_crit The mole fraction of H2SO4 in a critical cluster [-]
 KOKKOS_INLINE_FUNCTION
@@ -118,7 +118,7 @@ Real nucleation_rate(Real c_h2so4, Real temp, Real rel_hum, Real x_crit) {
 /// Computes the total number of molecules in a critical cluster as
 /// parameterized in Vehkamaki et al (2002), eq 13.
 /// @param [in] c_h2so4 The number concentration of H2SO4 gas [cm-3]
-/// @param [in] temp The atmospherіc temperature [K]
+/// @param [in] temp The atmospheric temperature [K]
 /// @param [in] rel_hum The relative humidity [-]
 /// @param [in] x_crit The mole fraction of H2SO4 in a critical cluster [-]
 KOKKOS_INLINE_FUNCTION
@@ -177,7 +177,7 @@ Real critical_radius(Real x_crit, Real n_tot) {
 /// Computes the threshold number concentration of H2SO4 [cm-3] that produces a
 /// nucleation rate of 1 cm-3 s-1 at the given temperature and relative
 /// humidity as parameterized by Vehkamaki et al (2002), eq 15.
-/// @param [in] temp The atmospherіc temperature [K]
+/// @param [in] temp The atmospheric temperature [K]
 /// @param [in] rel_hum The relative humidity [-]
 KOKKOS_INLINE_FUNCTION
 Real h2so4_nucleation_threshold(Real temp, Real rel_hum) {

--- a/src/mam4xx/wang2008.hpp
+++ b/src/mam4xx/wang2008.hpp
@@ -14,7 +14,7 @@ using Real = haero::Real;
 
 /// The functions in this file implement parameterizations described in
 /// Wang and Penner, Aerosol indirect forcing in a global model with particle
-/// nucleation, Atmos. Chem. Phys. Discuss. 8, pp. 13943–13998 (2008)
+/// nucleation, Atmos. Chem. Phys. Discuss. 8, pp. 13943-13998 (2008)
 
 /// These parameterizations assume that nucleated particles are 1 nm in
 /// diameter.

--- a/src/tests/mam4_gasaerexch_unit_tests.cpp
+++ b/src/tests/mam4_gasaerexch_unit_tests.cpp
@@ -48,7 +48,7 @@ TEST_CASE("test_compute_tendencies", "mam4_gasaerexch_process") {
 }
 
 TEST_CASE("test_multicol_compute_tendencies", "mam4_gasaerexch_process") {
-  // Now we process multiple columns within a single dіspatch (mc means
+  // Now we process multiple columns within a single dispatch (mc means
   // "multi-column").
   int ncol = 8;
   DeviceType::view_1d<Atmosphere> mc_atm("mc_progs", ncol);

--- a/src/tests/mam4_nucleation_unit_tests.cpp
+++ b/src/tests/mam4_nucleation_unit_tests.cpp
@@ -99,7 +99,7 @@ TEST_CASE("test_compute_tendencies", "mam4_nucleation_process") {
 }
 
 TEST_CASE("test_multicol_compute_tendencies", "mam4_nucleation_process") {
-  // Now we process multiple columns within a single dіspatch (mc means
+  // Now we process multiple columns within a single dispatch (mc means
   // "multi-column").
   int ncol = 8;
   DeviceType::view_1d<Atmosphere> mc_atm("mc_progs", ncol);

--- a/src/validation/gasaerexch/CMakeLists.txt
+++ b/src/validation/gasaerexch/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(gasaerexch_driver gasaerexch_driver.cpp
                gasaerexch_uptkrates_1box1gas.cpp)
 target_link_libraries(gasaerexch_driver skywalker;validation;${HAERO_LIBRARIES})
 
-# Copy the gas-aerosol exchange plotting ѕcript to our binary directory for
+# Copy the gas-aerosol exchange plotting script to our binary directory for
 # ease of use.
 set(SKYWALKER_RESULT mam4xx_skywalker_gasaerexch_uptkrates_1box1gas)
 configure_file(


### PR DESCRIPTION
Ran across a few of these lately and figured why not get rid of them. Most were in comments or something latex-y. And it appears that cmake doesn't get too grumpy about them.