### PR TITLE
Add C++ version of ma_precpevap_convproc and tests.

### DIFF
--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -525,6 +525,7 @@ void ma_precpevap(const Real dpdry_i, const Real evapc, const Real pr_flux,
 }
 
 //=========================================================================================
+template <typename SubView>
 KOKKOS_INLINE_FUNCTION
 void ma_precpprod(const Real rprd, const Real dpdry_i,
                   const bool doconvproc_extd[ConvProc::pcnst_extd],
@@ -532,9 +533,11 @@ void ma_precpprod(const Real rprd, const Real dpdry_i,
                   const int species_class[ConvProc::gas_pcnst],
                   const int mmtoo_prevap_resusp[ConvProc::gas_pcnst],
                   Real &pr_flux, Real &pr_flux_tmp, Real &pr_flux_base,
-                  ColumnView wd_flux, const ColumnView dcondt_wetdep,
-                  ColumnView dcondt, ColumnView dcondt_prevap,
-                  ColumnView dcondt_prevap_hist) {
+                  ColumnView wd_flux, 
+                  const SubView dcondt_wetdep,
+                  SubView dcondt, 
+                  SubView dcondt_prevap,
+                  SubView dcondt_prevap_hist) {
   // clang-format off
   // ------------------------------------------
   //  step 2 in ma_precpevap_convproc: aerosol scavenging from precipitation production
@@ -742,12 +745,12 @@ void ma_precpevap_convproc(
     ma_precpevap(dpdry_i[kk], evapc[kk], pr_flux, pr_flux_base, pr_flux_tmp,
                  x_ratio);
     // step 2 - precip production and aerosol scavenging
-    ColumnView dcondt_wetdep_sub =
+    auto dcondt_wetdep_sub =
         Kokkos::subview(dcondt_wetdep, kk, Kokkos::ALL());
-    ColumnView dcondt_sub = Kokkos::subview(dcondt, kk, Kokkos::ALL());
-    ColumnView dcondt_prevap_sub =
+    auto dcondt_sub = Kokkos::subview(dcondt, kk, Kokkos::ALL());
+    auto dcondt_prevap_sub =
         Kokkos::subview(dcondt_prevap, kk, Kokkos::ALL());
-    ColumnView dcondt_prevap_hist_sub =
+    auto dcondt_prevap_hist_sub =
         Kokkos::subview(dcondt_prevap_hist, kk, Kokkos::ALL());
     ma_precpprod(rprd[kk], dpdry_i[kk], doconvproc_extd, x_ratio, species_class,
                  mmtoo_prevap_resusp, pr_flux, pr_flux_tmp, pr_flux_base,

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -526,18 +526,14 @@ void ma_precpevap(const Real dpdry_i, const Real evapc, const Real pr_flux,
 
 //=========================================================================================
 template <typename SubView>
-KOKKOS_INLINE_FUNCTION
-void ma_precpprod(const Real rprd, const Real dpdry_i,
-                  const bool doconvproc_extd[ConvProc::pcnst_extd],
-                  const Real x_ratio,
-                  const int species_class[ConvProc::gas_pcnst],
-                  const int mmtoo_prevap_resusp[ConvProc::gas_pcnst],
-                  Real &pr_flux, Real &pr_flux_tmp, Real &pr_flux_base,
-                  ColumnView wd_flux, 
-                  const SubView dcondt_wetdep,
-                  SubView dcondt, 
-                  SubView dcondt_prevap,
-                  SubView dcondt_prevap_hist) {
+KOKKOS_INLINE_FUNCTION void
+ma_precpprod(const Real rprd, const Real dpdry_i,
+             const bool doconvproc_extd[ConvProc::pcnst_extd],
+             const Real x_ratio, const int species_class[ConvProc::gas_pcnst],
+             const int mmtoo_prevap_resusp[ConvProc::gas_pcnst], Real &pr_flux,
+             Real &pr_flux_tmp, Real &pr_flux_base, ColumnView wd_flux,
+             const SubView dcondt_wetdep, SubView dcondt, SubView dcondt_prevap,
+             SubView dcondt_prevap_hist) {
   // clang-format off
   // ------------------------------------------
   //  step 2 in ma_precpevap_convproc: aerosol scavenging from precipitation production
@@ -745,11 +741,9 @@ void ma_precpevap_convproc(
     ma_precpevap(dpdry_i[kk], evapc[kk], pr_flux, pr_flux_base, pr_flux_tmp,
                  x_ratio);
     // step 2 - precip production and aerosol scavenging
-    auto dcondt_wetdep_sub =
-        Kokkos::subview(dcondt_wetdep, kk, Kokkos::ALL());
+    auto dcondt_wetdep_sub = Kokkos::subview(dcondt_wetdep, kk, Kokkos::ALL());
     auto dcondt_sub = Kokkos::subview(dcondt, kk, Kokkos::ALL());
-    auto dcondt_prevap_sub =
-        Kokkos::subview(dcondt_prevap, kk, Kokkos::ALL());
+    auto dcondt_prevap_sub = Kokkos::subview(dcondt_prevap, kk, Kokkos::ALL());
     auto dcondt_prevap_hist_sub =
         Kokkos::subview(dcondt_prevap_hist, kk, Kokkos::ALL());
     ma_precpprod(rprd[kk], dpdry_i[kk], doconvproc_extd, x_ratio, species_class,

--- a/src/validation/convproc/CMakeLists.txt
+++ b/src/validation/convproc/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(convproc_driver convproc_driver.cpp
                compute_column_tendency.cpp
                ma_precpevap.cpp
                ma_precpprod.cpp
+               ma_precpevap_convproc.cpp
                ma_resuspend_convproc.cpp)
 target_link_libraries(convproc_driver skywalker;validation;${HAERO_LIBRARIES})
 
@@ -36,6 +37,7 @@ foreach (input
          compute_column_tendency
          ma_precpevap
          ma_precpprod
+         ma_precpevap_convproc
          ma_resuspend_convproc
          )
 

--- a/src/validation/convproc/convproc_driver.cpp
+++ b/src/validation/convproc/convproc_driver.cpp
@@ -30,6 +30,7 @@ void compute_column_tendency(Ensemble *ensemble);
 void ma_resuspend_convproc(Ensemble *ensemble);
 void ma_precpevap(Ensemble *ensemble);
 void ma_precpprod(Ensemble *ensemble);
+void ma_precpevap_convproc(Ensemble *ensemble);
 
 int main(int argc, char **argv) {
   if (argc == 1) {
@@ -63,6 +64,8 @@ int main(int argc, char **argv) {
       ma_precpevap(ensemble);
     } else if (func_name == "ma_precpprod") {
       ma_precpprod(ensemble);
+    } else if (func_name == "ma_precpevap_convproc") {
+      ma_precpevap_convproc(ensemble);
     } else {
       std::cerr << "Error: Test name not recognized:" << func_name << std::endl;
       exit(1);

--- a/src/validation/convproc/ma_precpevap_convproc.cpp
+++ b/src/validation/convproc/ma_precpevap_convproc.cpp
@@ -1,0 +1,142 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <catch2/catch.hpp>
+#include <iomanip>
+#include <iostream>
+#include <mam4xx/convproc.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+using namespace skywalker;
+using namespace mam4;
+
+namespace {
+void get_input(const Input &input, const std::string &name, const int size,
+               std::vector<Real> &host, ColumnView &dev) {
+  host = input.get_array(name);
+  dev = mam4::validation::create_column_view(size);
+
+  EKAT_ASSERT(host.size() == size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  for (int n = 0; n < size; ++n)
+    host_view[n] = host[n];
+  Kokkos::deep_copy(dev, host_view);
+}
+void get_input(const Input &input, const std::string &name, const int rows,
+               const int cols, std::vector<Real> &host,
+               Kokkos::View<Real **, Kokkos::MemoryUnmanaged> &dev) {
+  host = input.get_array(name);
+  ColumnView col_view = mam4::validation::create_column_view(rows * cols);
+  dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(col_view.data(), rows,
+                                                       cols);
+  EKAT_ASSERT(host.size() == rows * cols);
+  {
+    std::vector<std::vector<Real>> matrix(rows, std::vector<Real>(cols));
+    // Row Major layout
+    for (int i = 0, n = 0; i < rows; ++i)
+      for (int j = 0; j < cols; ++j, ++n)
+        matrix[i][j] = host[n];
+    auto host_view = Kokkos::create_mirror_view(dev);
+    for (int i = 0; i < rows; ++i)
+      for (int j = 0; j < cols; ++j)
+        host_view(i, j) = matrix[i][j];
+    Kokkos::deep_copy(dev, host_view);
+  }
+}
+void get_input(const int rows, const int cols, std::vector<Real> &host,
+               Kokkos::View<Real **, Kokkos::MemoryUnmanaged> &dev) {
+  host.resize(rows * cols, 0);
+  ColumnView col_view = mam4::validation::create_column_view(rows * cols);
+  dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(col_view.data(), rows,
+                                                       cols);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  for (int i = 0; i < rows; ++i)
+    for (int j = 0; j < cols; ++j)
+      host_view(i, j) = 0;
+  Kokkos::deep_copy(dev, host_view);
+}
+void set_output(Output &output, const std::string &name, const int rows,
+                const int cols, std::vector<Real> &host,
+                const Kokkos::View<Real **, Kokkos::MemoryUnmanaged> &dev) {
+  auto host_view = Kokkos::create_mirror_view(dev);
+  Kokkos::deep_copy(host_view, dev);
+  for (int i = 0, n = 0; i < rows; ++i)
+    for (int j = 0; j < cols; ++j, ++n)
+      host[n] = host_view(i, j);
+  output.set(name, host);
+}
+} // namespace
+void ma_precpevap_convproc(Ensemble *ensemble) {
+  // We don't need any settings for this particular test.
+  // Settings settings = ensemble->settings();
+  // Run the ensemble.
+  ensemble->process([=](const Input &input, Output &output) {
+    const int nlev = 72;
+    // Fetch ensemble parameters
+    // Convert to C++ index by subtracting one.
+    const int ktop = input.get("ktop") - 1;
+    EKAT_ASSERT(47 == ktop);
+    const int pcnst_extd = input.get("pcnst_extd");
+    EKAT_ASSERT(ConvProc::pcnst_extd == pcnst_extd);
+
+    std::vector<Real> dcondt_host, dcondt_prevap_host, dcondt_prevap_hist_host,
+        dcondt_wetdep_host, rprd_host, evapc_host, dpdry_i_host,
+        doconvproc_extd_host, species_class_host, mmtoo_prevap_resusp_host;
+    ColumnView rprd_dev, evapc_dev, dpdry_i_dev, doconvproc_extd_dev,
+        species_class_dev, mmtoo_prevap_resusp_dev;
+    Kokkos::View<Real **, Kokkos::MemoryUnmanaged> dcondt_dev,
+        dcondt_prevap_dev, dcondt_prevap_hist_dev, dcondt_wetdep_dev;
+    get_input(input, "rprd", nlev, rprd_host, rprd_dev);
+    get_input(input, "evapc", nlev, evapc_host, evapc_dev);
+    get_input(input, "dpdry_i", nlev, dpdry_i_host, dpdry_i_dev);
+    get_input(input, "dcondt_wetdep", nlev, pcnst_extd, dcondt_wetdep_host,
+              dcondt_wetdep_dev);
+    get_input(nlev, pcnst_extd, dcondt_prevap_host, dcondt_prevap_dev);
+    get_input(nlev, pcnst_extd, dcondt_prevap_hist_host,
+              dcondt_prevap_hist_dev);
+
+    get_input(input, "species_class", ConvProc::gas_pcnst, species_class_host,
+              species_class_dev);
+    get_input(input, "doconvproc_extd", pcnst_extd, doconvproc_extd_host,
+              doconvproc_extd_dev);
+    get_input(input, "dcondt", nlev, pcnst_extd, dcondt_host, dcondt_dev);
+    get_input(input, "mmtoo_prevap_resusp", ConvProc::gas_pcnst,
+              mmtoo_prevap_resusp_host, mmtoo_prevap_resusp_dev);
+    ColumnView wd_flux =
+        mam4::validation::create_column_view(ConvProc::pcnst_extd);
+    Kokkos::parallel_for(
+        "ma_precpevap_convproc", 1, KOKKOS_LAMBDA(int) {
+          Real rprd[nlev];
+          for (int i = 0; i < nlev; ++i)
+            rprd[i] = rprd_dev(i);
+          Real evapc[nlev];
+          for (int i = 0; i < nlev; ++i)
+            evapc[i] = evapc_dev(i);
+          Real dpdry_i[nlev];
+          for (int i = 0; i < nlev; ++i)
+            dpdry_i[i] = dpdry_i_dev(i);
+          bool doconvproc_extd[ConvProc::pcnst_extd];
+          for (int i = 0; i < ConvProc::pcnst_extd; ++i)
+            doconvproc_extd[i] = doconvproc_extd_dev[i];
+          int species_class[ConvProc::gas_pcnst];
+          for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+            species_class[i] = species_class_dev[i];
+          int mmtoo_prevap_resusp[ConvProc::gas_pcnst];
+          for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+            mmtoo_prevap_resusp[i] = mmtoo_prevap_resusp_dev[i] - 1;
+
+          convproc::ma_precpevap_convproc(
+              ktop, nlev, dcondt_wetdep_dev, rprd_dev, evapc_dev, dpdry_i_dev,
+              doconvproc_extd, species_class, mmtoo_prevap_resusp, wd_flux,
+              dcondt_prevap_dev, dcondt_prevap_hist_dev, dcondt_dev);
+        });
+    set_output(output, "dcondt", nlev, pcnst_extd, dcondt_host, dcondt_dev);
+    set_output(output, "dcondt_prevap", nlev, pcnst_extd, dcondt_prevap_host,
+               dcondt_prevap_dev);
+    set_output(output, "dcondt_prevap_hist", nlev, pcnst_extd,
+               dcondt_prevap_hist_host, dcondt_prevap_hist_dev);
+  });
+}

--- a/src/validation/convproc/ma_precpprod.cpp
+++ b/src/validation/convproc/ma_precpprod.cpp
@@ -124,20 +124,24 @@ void ma_precpprod(Ensemble *ensemble) {
           for (int i = 0; i < ConvProc::gas_pcnst; ++i)
             mmtoo_prevap_resusp[i] = mmtoo_prevap_resusp_dev[i] - 1;
 
-          ColumnView dcondt_wetdep =
+          auto dcondt_wetdep =
               Kokkos::subview(dcondt_wetdep_dev, kk, Kokkos::ALL());
-          ColumnView dcondt = Kokkos::subview(dcondt_dev, kk, Kokkos::ALL());
-          ColumnView dcondt_prevap =
+          auto dcondt = Kokkos::subview(dcondt_dev, kk, Kokkos::ALL());
+          auto dcondt_prevap =
               Kokkos::subview(dcondt_prevap_dev, kk, Kokkos::ALL());
-          ColumnView dcondt_prevap_hist =
+          auto dcondt_prevap_hist =
               Kokkos::subview(dcondt_prevap_hist_dev, kk, Kokkos::ALL());
           Real flux = pr_flux;
           Real flux_tmp = pr_flux_tmp;
           Real flux_base = pr_flux_base;
           convproc::ma_precpprod(
               rprd[kk], dpdry_i[kk], doconvproc_extd, x_ratio, species_class,
-              mmtoo_prevap_resusp, flux, flux_tmp, flux_base, wd_flux_dev,
-              dcondt_wetdep, dcondt, dcondt_prevap, dcondt_prevap_hist);
+              mmtoo_prevap_resusp, flux, flux_tmp, flux_base, 
+              wd_flux_dev,
+              dcondt_wetdep, 
+              dcondt, 
+              dcondt_prevap, 
+              dcondt_prevap_hist);
           return_vals[0] = flux;
           return_vals[1] = flux_tmp;
           return_vals[2] = flux_base;

--- a/src/validation/convproc/ma_precpprod.cpp
+++ b/src/validation/convproc/ma_precpprod.cpp
@@ -136,12 +136,8 @@ void ma_precpprod(Ensemble *ensemble) {
           Real flux_base = pr_flux_base;
           convproc::ma_precpprod(
               rprd[kk], dpdry_i[kk], doconvproc_extd, x_ratio, species_class,
-              mmtoo_prevap_resusp, flux, flux_tmp, flux_base, 
-              wd_flux_dev,
-              dcondt_wetdep, 
-              dcondt, 
-              dcondt_prevap, 
-              dcondt_prevap_hist);
+              mmtoo_prevap_resusp, flux, flux_tmp, flux_base, wd_flux_dev,
+              dcondt_wetdep, dcondt, dcondt_prevap, dcondt_prevap_hist);
           return_vals[0] = flux;
           return_vals[1] = flux_tmp;
           return_vals[2] = flux_base;


### PR DESCRIPTION
First case of running into a level-dependent process that has to be evaluated from the top level to the bottom because the computation of level n depends on the results of level n-1.  To complicate it a bit more the data at each level is itself an array of data of undetermined length making it a 2D array that needs to be sub-viewed at each level. So my first use of Kokkos::subview in mam4xx.