### PR TITLE
Expand GPU partitions and fix PNNL CI

### DIFF
--- a/.github/pnnl-ci/ci.sh
+++ b/.github/pnnl-ci/ci.sh
@@ -41,8 +41,8 @@ echo $PRECISION "detected for PRECISION"
 
 . /etc/profile.d/modules.sh
 module purge
-module load cmake
-module load gcc/9.1.0
+module load cmake/3.21.4
+module load gcc/10.2.0
 module load cuda/11.4
 module load python/3.7.0
 

--- a/.github/pnnl-ci/findIdleDLNodes.pl
+++ b/.github/pnnl-ci/findIdleDLNodes.pl
@@ -6,7 +6,7 @@ my @idle_parts = grep /idle/, @partitions;
 
 # Set to dl_shared for now
 # Change here for desired partition
-print "dl_shared";
+print "dl_shared,fat_shared,dl,fat";
 
 # Logic for selecting dl(v)(t) partitions with idle nodes
 #if ( scalar @idle_parts eq 0 ) {


### PR DESCRIPTION
List of GPU partitions is now given and gcc 10 is now being used on deception - see https://github.com/eagles-project/haero/pull/451 for the associated HAERO PR