### PR TITLE
removing redundant mam4xx folder from library install location

### DIFF
--- a/src/mam4xx/CMakeLists.txt
+++ b/src/mam4xx/CMakeLists.txt
@@ -28,4 +28,4 @@ install(FILES
         DESTINATION include/mam4xx)
 
 add_library(mam4xx aero_modes.cpp)
-install(TARGETS mam4xx DESTINATION ${CMAKE_INSTALL_LIBDIR}/mam4xx)
+install(TARGETS mam4xx DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Eamxx can't find `libmam4xx.a` because it's installed behind an extra `mam4xx` folder.   This PR removes that folder from the Mam4xx library install path.