### PR TITLE
Move `mam4_test_config.hpp` out of source tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
 .haero
-mam4_test_config.hpp
 build/
 haero/

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -12,7 +12,6 @@ file(COPY ${MAM4XX_HAERO_DIR}/bin/test-launcher DESTINATION ${PROJECT_BINARY_DIR
 add_library(mam4xx_tests kohler_verification.cpp
                          atmosphere_utils.cpp
                          testing.cpp)
-# target_include_directories(mam4xx_tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(mam4xx_tests PUBLIC ${PROJECT_BINARY_DIR}/include)
 target_include_directories(mam4xx_tests PUBLIC ${HAERO_INCLUDE_DIRS})
 target_link_libraries(mam4xx_tests ${HAERO_LIBRARIES})

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(EkatCreateUnitTest)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mam4_test_config.hpp.in
-  ${CMAKE_CURRENT_SOURCE_DIR}/mam4_test_config.hpp
+  ${PROJECT_BINARY_DIR}/include/mam4_test_config.hpp
   @ONLY
 )
 
@@ -12,7 +12,8 @@ file(COPY ${MAM4XX_HAERO_DIR}/bin/test-launcher DESTINATION ${PROJECT_BINARY_DIR
 add_library(mam4xx_tests kohler_verification.cpp
                          atmosphere_utils.cpp
                          testing.cpp)
-target_include_directories(mam4xx_tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+# target_include_directories(mam4xx_tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(mam4xx_tests PUBLIC ${PROJECT_BINARY_DIR}/include)
 target_include_directories(mam4xx_tests PUBLIC ${HAERO_INCLUDE_DIRS})
 target_link_libraries(mam4xx_tests ${HAERO_LIBRARIES})
 target_link_libraries(mam4xx_tests mam4xx)

--- a/src/tests/kohler_unit_tests.cpp
+++ b/src/tests/kohler_unit_tests.cpp
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "kohler_verification.hpp"
-#include "mam4_test_config.hpp"
+#include <mam4_test_config.hpp>
 #include <mam4xx/kohler.hpp>
 
 #include <catch2/catch.hpp>

--- a/src/tests/kohler_verification.cpp
+++ b/src/tests/kohler_verification.cpp
@@ -6,7 +6,7 @@
 #include "kohler_verification.hpp"
 
 #ifdef HAERO_DOUBLE_PRECISION
-#include "mam4_test_config.hpp"
+#include <mam4_test_config.hpp>
 
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
This PR is a small housekeeping one that moves, `mam4_test_config.hpp`, the configure file that's generated by `mam4_test_config.hpp.in`, out of the source tree and into `${PROJECT_BINARY_DIR}/include/`.