### PR TITLE
Add conversion factor of 1e-3 to `conversions.hpp` to account for change in units

### DIFF
--- a/src/mam4xx/conversions.hpp
+++ b/src/mam4xx/conversions.hpp
@@ -19,6 +19,8 @@ using Constants = haero::Constants;
 using haero::cube;
 using haero::square;
 
+constexpr Real mol_to_kmol = 1e-3;
+
 /// Given a number concentration for a species or mixture [m-3], computes and
 /// returns a mass mixing ratio [kg species/kg dry air] based on its molecular
 /// weight and on the density of dry air in the vicinity.
@@ -56,7 +58,9 @@ KOKKOS_INLINE_FUNCTION Real number_conc_from_mmr(Real mmr, Real molecular_wt,
 /// @param [in] molecular_wt The molecular weight of the species/mixture
 /// [kg/kmol]
 KOKKOS_INLINE_FUNCTION Real mmr_from_vmr(Real vmr, Real molecular_wt) {
-  const auto mw_dry_air = Constants::molec_weight_dry_air;
+  // we convert here since haero::Constants uses SI units.
+  // e.g., kg/mol for mw_dry_air
+  const auto mw_dry_air = Constants::molec_weight_dry_air * mol_to_kmol;
   return vmr * molecular_wt / mw_dry_air;
 }
 
@@ -67,7 +71,9 @@ KOKKOS_INLINE_FUNCTION Real mmr_from_vmr(Real vmr, Real molecular_wt) {
 /// @param [in] molecular_wt The molecular weight of the species/mixture
 /// [kg/kmol]
 KOKKOS_INLINE_FUNCTION Real vmr_from_mmr(Real mmr, Real molecular_wt) {
-  const auto mw_dry_air = Constants::molec_weight_dry_air;
+  // we convert here since haero::Constants uses SI units.
+  // e.g., kg/mol for mw_dry_air
+  const auto mw_dry_air = Constants::molec_weight_dry_air * mol_to_kmol;
   return mmr * mw_dry_air / molecular_wt;
 }
 

--- a/src/mam4xx/rename.hpp
+++ b/src/mam4xx/rename.hpp
@@ -682,18 +682,14 @@ public:
               // get the mapping from the mam4xx species ordering to rename's
               rename_idx = _mam4xx2rename_idx[imode][jspec];
               // convert mass mixing ratios to molar mixing ratios
-              qmol_i_cur[imode][rename_idx] = conversions::vmr_from_mmr(
-                  prognostics.q_aero_i[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
-              qmol_i_del[imode][rename_idx] = conversions::vmr_from_mmr(
-                  tendencies.q_aero_i[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
-              qmol_c_cur[imode][rename_idx] = conversions::vmr_from_mmr(
-                  prognostics.q_aero_c[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
-              qmol_c_del[imode][rename_idx] = conversions::vmr_from_mmr(
-                  tendencies.q_aero_c[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
+              qmol_i_cur[imode][rename_idx] = conversions::mass_mr_to_molar_mr(
+                  prognostics.q_aero_i[imode][rename_idx](kk), rename_idx);
+              qmol_i_del[imode][rename_idx] = conversions::mass_mr_to_molar_mr(
+                  tendencies.q_aero_i[imode][rename_idx](kk), rename_idx);
+              qmol_c_cur[imode][rename_idx] = conversions::mass_mr_to_molar_mr(
+                  prognostics.q_aero_c[imode][rename_idx](kk), rename_idx);
+              qmol_c_del[imode][rename_idx] = conversions::mass_mr_to_molar_mr(
+                  tendencies.q_aero_c[imode][rename_idx](kk), rename_idx);
             }
           }
 

--- a/src/tests/conversions_unit_tests.cpp
+++ b/src/tests/conversions_unit_tests.cpp
@@ -105,20 +105,32 @@ TEST_CASE("conversions", "") {
     auto const rho = density_of_ideal_gas(unit_temp, unit_pressure);
     auto const mmr = 1e-8;
     auto const num_conc =
-        number_conc_from_mmr(mmr, haero::Constants::molec_weight_nacl, rho);
-    auto const mmr0 = mmr_from_number_conc(
+        number_conc_from_mass_mr(mmr, haero::Constants::molec_weight_nacl, rho);
+    auto const mmr0 = mass_mr_from_number_conc(
         num_conc, haero::Constants::molec_weight_nacl, rho);
 
     logger.info("unit_temp = {}, unit_pressure = {}, rho = {}", unit_temp,
                 unit_pressure, rho);
-    logger.info("molec_weight_nacl= {}", haero::Constants::molec_weight_nacl);
+    logger.info(
+        "density_nacl= {}",
+        mam4::aero_species(aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                                  mam4::AeroId::NaCl))
+            .density);
     logger.info("mixing ratio = {}, num_conc = {}, mmr0 = {}", mmr, num_conc,
                 mmr0);
     REQUIRE(FloatingPoint<Real>::equiv(mmr, mmr0));
 
     // mass mixing ratio (mmr) <-> molar mixing ratio (vmr)
-    auto const vmr = vmr_from_mmr(mmr0, haero::Constants::molec_weight_nacl);
-    auto const mmr1 = mmr_from_vmr(vmr, haero::Constants::molec_weight_nacl);
+    auto const vmr = mass_mr_to_vol_mr(
+        mmr0,
+        mam4::aero_species(aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                                  mam4::AeroId::NaCl))
+            .density);
+    auto const mmr1 = vol_mr_to_mass_mr(
+        vmr,
+        mam4::aero_species(aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                                  mam4::AeroId::NaCl))
+            .density);
     logger.info("mmr0 = {}, vmr = {}, mmr1 = {}", mmr0, vmr, mmr1);
     REQUIRE(FloatingPoint<Real>::equiv(mmr1, mmr0));
   }

--- a/src/validation/rename/find_renaming_pairs.cpp
+++ b/src/validation/rename/find_renaming_pairs.cpp
@@ -17,7 +17,7 @@ void find_renaming_pairs(Ensemble *ensemble) {
 
   ensemble->process([=](const Input &input, Output &output) {
     const int nmodes = AeroConfig::num_modes();
-    const int naerosol_species = AeroConfig::num_aerosol_ids();
+    // const int naerosol_species = AeroConfig::num_aerosol_ids();
 
     // int dest_mode_of_mode = input.get_array("dest_mode_of_mode");
     int dest_mode_of_mode[nmodes] = {-1, 0, -1, -1};
@@ -44,8 +44,8 @@ void find_renaming_pairs(Ensemble *ensemble) {
                                 ln_dia_cutoff, diameter_threshold);
 
     // We use MW from rename-mam4.
-    Real molecular_weight_rename[naerosol_species] = {
-        150, 115, 150, 12, 58.5, 135, 250092}; // [kg/kmol]
+    // Real molecular_weight_rename[naerosol_species] = {
+    //     150, 115, 150, 12, 58.5, 135, 250092}; // [kg/kmol]
     // for (int iaero = 0; iaero < naerosol_species; ++iaero) {
     //   mass_2_vol[iaero] =
     //       molecular_weight_rename[iaero] / aero_species(iaero).density;


### PR DESCRIPTION
Haero gives `Constants::molec_weight_dry_air` in units of kg/mol, whereas `conversions.hpp` requires kg/kmol for `mmr_from_vmr()` and `vmr_from_mmr()`. So, we multiply by `constexpr Real mol_to_kmol = 1e-3` to account for this.


Closes #152 

**Note:** I realized my build was crashing due to unused variables, so I cherry-picked some commits from `collab/nucleate_ice` that fixed them.