### PR TITLE
Refactor mixing ratio conversion functions

### DIFF
--- a/src/mam4xx/conversions.hpp
+++ b/src/mam4xx/conversions.hpp
@@ -92,7 +92,7 @@ KOKKOS_INLINE_FUNCTION Real vol_mr_to_molar_mr(Real vol_mr, int aero_idx) {
 /// @param [in] aero_idx The array index for the aerosol of interest
 KOKKOS_INLINE_FUNCTION Real molar_mr_to_vol_mr(Real molar_mr, int aero_idx) {
   AeroSpecies spec = mam4::aero_species(aero_idx);
-  return molar_mr / spec.density * spec.molecular_weight;
+  return molar_mr / (spec.density * spec.molecular_weight);
 }
 
 /// Given a mass mixing ratio (mass_mr) for a species or mixture

--- a/src/mam4xx/conversions.hpp
+++ b/src/mam4xx/conversions.hpp
@@ -19,6 +19,8 @@ using Constants = haero::Constants;
 using haero::cube;
 using haero::square;
 
+constexpr Real mol_to_kmol = 1e-3;
+
 /// Given a number concentration for a species or mixture [m-3], computes and
 /// returns a mass mixing ratio [kg species/kg dry air] based on its molecular
 /// weight and on the density of dry air in the vicinity.
@@ -56,7 +58,9 @@ KOKKOS_INLINE_FUNCTION Real number_conc_from_mmr(Real mmr, Real molecular_wt,
 /// @param [in] molecular_wt The molecular weight of the species/mixture
 /// [kg/kmol]
 KOKKOS_INLINE_FUNCTION Real mmr_from_vmr(Real vmr, Real molecular_wt) {
-  const auto mw_dry_air = Constants::molec_weight_dry_air;
+  // we convert here since haero::Constants uses SI units.
+  // e.g., kg/mol for mw_dry_air
+  const auto mw_dry_air = Constants::molec_weight_dry_air * mol_to_kmol;
   return vmr * molecular_wt / mw_dry_air;
 }
 
@@ -67,7 +71,9 @@ KOKKOS_INLINE_FUNCTION Real mmr_from_vmr(Real vmr, Real molecular_wt) {
 /// @param [in] molecular_wt The molecular weight of the species/mixture
 /// [kg/kmol]
 KOKKOS_INLINE_FUNCTION Real vmr_from_mmr(Real mmr, Real molecular_wt) {
-  const auto mw_dry_air = Constants::molec_weight_dry_air;
+  // we convert here since haero::Constants uses SI units.
+  // e.g., kg/mol for mw_dry_air
+  const auto mw_dry_air = Constants::molec_weight_dry_air * mol_to_kmol;
   return mmr * mw_dry_air / molecular_wt;
 }
 

--- a/src/mam4xx/rename.hpp
+++ b/src/mam4xx/rename.hpp
@@ -683,18 +683,14 @@ public:
               // get the mapping from the mam4xx species ordering to rename's
               rename_idx = _mam4xx2rename_idx[imode][jspec];
               // convert mass mixing ratios to molar mixing ratios
-              qmol_i_cur[imode][rename_idx] = conversions::vmr_from_mmr(
-                  prognostics.q_aero_i[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
-              qmol_i_del[imode][rename_idx] = conversions::vmr_from_mmr(
-                  tendencies.q_aero_i[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
-              qmol_c_cur[imode][rename_idx] = conversions::vmr_from_mmr(
-                  prognostics.q_aero_c[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
-              qmol_c_del[imode][rename_idx] = conversions::vmr_from_mmr(
-                  tendencies.q_aero_c[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
+              qmol_i_cur[imode][rename_idx] = conversions::mass_mr_to_molar_mr(
+                  prognostics.q_aero_i[imode][rename_idx](kk), rename_idx);
+              qmol_i_del[imode][rename_idx] = conversions::mass_mr_to_molar_mr(
+                  tendencies.q_aero_i[imode][rename_idx](kk), rename_idx);
+              qmol_c_cur[imode][rename_idx] = conversions::mass_mr_to_molar_mr(
+                  prognostics.q_aero_c[imode][rename_idx](kk), rename_idx);
+              qmol_c_del[imode][rename_idx] = conversions::mass_mr_to_molar_mr(
+                  tendencies.q_aero_c[imode][rename_idx](kk), rename_idx);
             }
           }
 

--- a/src/tests/conversions_unit_tests.cpp
+++ b/src/tests/conversions_unit_tests.cpp
@@ -105,20 +105,32 @@ TEST_CASE("conversions", "") {
     auto const rho = density_of_ideal_gas(unit_temp, unit_pressure);
     auto const mmr = 1e-8;
     auto const num_conc =
-        number_conc_from_mmr(mmr, haero::Constants::molec_weight_nacl, rho);
-    auto const mmr0 = mmr_from_number_conc(
+        number_conc_from_mass_mr(mmr, haero::Constants::molec_weight_nacl, rho);
+    auto const mmr0 = mass_mr_from_number_conc(
         num_conc, haero::Constants::molec_weight_nacl, rho);
 
     logger.info("unit_temp = {}, unit_pressure = {}, rho = {}", unit_temp,
                 unit_pressure, rho);
-    logger.info("molec_weight_nacl= {}", haero::Constants::molec_weight_nacl);
+    logger.info(
+        "density_nacl= {}",
+        mam4::aero_species(aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                                  mam4::AeroId::NaCl))
+            .density);
     logger.info("mixing ratio = {}, num_conc = {}, mmr0 = {}", mmr, num_conc,
                 mmr0);
     REQUIRE(FloatingPoint<Real>::equiv(mmr, mmr0));
 
     // mass mixing ratio (mmr) <-> molar mixing ratio (vmr)
-    auto const vmr = vmr_from_mmr(mmr0, haero::Constants::molec_weight_nacl);
-    auto const mmr1 = mmr_from_vmr(vmr, haero::Constants::molec_weight_nacl);
+    auto const vmr = mass_mr_to_vol_mr(
+        mmr0,
+        mam4::aero_species(aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                                  mam4::AeroId::NaCl))
+            .density);
+    auto const mmr1 = vol_mr_to_mass_mr(
+        vmr,
+        mam4::aero_species(aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                                  mam4::AeroId::NaCl))
+            .density);
     logger.info("mmr0 = {}, vmr = {}, mmr1 = {}", mmr0, vmr, mmr1);
     REQUIRE(FloatingPoint<Real>::equiv(mmr1, mmr0));
   }

--- a/src/tests/conversions_unit_tests.cpp
+++ b/src/tests/conversions_unit_tests.cpp
@@ -104,8 +104,8 @@ TEST_CASE("conversions", "") {
     logger.info("SECTION mixing ratios");
     auto const rho = density_of_ideal_gas(unit_temp, unit_pressure);
     auto const mass_mr = 1e-8;
-    auto const num_conc =
-        number_conc_from_mass_mr(mass_mr, haero::Constants::molec_weight_nacl, rho);
+    auto const num_conc = number_conc_from_mass_mr(
+        mass_mr, haero::Constants::molec_weight_nacl, rho);
     auto const mass_mr0 = mass_mr_from_number_conc(
         num_conc, haero::Constants::molec_weight_nacl, rho);
 
@@ -116,18 +116,19 @@ TEST_CASE("conversions", "") {
         mam4::aero_species(aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
                                                   mam4::AeroId::NaCl))
             .density);
-    logger.info("mixing ratio = {}, num_conc = {}, mass_mr0 = {}", mass_mr, num_conc,
-                mass_mr0);
+    logger.info("mixing ratio = {}, num_conc = {}, mass_mr0 = {}", mass_mr,
+                num_conc, mass_mr0);
     REQUIRE(FloatingPoint<Real>::equiv(mass_mr, mass_mr0));
 
     // mass mixing ratio (mass_mr) <-> volume mixing ratio (vmr)
     auto const vmr0 = mass_mr_to_vol_mr(
         mass_mr0, aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
-                                     mam4::AeroId::NaCl));
+                                         mam4::AeroId::NaCl));
     auto const mass_mr1 = vol_mr_to_mass_mr(
         vmr0, aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
-                                    mam4::AeroId::NaCl));
-    logger.info("mass_mr0 = {}, vmr0 = {}, mass_mr1 = {}", mass_mr0, vmr0, mass_mr1);
+                                     mam4::AeroId::NaCl));
+    logger.info("mass_mr0 = {}, vmr0 = {}, mass_mr1 = {}", mass_mr0, vmr0,
+                mass_mr1);
     REQUIRE(FloatingPoint<Real>::equiv(mass_mr1, mass_mr0));
     // volume mixing ratio (vmr) <->  molar mixing ratio (molar_mr)
     auto const molar_mr0 = vol_mr_to_molar_mr(
@@ -135,17 +136,18 @@ TEST_CASE("conversions", "") {
                                      mam4::AeroId::NaCl));
     auto const vmr1 = molar_mr_to_vol_mr(
         molar_mr0, aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
-                                    mam4::AeroId::NaCl));
+                                          mam4::AeroId::NaCl));
     logger.info("vmr0 = {}, molar_mr0 = {}, vmr1 = {}", vmr0, molar_mr0, vmr1);
     REQUIRE(FloatingPoint<Real>::equiv(vmr1, vmr0));
     // mass mixing ratio (mass_mr) <-> molar mixing ratio (molar_mr)
     auto const molar_mr00 = mass_mr_to_molar_mr(
         mass_mr0, aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
-                                     mam4::AeroId::NaCl));
+                                         mam4::AeroId::NaCl));
     auto const mass_mr2 = molar_mr_to_mass_mr(
         molar_mr00, aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
-                                    mam4::AeroId::NaCl));
-    logger.info("mass_mr0 = {}, molar_mr00 = {}, mass_mr2 = {}", mass_mr0, molar_mr00, mass_mr2);
+                                           mam4::AeroId::NaCl));
+    logger.info("mass_mr0 = {}, molar_mr00 = {}, mass_mr2 = {}", mass_mr0,
+                molar_mr00, mass_mr2);
     REQUIRE(FloatingPoint<Real>::equiv(mass_mr2, mass_mr0));
   }
 

--- a/src/tests/conversions_unit_tests.cpp
+++ b/src/tests/conversions_unit_tests.cpp
@@ -100,13 +100,13 @@ TEST_CASE("conversions", "") {
   }
 
   SECTION("mixing ratios") {
-    // mass mixing ratio (mmr) <-> number_conc
+    // mass mixing ratio (mass_mr) <-> number_conc
     logger.info("SECTION mixing ratios");
     auto const rho = density_of_ideal_gas(unit_temp, unit_pressure);
-    auto const mmr = 1e-8;
+    auto const mass_mr = 1e-8;
     auto const num_conc =
-        number_conc_from_mass_mr(mmr, haero::Constants::molec_weight_nacl, rho);
-    auto const mmr0 = mass_mr_from_number_conc(
+        number_conc_from_mass_mr(mass_mr, haero::Constants::molec_weight_nacl, rho);
+    auto const mass_mr0 = mass_mr_from_number_conc(
         num_conc, haero::Constants::molec_weight_nacl, rho);
 
     logger.info("unit_temp = {}, unit_pressure = {}, rho = {}", unit_temp,
@@ -116,23 +116,37 @@ TEST_CASE("conversions", "") {
         mam4::aero_species(aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
                                                   mam4::AeroId::NaCl))
             .density);
-    logger.info("mixing ratio = {}, num_conc = {}, mmr0 = {}", mmr, num_conc,
-                mmr0);
-    REQUIRE(FloatingPoint<Real>::equiv(mmr, mmr0));
+    logger.info("mixing ratio = {}, num_conc = {}, mass_mr0 = {}", mass_mr, num_conc,
+                mass_mr0);
+    REQUIRE(FloatingPoint<Real>::equiv(mass_mr, mass_mr0));
 
-    // mass mixing ratio (mmr) <-> molar mixing ratio (vmr)
-    auto const vmr = mass_mr_to_vol_mr(
-        mmr0,
-        mam4::aero_species(aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
-                                                  mam4::AeroId::NaCl))
-            .density);
-    auto const mmr1 = vol_mr_to_mass_mr(
-        vmr,
-        mam4::aero_species(aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
-                                                  mam4::AeroId::NaCl))
-            .density);
-    logger.info("mmr0 = {}, vmr = {}, mmr1 = {}", mmr0, vmr, mmr1);
-    REQUIRE(FloatingPoint<Real>::equiv(mmr1, mmr0));
+    // mass mixing ratio (mass_mr) <-> volume mixing ratio (vmr)
+    auto const vmr0 = mass_mr_to_vol_mr(
+        mass_mr0, aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                     mam4::AeroId::NaCl));
+    auto const mass_mr1 = vol_mr_to_mass_mr(
+        vmr0, aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                    mam4::AeroId::NaCl));
+    logger.info("mass_mr0 = {}, vmr0 = {}, mass_mr1 = {}", mass_mr0, vmr0, mass_mr1);
+    REQUIRE(FloatingPoint<Real>::equiv(mass_mr1, mass_mr0));
+    // volume mixing ratio (vmr) <->  molar mixing ratio (molar_mr)
+    auto const molar_mr0 = vol_mr_to_molar_mr(
+        vmr0, aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                     mam4::AeroId::NaCl));
+    auto const vmr1 = molar_mr_to_vol_mr(
+        molar_mr0, aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                    mam4::AeroId::NaCl));
+    logger.info("vmr0 = {}, molar_mr0 = {}, vmr1 = {}", vmr0, molar_mr0, vmr1);
+    REQUIRE(FloatingPoint<Real>::equiv(vmr1, vmr0));
+    // mass mixing ratio (mass_mr) <-> molar mixing ratio (molar_mr)
+    auto const molar_mr00 = mass_mr_to_molar_mr(
+        mass_mr0, aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                     mam4::AeroId::NaCl));
+    auto const mass_mr2 = molar_mr_to_mass_mr(
+        molar_mr00, aerosol_index_for_mode(mam4::ModeIndex::Accumulation,
+                                    mam4::AeroId::NaCl));
+    logger.info("mass_mr0 = {}, molar_mr00 = {}, mass_mr2 = {}", mass_mr0, molar_mr00, mass_mr2);
+    REQUIRE(FloatingPoint<Real>::equiv(mass_mr2, mass_mr0));
   }
 
   SECTION("temperature") {


### PR DESCRIPTION
This PR is the older sibling of #155 and the result of @pbosler's comments therein.

Based on Pete's feedback, I renamed/changed/corrected a few functions and also added a couple new ones. These functions are:
- `vol_mr_to_mass_mr()`
- `mass_mr_to_vol_mr()`
- `vol_mr_to_molar_mr()`
- `molar_mr_to_vol_mr()`
- `mass_mr_to_molar_mr()` (**_New_**: this is what was actually intended to be used in `rename()`)
- `molar_mr_to_mass_mr()` (**_New_**)

In the current form, these functions do relatively basic arithmetic calculations, perhaps begging the question of whether they should even be included. I suppose it saves some ugly indexing or extra function calls in the main source files, but I'm fine if others would prefer to get rid of some/all.

I would also ask others to take a look at the convention I use of passing the aerosol's array index as an argument. It seemed to be an efficient way of grabbing density and molecular weight. Also seemed convenient since aerosols are often getting looped over when these functions are called, meaning their index is close at hand. However, it does rely on the calling process to be sure it isn't passing an invalid index (i.e., one not included in the mode of interest or a number higher than 6).

@pressel @odiazib @singhbalwinder @overfelt @jeff-cohere (Jeff, please don't read this until next week 🙂)

Closes #152 