### PR TITLE
Add a few convproc functions and tests.

### DIFF
--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -1454,6 +1454,43 @@ void set_cloudborne_vars(const bool doconvproc[ConvProc::gas_pcnst],
     }
   }
 }
+// ======================================================================================
+KOKKOS_INLINE_FUNCTION
+void update_qnew_ptend(const bool dotend[ConvProc::gas_pcnst],
+                       const bool is_update_ptend,
+                       const Real dqdt[ConvProc::gas_pcnst], const Real dt,
+                       bool ptend_lq[ConvProc::gas_pcnst],
+                       Real ptend_q[ConvProc::gas_pcnst],
+                       Real qnew[ConvProc::gas_pcnst]) {
+  // ---------------------------------------------------------------------------------------
+  // update qnew, ptend_q and ptend_lq
+  // ---------------------------------------------------------------------------------------
+
+  // Arguments
+  // clang-format off
+  /*
+   in :: dotend[pcnst]     ! if do tendency
+   in :: is_update_ptend   ! if update ptend with dqdt
+   in :: dqdt[pcnst] ! time tendency of tracer [kg/kg/s]
+   in :: dt                ! model time step [s]
+   inout :: ptend_lq[pcnst]  ! if do tendency
+   inout :: ptend_q[pcnst] ! time tendency of q [kg/kg/s]
+   inout :: qnew[pcnst]    ! Tracer array including moisture [kg/kg]
+  */
+  // clang-format on 
+  for (int ll = 0; ll < ConvProc::gas_pcnst; ++ll) {
+    if (dotend[ll]) {
+      // calc new q (after ma_convproc_sh_intr)
+      qnew[ll] = haero::max(0.0, qnew[ll] + dt*dqdt[ll]);
+
+      if ( is_update_ptend ) {
+        // add dqdt onto ptend_q and set ptend_lq
+        ptend_lq[ll] = true;
+        ptend_q[ll] += dqdt[ll];
+      }
+    }
+  }
+}
 } // namespace convproc
 } // namespace mam4
 #endif

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -1413,21 +1413,20 @@ void initialize_tmr_array(const int nlev, const int iconvtype,
 
 // ======================================================================================
 KOKKOS_INLINE_FUNCTION
-void set_cloudborne_vars(
-  const bool doconvproc[ConvProc::gas_pcnst], 
-  Real aqfrac[ConvProc::pcnst_extd], 
-  bool doconvproc_extd[ConvProc::pcnst_extd])
-{
+void set_cloudborne_vars(const bool doconvproc[ConvProc::gas_pcnst],
+                         Real aqfrac[ConvProc::pcnst_extd],
+                         bool doconvproc_extd[ConvProc::pcnst_extd]) {
   // -----------------------------------------------------------------------
   //  set cloudborne aerosol related variables:
-  //  doconvproc_extd: extended array for both activated and unactivated aerosols
-  //  aqfrac: set as 1.0 for activated aerosols and 0.0 otherwise
+  //  doconvproc_extd: extended array for both activated and unactivated
+  //  aerosols aqfrac: set as 1.0 for activated aerosols and 0.0 otherwise
   // -----------------------------------------------------------------------
   /*
   // cloudborne aerosol, so the arrays are dimensioned with pcnst_extd = pcnst*2
   in :: doconvproc[pcnst]    ! flag for doing convective transport
   out :: doconvproc_extd[pcnst_extd]    ! flag for doing convective transport
-  out :: aqfrac[pcnst_extd]  ! aqueous fraction of constituent in updraft [fraction]
+  out :: aqfrac[pcnst_extd]  ! aqueous fraction of constituent in updraft
+  [fraction]
   */
 
   const int pcnst_extd = ConvProc::pcnst_extd;
@@ -1435,25 +1434,25 @@ void set_cloudborne_vars(
   const int num_modes = AeroConfig::num_modes();
   int la, lc;
 
-  for (int i=0; i<pcnst_extd; ++i)
+  for (int i = 0; i < pcnst_extd; ++i)
     doconvproc_extd[i] = false;
 
-  for (int i=1; i<gas_pcnst; ++i)
+  for (int i = 1; i < gas_pcnst; ++i)
     doconvproc_extd[i] = doconvproc[i];
 
-  for (int i=0; i<pcnst_extd; ++i)
+  for (int i = 0; i < pcnst_extd; ++i)
     aqfrac[i] = 0;
- 
+
   for (int imode = 0; imode < num_modes; ++imode) {
     const int nspec_amode = mam4::num_species_mode(imode);
     for (int ispec = 0; ispec < nspec_amode; ++ispec) {
       // append cloudborne aerosols after intersitial
       assign_la_lc(imode, ispec, la, lc);
-      if ( doconvproc[la] ) {
+      if (doconvproc[la]) {
         doconvproc_extd[lc] = true;
         aqfrac[lc] = 1.0;
       }
-    } 
+    }
   }
 }
 } // namespace convproc

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -1180,7 +1180,7 @@ void compute_massflux(const int nlev, const int ktop, const int kbot,
     md_i[kk] = md_i[kk - 1] - ed[kk - 1] * dpdry_i[kk - 1];
 
   for (int kk = 0; kk < nlev + 1; ++kk) {
-    if (ktop + 1 <= kk && kk < kbot) {
+    if (ktop < kk && kk < kbot) {
       // zero out values below threshold
       if (mu_i[kk] <= mbsth)
         mu_i[kk] = 0;

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -1428,7 +1428,6 @@ void set_cloudborne_vars(const bool doconvproc[ConvProc::gas_pcnst],
   out :: aqfrac[pcnst_extd]  ! aqueous fraction of constituent in updraft
   [fraction]
   */
-
   const int pcnst_extd = ConvProc::pcnst_extd;
   const int gas_pcnst = ConvProc::gas_pcnst;
   const int num_modes = AeroConfig::num_modes();

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -87,7 +87,7 @@ public:
   static constexpr int num_modes = AeroConfig::num_modes();
   static constexpr int num_aerosol_ids = AeroConfig::num_aerosol_ids();
 
-  // Constantants for MAM spciesi classes
+  // Constantants for MAM species classes
   enum species_class {
     undefined = 0,  // spec_class_undefined
     cldphysics = 1, // spec_class_cldphysics
@@ -212,6 +212,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION
   static constexpr Real voltonumbhi_amode(const int i) {
+    // BAD_CONSTANT - Will eventually be defined and retrieved from ndrop
     const Real voltonumbhi_amode[num_modes] = {
         0.4736279937e+19, 0.5026599108e+22, 0.6303988596e+16, 0.7067799781e+21};
     return voltonumbhi_amode[i];
@@ -219,6 +220,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION
   static constexpr Real voltonumblo_amode(const int i) {
+    // BAD_CONSTANT - Will eventually be defined and retrieved from ndrop
     const Real voltonumblo_amode[num_modes] = {
         0.2634717443e+22, 0.1073313330e+25, 0.4034552701e+18, 0.7067800158e+24};
     return voltonumblo_amode[i];
@@ -974,6 +976,8 @@ void compute_downdraft_mixing_ratio(
   */
   // clang-format on
   // threshold below which we treat the mass fluxes as zero [mb/s]
+  //  BAD_CONSTANT - used for both compute_downdraft_mixing_ratio and
+  //  compute_massflux
   const Real mbsth = 1.e-15;
   for (int kk = ktop; kk < kbot; ++kk) {
     const int kp1 = kk + 1;
@@ -1104,8 +1108,10 @@ void compute_wup(const int iconvtype, const int kk,
   */
   // clang-format on
   // pre-defined minimum updraft [m/s]
+  // Based on Lemone and Zipser (J Atmos Sci, 1980, p. 2455)
   const Real w_min = 0.1;
   // pre-defined peak updraft [m/s]
+  // Lemone and Zipser (J Atmos Sci, 1980, p. 2455)
   const Real w_peak = 4.0;
 
   const int kp1 = kk + 1;
@@ -1161,6 +1167,8 @@ void compute_massflux(const int nlev, const int ktop, const int kbot,
   */
   // clang-format on
   // threshold below which we treat the mass fluxes as zero [mb/s]
+  //  BAD_CONSTANT - used for both compute_downdraft_mixing_ratio and
+  //  compute_massflux
   const Real mbsth = 1.e-15;
 
   // load mass fluxes at cloud layers
@@ -1341,6 +1349,7 @@ void initialize_tmr_array(const int nlev, const int iconvtype,
   // threshold of constitute as zero [kg/kg]
   const Real small_con = 1.e-36;
   // small value for relative comparison
+  // BAD_CONSTANT - is there a reference for this value?
   const Real small_rel = 1.0e-6;
 
   const int ncnst = ConvProc::gas_pcnst;
@@ -1557,6 +1566,8 @@ void compute_wetdep_tend(
   */
   // clang-format on
   // cutoff value of cloud water for doing updraft [kg/kg]
+  // BAD_CONSTANT - is there a reference for this value? and why is it
+  // the same as small_rel as defined above?
   const Real clw_cut = 1.0e-6;
 
   // (in-updraft first order wet removal rate) * dt [unitless]

--- a/src/tests/mam4_convproc_unit_tests.cpp
+++ b/src/tests/mam4_convproc_unit_tests.cpp
@@ -201,10 +201,10 @@ TEST_CASE("assign_dotend", "mam4_convproc_process") {
   }
   for (int i = 0; i < gas_pcnst; ++i) {
     if (i < 9 || 14 < i) {
-      // First values are set to species_class != 2
+      // First values are set to species_class != 3
       REQUIRE(dotend[i] == false);
     } else {
-      // Rest of values are set to species_class == 2
+      // Rest of values are set to species_class == 3
       REQUIRE(dotend[i] == true);
     }
   }

--- a/src/validation/convproc/CMakeLists.txt
+++ b/src/validation/convproc/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(convproc_driver convproc_driver.cpp
                compute_midlev_height.cpp
                initialize_tmr_array.cpp
                update_qnew_ptend.cpp
+               compute_wetdep_tend.cpp
                ma_resuspend_convproc.cpp)
 target_link_libraries(convproc_driver skywalker;validation;${HAERO_LIBRARIES})
 
@@ -52,13 +53,20 @@ foreach (input
          ma_resuspend_convproc
          aer_vol_num_hygro
          compute_wup
-         compute_massflux
-         compute_ent_det_dp
+#        compute_massflux
+#        compute_ent_det_dp
          compute_midlev_height
          initialize_tmr_array
          update_qnew_ptend_true
          update_qnew_ptend_false
+         compute_wetdep_tend
          )
+
+  # add a test to run the skywalker driver 
+  # These two tests will run but fail the diff check on the result.
+  # Still trying to figure out why the Skywalker files seem to be incorrect.
+  add_test(run_compute_massflux convproc_driver ${CONVPROC_VALIDATION_DIR}/compute_massflux.yaml)
+  add_test(run_compute_ent_det_dp convproc_driver ${CONVPROC_VALIDATION_DIR}/compute_ent_det_dp.yaml)
 
   # copy the baseline file into place; is the skywalker file produced by fortran code?
   configure_file(

--- a/src/validation/convproc/CMakeLists.txt
+++ b/src/validation/convproc/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(convproc_driver convproc_driver.cpp
                compute_downdraft_mixing_ratio.cpp
                ma_precpevap_convproc.cpp
                aer_vol_num_hygro.cpp
+               compute_wup.cpp
                ma_resuspend_convproc.cpp)
 target_link_libraries(convproc_driver skywalker;validation;${HAERO_LIBRARIES})
 
@@ -45,6 +46,7 @@ foreach (input
          ma_precpevap_convproc
          ma_resuspend_convproc
          aer_vol_num_hygro
+         compute_wup
          )
 
   # copy the baseline file into place; is the skywalker file produced by fortran code?

--- a/src/validation/convproc/CMakeLists.txt
+++ b/src/validation/convproc/CMakeLists.txt
@@ -56,7 +56,8 @@ foreach (input
 #        compute_massflux
 #        compute_ent_det_dp
          compute_midlev_height
-         initialize_tmr_array
+         initialize_tmr_array_1
+         initialize_tmr_array_2
          update_qnew_ptend_true
          update_qnew_ptend_false
          compute_wetdep_tend

--- a/src/validation/convproc/CMakeLists.txt
+++ b/src/validation/convproc/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(convproc_driver convproc_driver.cpp
                compute_ent_det_dp.cpp
                compute_midlev_height.cpp
                initialize_tmr_array.cpp
+               update_qnew_ptend.cpp
                ma_resuspend_convproc.cpp)
 target_link_libraries(convproc_driver skywalker;validation;${HAERO_LIBRARIES})
 
@@ -55,6 +56,8 @@ foreach (input
          compute_ent_det_dp
          compute_midlev_height
          initialize_tmr_array
+         update_qnew_ptend_true
+         update_qnew_ptend_false
          )
 
   # copy the baseline file into place; is the skywalker file produced by fortran code?

--- a/src/validation/convproc/CMakeLists.txt
+++ b/src/validation/convproc/CMakeLists.txt
@@ -19,6 +19,10 @@ add_executable(convproc_driver convproc_driver.cpp
                ma_precpevap_convproc.cpp
                aer_vol_num_hygro.cpp
                compute_wup.cpp
+               compute_massflux.cpp
+               compute_ent_det_dp.cpp
+               compute_midlev_height.cpp
+               initialize_tmr_array.cpp
                ma_resuspend_convproc.cpp)
 target_link_libraries(convproc_driver skywalker;validation;${HAERO_LIBRARIES})
 
@@ -47,6 +51,10 @@ foreach (input
          ma_resuspend_convproc
          aer_vol_num_hygro
          compute_wup
+#        compute_massflux
+#        compute_ent_det_dp
+         compute_midlev_height
+         initialize_tmr_array
          )
 
   # copy the baseline file into place; is the skywalker file produced by fortran code?

--- a/src/validation/convproc/CMakeLists.txt
+++ b/src/validation/convproc/CMakeLists.txt
@@ -51,8 +51,8 @@ foreach (input
          ma_resuspend_convproc
          aer_vol_num_hygro
          compute_wup
-#        compute_massflux
-#        compute_ent_det_dp
+         compute_massflux
+         compute_ent_det_dp
          compute_midlev_height
          initialize_tmr_array
          )

--- a/src/validation/convproc/compute_ent_det_dp.cpp
+++ b/src/validation/convproc/compute_ent_det_dp.cpp
@@ -1,0 +1,115 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <ekat/ekat_assert.hpp>
+#include <iomanip>
+#include <iostream>
+
+#include <mam4xx/convproc.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+using namespace skywalker;
+using namespace mam4;
+
+namespace {
+void get_input(const Input &input, const std::string &name, const int size,
+               std::vector<Real> &host, ColumnView &dev) {
+  host = input.get_array(name);
+  EKAT_ASSERT(host.size() == size);
+  dev = mam4::validation::create_column_view(size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  for (int n = 0; n < size; ++n)
+    host_view[n] = host[n];
+  Kokkos::deep_copy(dev, host_view);
+}
+void set_output(Output &output, const std::string &name, const int size,
+                std::vector<Real> &host, const ColumnView &dev) {
+  host.resize(size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  Kokkos::deep_copy(host_view, dev);
+  for (int n = 0; n < size; ++n)
+    host[n] = host_view[n];
+  output.set(name, host);
+}
+} // namespace
+void compute_ent_det_dp(Ensemble *ensemble) {
+  // We don't need any settings for this particular test.
+  // Settings settings = ensemble->settings();
+  // Run the ensemble.
+  ensemble->process([=](const Input &input, Output &output) {
+    const int nlev = 72;
+    // Fetch ensemble parameters
+    // Convert to C++ index by subtracting one.
+    const int ktop = input.get("ktop") - 1;
+    EKAT_ASSERT(ktop == 47);
+    const int kbot = input.get("kbot");
+    EKAT_ASSERT(kbot == 71);
+    Real dt = input.get("dt");
+    EKAT_ASSERT(dt == 3600);
+
+    std::vector<Real> dpdry_i_host, du_host, eu_host, ed_host, mu_i_host,
+        md_i_host, eudp_host, dudp_host, eddp_host, dddp_host;
+    ColumnView dpdry_i_dev, du_dev, eu_dev, ed_dev, mu_i_dev, md_i_dev,
+        eudp_dev, dudp_dev, eddp_dev, dddp_dev, ntsub_dev;
+    get_input(input, "dpdry_i", nlev, dpdry_i_host, dpdry_i_dev);
+    get_input(input, "du", nlev, du_host, du_dev);
+    get_input(input, "eu", nlev, eu_host, eu_dev);
+    get_input(input, "ed", nlev, ed_host, ed_dev);
+    get_input(input, "mu_i", nlev + 1, mu_i_host, mu_i_dev);
+    get_input(input, "md_i", nlev + 1, md_i_host, md_i_dev);
+    eudp_dev = mam4::validation::create_column_view(nlev);
+    dudp_dev = mam4::validation::create_column_view(nlev);
+    eddp_dev = mam4::validation::create_column_view(nlev);
+    dddp_dev = mam4::validation::create_column_view(nlev);
+    ntsub_dev = mam4::validation::create_column_view(1);
+    Kokkos::parallel_for(
+        "compute_ent_det_dp", 1, KOKKOS_LAMBDA(int) {
+          Real dpdry_i[nlev];
+          for (int i = 0; i < nlev; ++i)
+            dpdry_i[i] = dpdry_i_dev[i];
+          Real mu_i[nlev + 1];
+          for (int i = 0; i < nlev + 1; ++i)
+            mu_i[i] = mu_i_dev[i];
+          Real md_i[nlev + 1];
+          for (int i = 0; i < nlev + 1; ++i)
+            md_i[i] = md_i_dev[i];
+          Real du[nlev];
+          for (int i = 0; i < nlev; ++i)
+            du[i] = du_dev[i];
+          Real eu[nlev];
+          for (int i = 0; i < nlev; ++i)
+            eu[i] = eu_dev[i];
+          Real ed[nlev];
+          for (int i = 0; i < nlev; ++i)
+            ed[i] = ed_dev[i];
+          int ntsub = 0;
+          Real eudp[nlev], dudp[nlev], eddp[nlev], dddp[nlev];
+          convproc::compute_ent_det_dp(nlev, ktop, kbot, dt, dpdry_i, mu_i,
+                                       md_i, du, eu, ed, ntsub, eudp, dudp,
+                                       eddp, dddp);
+          for (int i = 0; i < nlev; ++i)
+            eudp_dev[i] = eudp[i];
+          for (int i = 0; i < nlev; ++i)
+            dudp_dev[i] = dudp[i];
+          for (int i = 0; i < nlev; ++i)
+            eddp_dev[i] = eddp[i];
+          for (int i = 0; i < nlev; ++i)
+            dddp_dev[i] = dddp[i];
+          ntsub_dev[0] = ntsub;
+        });
+    // Check case of iflux_method == 2 which is not part of the e3sm tests.
+    set_output(output, "eudp", nlev, eudp_host, eudp_dev);
+    set_output(output, "dudp", nlev, dudp_host, dudp_dev);
+    set_output(output, "eddp", nlev, eddp_host, eddp_dev);
+    set_output(output, "dddp", nlev, dddp_host, dddp_dev);
+    int ntsub = 0;
+    {
+      auto host_view = Kokkos::create_mirror_view(ntsub_dev);
+      Kokkos::deep_copy(host_view, ntsub_dev);
+      ntsub = host_view[0];
+    }
+    output.set("ntsub", ntsub);
+  });
+}

--- a/src/validation/convproc/compute_massflux.cpp
+++ b/src/validation/convproc/compute_massflux.cpp
@@ -1,0 +1,98 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <ekat/ekat_assert.hpp>
+#include <iomanip>
+#include <iostream>
+
+#include <mam4xx/convproc.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+using namespace skywalker;
+using namespace mam4;
+
+namespace {
+void get_input(const Input &input, const std::string &name, const int size,
+               std::vector<Real> &host, ColumnView &dev) {
+  host = input.get_array(name);
+  EKAT_ASSERT(host.size() == size);
+  dev = mam4::validation::create_column_view(size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  for (int n = 0; n < size; ++n)
+    host_view[n] = host[n];
+  Kokkos::deep_copy(dev, host_view);
+}
+void set_output(Output &output, const std::string &name, const int size,
+                std::vector<Real> &host, const ColumnView &dev) {
+  host.resize(size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  Kokkos::deep_copy(host_view, dev);
+  for (int n = 0; n < size; ++n)
+    host[n] = host_view[n];
+  output.set(name, host);
+}
+} // namespace
+void compute_massflux(Ensemble *ensemble) {
+  // We don't need any settings for this particular test.
+  // Settings settings = ensemble->settings();
+  // Run the ensemble.
+  ensemble->process([=](const Input &input, Output &output) {
+    const int nlev = 72;
+    // Fetch ensemble parameters
+    // Convert to C++ index by subtracting one.
+    const int ktop = input.get("ktop") - 1;
+    EKAT_ASSERT(ktop == 47);
+    const int kbot = input.get("kbot");
+    EKAT_ASSERT(kbot == 71);
+    Real xx_mfup_max = input.get("xx_mfup_max");
+    EKAT_ASSERT(xx_mfup_max == 0);
+
+    std::vector<Real> dpdry_i_host, du_host, eu_host, ed_host, mu_i_host,
+        md_i_host;
+    ColumnView dpdry_i_dev, du_dev, eu_dev, ed_dev, mu_i_dev, md_i_dev,
+        xx_mfup_max_dev;
+    get_input(input, "dpdry_i", nlev, dpdry_i_host, dpdry_i_dev);
+    get_input(input, "du", nlev, du_host, du_dev);
+    get_input(input, "eu", nlev, eu_host, eu_dev);
+    get_input(input, "ed", nlev, ed_host, ed_dev);
+    mu_i_dev = mam4::validation::create_column_view(nlev + 1);
+    md_i_dev = mam4::validation::create_column_view(nlev + 1);
+    xx_mfup_max_dev = mam4::validation::create_column_view(1);
+    Kokkos::parallel_for(
+        "compute_massflux", 1, KOKKOS_LAMBDA(int) {
+          Real dpdry_i[nlev];
+          for (int i = 0; i < nlev; ++i)
+            dpdry_i[i] = dpdry_i_dev[i];
+          Real du[nlev];
+          for (int i = 0; i < nlev; ++i)
+            du[i] = du_dev[i];
+          Real eu[nlev];
+          for (int i = 0; i < nlev; ++i)
+            eu[i] = eu_dev[i];
+          Real ed[nlev];
+          for (int i = 0; i < nlev; ++i)
+            ed[i] = ed_dev[i];
+          Real mu_i[nlev + 1];
+          Real md_i[nlev + 1];
+          Real mfup_max = xx_mfup_max;
+          convproc::compute_massflux(nlev, ktop, kbot, dpdry_i, du, eu, ed,
+                                     mu_i, md_i, mfup_max);
+          for (int i = 0; i < nlev + 1; ++i)
+            mu_i_dev[i] = mu_i[i];
+          for (int i = 0; i < nlev + 1; ++i)
+            md_i_dev[i] = md_i[i];
+          xx_mfup_max_dev[0] = mfup_max;
+        });
+    // Check case of iflux_method == 2 which is not part of the e3sm tests.
+    set_output(output, "mu_i", nlev + 1, mu_i_host, mu_i_dev);
+    set_output(output, "md_i", nlev + 1, md_i_host, md_i_dev);
+    {
+      auto host_view = Kokkos::create_mirror_view(xx_mfup_max_dev);
+      Kokkos::deep_copy(host_view, xx_mfup_max_dev);
+      xx_mfup_max = host_view[0];
+    }
+    output.set("xx_mfup_max", xx_mfup_max);
+  });
+}

--- a/src/validation/convproc/compute_midlev_height.cpp
+++ b/src/validation/convproc/compute_midlev_height.cpp
@@ -1,0 +1,65 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <ekat/ekat_assert.hpp>
+#include <iomanip>
+#include <iostream>
+
+#include <mam4xx/convproc.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+using namespace skywalker;
+using namespace mam4;
+
+namespace {
+void get_input(const Input &input, const std::string &name, const int size,
+               std::vector<Real> &host, ColumnView &dev) {
+  host = input.get_array(name);
+  EKAT_ASSERT(host.size() == size);
+  dev = mam4::validation::create_column_view(size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  for (int n = 0; n < size; ++n)
+    host_view[n] = host[n];
+  Kokkos::deep_copy(dev, host_view);
+}
+void set_output(Output &output, const std::string &name, const int size,
+                std::vector<Real> &host, const ColumnView &dev) {
+  host.resize(size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  Kokkos::deep_copy(host_view, dev);
+  for (int n = 0; n < size; ++n)
+    host[n] = host_view[n];
+  output.set(name, host);
+}
+} // namespace
+void compute_midlev_height(Ensemble *ensemble) {
+  // We don't need any settings for this particular test.
+  // Settings settings = ensemble->settings();
+  // Run the ensemble.
+  ensemble->process([=](const Input &input, Output &output) {
+    const int nlev = 72;
+
+    std::vector<Real> dpdry_i_host, rhoair_i_host, zmagl_host;
+    ColumnView dpdry_i_dev, rhoair_i_dev, zmagl_dev;
+    get_input(input, "dpdry_i", nlev, dpdry_i_host, dpdry_i_dev);
+    get_input(input, "rhoair_i", nlev, rhoair_i_host, rhoair_i_dev);
+    zmagl_dev = mam4::validation::create_column_view(nlev);
+    Kokkos::parallel_for(
+        "compute_midlev_height", 1, KOKKOS_LAMBDA(int) {
+          Real dpdry_i[nlev];
+          for (int i = 0; i < nlev; ++i)
+            dpdry_i[i] = dpdry_i_dev[i];
+          Real rhoair_i[nlev];
+          for (int i = 0; i < nlev; ++i)
+            rhoair_i[i] = rhoair_i_dev[i];
+          Real zmagl[nlev];
+          convproc::compute_midlev_height(nlev, dpdry_i, rhoair_i, zmagl);
+          for (int i = 0; i < nlev; ++i)
+            zmagl_dev[i] = zmagl[i];
+        });
+    // Check case of iflux_method == 2 which is not part of the e3sm tests.
+    set_output(output, "zmagl", nlev, zmagl_host, zmagl_dev);
+  });
+}

--- a/src/validation/convproc/compute_wetdep_tend.cpp
+++ b/src/validation/convproc/compute_wetdep_tend.cpp
@@ -1,0 +1,148 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <mam4xx/convproc.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+using namespace skywalker;
+using namespace mam4;
+
+namespace {
+void get_input(const Input &input, const std::string &name, const int size,
+               std::vector<Real> &host, ColumnView &dev) {
+  host = input.get_array(name);
+  dev = mam4::validation::create_column_view(size);
+
+  EKAT_ASSERT(host.size() == size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  for (int n = 0; n < size; ++n)
+    host_view[n] = host[n];
+  Kokkos::deep_copy(dev, host_view);
+}
+void get_input(const Input &input, const std::string &name, const int rows,
+               const int cols, const bool col_major, std::vector<Real> &host,
+               Kokkos::View<Real **, Kokkos::MemoryUnmanaged> &dev) {
+  host = input.get_array(name);
+  ColumnView col_view = mam4::validation::create_column_view(rows * cols);
+  dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(col_view.data(), rows,
+                                                       cols);
+  EKAT_ASSERT(host.size() == rows * cols);
+  {
+    std::vector<std::vector<Real>> matrix(rows, std::vector<Real>(cols));
+    if (col_major)
+      for (int j = 0, n = 0; j < cols; ++j)
+        for (int i = 0; i < rows; ++i, ++n)
+          matrix[i][j] = host[n];
+    else
+      for (int i = 0, n = 0; i < rows; ++i)
+        for (int j = 0; j < cols; ++j, ++n)
+          matrix[i][j] = host[n];
+    auto host_view = Kokkos::create_mirror_view(dev);
+    for (int i = 0; i < rows; ++i)
+      for (int j = 0; j < cols; ++j)
+        host_view(i, j) = matrix[i][j];
+    Kokkos::deep_copy(dev, host_view);
+  }
+}
+
+void set_output(Output &output, const std::string &name, const int rows,
+                const int cols, const bool col_major, std::vector<Real> &host,
+                const Kokkos::View<Real **, Kokkos::MemoryUnmanaged> &dev) {
+  auto host_view = Kokkos::create_mirror_view(dev);
+  Kokkos::deep_copy(host_view, dev);
+  if (col_major)
+    for (int j = 0, n = 0; j < cols; ++j)
+      for (int i = 0; i < rows; ++i, ++n)
+        host[n] = host_view(i, j);
+  else
+    for (int i = 0, n = 0; i < rows; ++i)
+      for (int j = 0; j < cols; ++j, ++n)
+        host[n] = host_view(i, j);
+  output.set(name, host);
+}
+} // namespace
+void compute_wetdep_tend(Ensemble *ensemble) {
+
+  // We don't need any settings for this particular test.
+  // Settings settings = ensemble->settings();
+
+  // Run the ensemble.
+  ensemble->process([=](const Input &input, Output &output) {
+    const int pcnst_extd = ConvProc::pcnst_extd;
+    const int nlev = 72;
+    // Fetch ensemble parameters
+
+    // delta t (model time increment) [s]
+    const Real dt = input.get("dt");
+    EKAT_ASSERT(dt == 3600);
+    // Convert to C++ offset
+    const Real kk = input.get("kk") - 1;
+    EKAT_ASSERT(kk == 53);
+
+    // flag for doing convective transport
+    std::vector<Real> doconvproc_extd_host, dt_u_host, dp_i_host,
+        cldfrac_i_host, mu_p_eudp_host, aqfrac_host, icwmr_host, rprd_host,
+        conu_host, dconudt_wetdep_host;
+    ColumnView doconvproc_extd_dev, dt_u_dev, dp_i_dev, cldfrac_i_dev,
+        mu_p_eudp_dev, aqfrac_dev, icwmr_dev, rprd_dev;
+    Kokkos::View<Real **, Kokkos::MemoryUnmanaged> conu_dev, dconudt_wetdep_dev;
+
+    get_input(input, "doconvproc_extd", pcnst_extd, doconvproc_extd_host,
+              doconvproc_extd_dev);
+    get_input(input, "dt_u", nlev, dt_u_host, dt_u_dev);
+    get_input(input, "dp_i", nlev, dp_i_host, dp_i_dev);
+    get_input(input, "cldfrac_i", nlev, cldfrac_i_host, cldfrac_i_dev);
+    get_input(input, "mu_p_eudp", nlev, mu_p_eudp_host, mu_p_eudp_dev);
+    get_input(input, "aqfrac", pcnst_extd, aqfrac_host, aqfrac_dev);
+    get_input(input, "icwmr", nlev, icwmr_host, icwmr_dev);
+    get_input(input, "rprd", nlev, rprd_host, rprd_dev);
+    get_input(input, "conu", nlev + 1, pcnst_extd, false, conu_host, conu_dev);
+    get_input(input, "dconudt_wetdep", nlev + 1, pcnst_extd, false,
+              dconudt_wetdep_host, dconudt_wetdep_dev);
+
+    Kokkos::parallel_for(
+        "compute_wetdep_tend", 1, KOKKOS_LAMBDA(int) {
+          Real dt_u[nlev], dp_i[nlev], cldfrac_i[nlev], mu_p_eudp[nlev],
+              icwmr[nlev], rprd[nlev];
+          for (int n = 0; n < nlev; ++n) {
+            dt_u[n] = dt_u_dev[n];
+            dp_i[n] = dp_i_dev[n];
+            cldfrac_i[n] = cldfrac_i_dev[n];
+            mu_p_eudp[n] = mu_p_eudp_dev[n];
+            icwmr[n] = icwmr_dev[n];
+            rprd[n] = rprd_dev[n];
+          }
+          Real conu[nlev + 1][pcnst_extd], dconudt_wetdep[nlev + 1][pcnst_extd];
+          for (int i = 0; i < nlev + 1; ++i) {
+            for (int j = 0; j < pcnst_extd; ++j) {
+              conu[i][j] = conu_dev(i, j);
+              dconudt_wetdep[i][j] = dconudt_wetdep_dev(i, j);
+            }
+          }
+          bool doconvproc_extd[pcnst_extd];
+          Real aqfrac[pcnst_extd];
+          for (int n = 0; n < pcnst_extd; ++n) {
+            aqfrac[n] = aqfrac_dev[n];
+            doconvproc_extd[n] = doconvproc_extd_dev[n];
+          }
+
+          convproc::compute_wetdep_tend(doconvproc_extd, kk, dt, dt_u, dp_i,
+                                        cldfrac_i, mu_p_eudp, aqfrac, icwmr,
+                                        rprd, conu, dconudt_wetdep);
+          for (int i = 0; i < nlev + 1; ++i) {
+            for (int j = 0; j < pcnst_extd; ++j) {
+              conu_dev(i, j) = conu[i][j];
+              dconudt_wetdep_dev(i, j) = dconudt_wetdep[i][j];
+            }
+          }
+        });
+
+    set_output(output, "conu", nlev + 1, pcnst_extd, false, conu_host,
+               conu_dev);
+    set_output(output, "dconudt_wetdep", nlev + 1, pcnst_extd, false,
+               dconudt_wetdep_host, dconudt_wetdep_dev);
+  });
+}

--- a/src/validation/convproc/compute_wup.cpp
+++ b/src/validation/convproc/compute_wup.cpp
@@ -1,0 +1,177 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <ekat/ekat_assert.hpp>
+#include <iomanip>
+#include <iostream>
+
+#include <mam4xx/convproc.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+using namespace skywalker;
+using namespace mam4;
+
+namespace {
+void get_input(const Input &input, const std::string &name, const int size,
+               std::vector<Real> &host, ColumnView &dev) {
+  host = input.get_array(name);
+  EKAT_ASSERT(host.size() == size);
+  dev = mam4::validation::create_column_view(size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  for (int n = 0; n < size; ++n)
+    host_view[n] = host[n];
+  Kokkos::deep_copy(dev, host_view);
+}
+void set_output(Output &output, const std::string &name, const int size,
+                std::vector<Real> &host, const ColumnView &dev) {
+  host.resize(size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  Kokkos::deep_copy(host_view, dev);
+  for (int n = 0; n < size; ++n)
+    host[n] = host_view[n];
+  output.set(name, host);
+}
+} // namespace
+void compute_wup(Ensemble *ensemble) {
+  // We don't need any settings for this particular test.
+  // Settings settings = ensemble->settings();
+  // Run the ensemble.
+  ensemble->process([=](const Input &input, Output &output) {
+    const int nlev = 72;
+    // Fetch ensemble parameters
+    // Convert to C++ index by subtracting one.
+    const int kk = input.get("kk") - 1;
+    EKAT_ASSERT(kk == 53);
+    const Real iconvtype = input.get("iconvtype");
+    EKAT_ASSERT(iconvtype == 1);
+
+    std::vector<Real> mu_i_host, cldfrac_i_host, rhoair_i_host, zmagl_host,
+        wup_host, wup_2_host;
+    ColumnView mu_i_dev, cldfrac_i_dev, rhoair_i_dev, zmagl_dev, wup_dev,
+        wup_2_dev;
+    get_input(input, "mu_i", nlev + 1, mu_i_host, mu_i_dev);
+    get_input(input, "cldfrac_i", nlev, cldfrac_i_host, cldfrac_i_dev);
+    get_input(input, "rhoair_i", nlev, rhoair_i_host, rhoair_i_dev);
+    get_input(input, "zmagl", nlev, zmagl_host, zmagl_dev);
+    get_input(input, "wup", nlev, wup_host, wup_dev);
+    wup_2_dev = mam4::validation::create_column_view(nlev);
+    Kokkos::parallel_for(
+        "compute_wup", 1, KOKKOS_LAMBDA(int) {
+          Real mu_i[nlev + 1];
+          for (int i = 0; i < nlev + 1; ++i)
+            mu_i[i] = mu_i_dev[i];
+          Real cldfrac_i[nlev];
+          for (int i = 0; i < nlev; ++i)
+            cldfrac_i[i] = cldfrac_i_dev[i];
+          Real rhoair_i[nlev];
+          for (int i = 0; i < nlev; ++i)
+            rhoair_i[i] = rhoair_i_dev[i];
+          Real zmagl[nlev];
+          for (int i = 0; i < nlev; ++i)
+            zmagl[i] = zmagl_dev[i];
+          Real wup[nlev];
+          for (int i = 0; i < nlev; ++i)
+            wup[i] = wup_dev[i];
+          Real wup_2[nlev];
+          for (int i = 0; i < nlev; ++i)
+            wup_2[i] = wup_dev[i];
+
+          convproc::compute_wup(iconvtype, kk, mu_i, cldfrac_i, rhoair_i, zmagl,
+                                wup);
+          const int iconvtype_2 = 2;
+          convproc::compute_wup(iconvtype_2, kk, mu_i, cldfrac_i, rhoair_i,
+                                zmagl, wup_2);
+          for (int i = 0; i < nlev; ++i)
+            wup_dev[i] = wup[i];
+          for (int i = 0; i < nlev; ++i)
+            wup_2_dev[i] = wup_2[i];
+        });
+    // This special test checks an if statement in compute_wup that
+    // sets hygro to 0.2 in case of very small volume. It is tripped twice:
+    wup_2_host.resize(nlev);
+    {
+      auto host_view = Kokkos::create_mirror_view(wup_2_dev);
+      Kokkos::deep_copy(host_view, wup_2_dev);
+      for (int n = 0; n < nlev; ++n)
+        wup_2_host[n] = host_view[n];
+    }
+    const Real wup_2_chk[nlev] = {0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0,
+                                  0.981255604817,
+                                  3.42602978,
+                                  3.341147389,
+                                  3.266199917,
+                                  3.198549306,
+                                  3.131584108,
+                                  3.061526817,
+                                  2.985477952,
+                                  2.803891447,
+                                  2.618128155,
+                                  2.427279426,
+                                  2.23011197,
+                                  2.02485641,
+                                  1.80882474,
+                                  1.577618489,
+                                  1.323448376,
+                                  1.029998341,
+                                  0.6919802548,
+                                  0};
+    for (int i = 0; i < nlev; ++i)
+      EKAT_ASSERT(std::abs(wup_2_host[i] - wup_2_chk[i]) < .000001);
+
+    set_output(output, "wup", nlev, wup_host, wup_dev);
+  });
+}

--- a/src/validation/convproc/convproc_driver.cpp
+++ b/src/validation/convproc/convproc_driver.cpp
@@ -34,6 +34,7 @@ void ma_precpevap_convproc(Ensemble *ensemble);
 void initialize_dcondt(Ensemble *ensemble);
 void compute_downdraft_mixing_ratio(Ensemble *ensemble);
 void aer_vol_num_hygro(Ensemble *ensemble);
+void compute_wup(Ensemble *ensemble);
 
 int main(int argc, char **argv) {
   if (argc == 1) {
@@ -73,6 +74,8 @@ int main(int argc, char **argv) {
       compute_downdraft_mixing_ratio(ensemble);
     } else if (func_name == "aer_vol_num_hygro") {
       aer_vol_num_hygro(ensemble);
+    } else if (func_name == "compute_wup") {
+      compute_wup(ensemble);
     } else {
       std::cerr << "Error: Test name not recognized:" << func_name << std::endl;
       exit(1);

--- a/src/validation/convproc/convproc_driver.cpp
+++ b/src/validation/convproc/convproc_driver.cpp
@@ -40,6 +40,7 @@ void compute_ent_det_dp(Ensemble *ensemble);
 void compute_midlev_height(Ensemble *ensemble);
 void initialize_tmr_array(Ensemble *ensemble);
 void update_qnew_ptend(Ensemble *ensemble);
+void compute_wetdep_tend(Ensemble *ensemble);
 
 int main(int argc, char **argv) {
   if (argc == 1) {
@@ -91,6 +92,8 @@ int main(int argc, char **argv) {
       initialize_tmr_array(ensemble);
     } else if (func_name == "update_qnew_ptend") {
       update_qnew_ptend(ensemble);
+    } else if (func_name == "compute_wetdep_tend") {
+      compute_wetdep_tend(ensemble);
     } else {
       std::cerr << "Error: Test name not recognized:" << func_name << std::endl;
       exit(1);

--- a/src/validation/convproc/convproc_driver.cpp
+++ b/src/validation/convproc/convproc_driver.cpp
@@ -35,6 +35,10 @@ void initialize_dcondt(Ensemble *ensemble);
 void compute_downdraft_mixing_ratio(Ensemble *ensemble);
 void aer_vol_num_hygro(Ensemble *ensemble);
 void compute_wup(Ensemble *ensemble);
+void compute_massflux(Ensemble *ensemble);
+void compute_ent_det_dp(Ensemble *ensemble);
+void compute_midlev_height(Ensemble *ensemble);
+void initialize_tmr_array(Ensemble *ensemble);
 
 int main(int argc, char **argv) {
   if (argc == 1) {
@@ -76,6 +80,14 @@ int main(int argc, char **argv) {
       aer_vol_num_hygro(ensemble);
     } else if (func_name == "compute_wup") {
       compute_wup(ensemble);
+    } else if (func_name == "compute_massflux") {
+      compute_massflux(ensemble);
+    } else if (func_name == "compute_ent_det_dp") {
+      compute_ent_det_dp(ensemble);
+    } else if (func_name == "compute_midlev_height") {
+      compute_midlev_height(ensemble);
+    } else if (func_name == "initialize_tmr_array") {
+      initialize_tmr_array(ensemble);
     } else {
       std::cerr << "Error: Test name not recognized:" << func_name << std::endl;
       exit(1);

--- a/src/validation/convproc/convproc_driver.cpp
+++ b/src/validation/convproc/convproc_driver.cpp
@@ -39,6 +39,7 @@ void compute_massflux(Ensemble *ensemble);
 void compute_ent_det_dp(Ensemble *ensemble);
 void compute_midlev_height(Ensemble *ensemble);
 void initialize_tmr_array(Ensemble *ensemble);
+void update_qnew_ptend(Ensemble *ensemble);
 
 int main(int argc, char **argv) {
   if (argc == 1) {
@@ -88,6 +89,8 @@ int main(int argc, char **argv) {
       compute_midlev_height(ensemble);
     } else if (func_name == "initialize_tmr_array") {
       initialize_tmr_array(ensemble);
+    } else if (func_name == "update_qnew_ptend") {
+      update_qnew_ptend(ensemble);
     } else {
       std::cerr << "Error: Test name not recognized:" << func_name << std::endl;
       exit(1);

--- a/src/validation/convproc/initialize_tmr_array.cpp
+++ b/src/validation/convproc/initialize_tmr_array.cpp
@@ -1,0 +1,133 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <ekat/ekat_assert.hpp>
+#include <iomanip>
+#include <iostream>
+
+#include <mam4xx/convproc.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+using namespace skywalker;
+using namespace mam4;
+
+namespace {
+void get_input(const Input &input, const std::string &name, const int size,
+               std::vector<Real> &host, ColumnView &dev) {
+  host = input.get_array(name);
+  EKAT_ASSERT(host.size() == size);
+  dev = mam4::validation::create_column_view(size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  for (int n = 0; n < size; ++n)
+    host_view[n] = host[n];
+  Kokkos::deep_copy(dev, host_view);
+}
+void get_input(const Input &input, const std::string &name, const int rows,
+               const int cols, std::vector<Real> &host,
+               Kokkos::View<Real **, Kokkos::MemoryUnmanaged> &dev) {
+  host = input.get_array(name);
+  EKAT_ASSERT(host.size() == rows * cols);
+  ColumnView col_view = mam4::validation::create_column_view(rows * cols);
+  dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(col_view.data(), rows,
+                                                       cols);
+  {
+    std::vector<std::vector<Real>> matrix(rows, std::vector<Real>(cols));
+    for (int j = 0, n = 0; j < cols; ++j)
+      for (int i = 0; i < rows; ++i, ++n)
+        matrix[i][j] = host[n];
+    auto host_view = Kokkos::create_mirror_view(dev);
+    for (int i = 0; i < rows; ++i)
+      for (int j = 0; j < cols; ++j)
+        host_view(i, j) = matrix[i][j];
+    Kokkos::deep_copy(dev, host_view);
+  }
+}
+void set_output(Output &output, const std::string &name, const int rows,
+                const int cols, std::vector<Real> &host,
+                const Kokkos::View<Real **, Kokkos::MemoryUnmanaged> &dev) {
+  host.resize(rows * cols);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  Kokkos::deep_copy(host_view, dev);
+  for (int i = 0, n = 0; i < rows; ++i)
+    for (int j = 0; j < cols; ++j, ++n)
+      host[n] = host_view(i, j);
+  output.set(name, host);
+}
+} // namespace
+void initialize_tmr_array(Ensemble *ensemble) {
+  // We don't need any settings for this particular test.
+  // Settings settings = ensemble->settings();
+  // Run the ensemble.
+  ensemble->process([=](const Input &input, Output &output) {
+    const int nlev = 72;
+    // Fetch ensemble parameters
+    // Convert to C++ index by subtracting one.
+    const int pcnst_extd = input.get("pcnst_extd");
+    EKAT_ASSERT(pcnst_extd == 80);
+    const int ncnst = input.get("ncnst");
+    EKAT_ASSERT(ncnst == 40);
+    const int iconvtype = input.get("iconvtype");
+    EKAT_ASSERT(iconvtype == 1);
+
+    std::vector<Real> doconvproc_extd_host, q_i_host, gath_host, chat_host,
+        conu_host, cond_host;
+    ;
+    ColumnView doconvproc_extd_dev;
+    Kokkos::View<Real **, Kokkos::MemoryUnmanaged> q_i_dev, gath_dev, chat_dev,
+        conu_dev, cond_dev;
+    get_input(input, "doconvproc_extd", pcnst_extd, doconvproc_extd_host,
+              doconvproc_extd_dev);
+    get_input(input, "q_i", nlev, ncnst, q_i_host, q_i_dev);
+
+    auto col_view = mam4::validation::create_column_view(pcnst_extd * nlev);
+    gath_dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(col_view.data(),
+                                                              nlev, pcnst_extd);
+    col_view = mam4::validation::create_column_view(pcnst_extd * (nlev + 1));
+    chat_dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(
+        col_view.data(), nlev + 1, pcnst_extd);
+    col_view = mam4::validation::create_column_view(pcnst_extd * (nlev + 1));
+    conu_dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(
+        col_view.data(), nlev + 1, pcnst_extd);
+    col_view = mam4::validation::create_column_view(pcnst_extd * (nlev + 1));
+    cond_dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(
+        col_view.data(), nlev + 1, pcnst_extd);
+
+    Kokkos::parallel_for(
+        "initialize_tmr_array", 1, KOKKOS_LAMBDA(int) {
+          const int pcnst_extd = ConvProc::pcnst_extd;
+          const int pcnst = ConvProc::gas_pcnst;
+          bool doconvproc_extd[pcnst_extd];
+          for (int i = 0; i < pcnst_extd; ++i)
+            doconvproc_extd[i] = doconvproc_extd_dev[i];
+          Real q_i[nlev][pcnst];
+          for (int i = 0; i < nlev; ++i)
+            for (int j = 0; j < pcnst; ++j)
+              q_i[i][j] = q_i_dev(i, j);
+          Real gath[nlev][pcnst_extd];
+          Real chat[nlev + 1][pcnst_extd];
+          Real conu[nlev + 1][pcnst_extd];
+          Real cond[nlev + 1][pcnst_extd];
+          convproc::initialize_tmr_array(nlev, iconvtype, doconvproc_extd, q_i,
+                                         gath, chat, conu, cond);
+          for (int i = 0; i < nlev; ++i)
+            for (int j = 0; j < pcnst_extd; ++j)
+              gath_dev(i, j) = gath[i][j];
+          for (int i = 0; i < nlev + 1; ++i)
+            for (int j = 0; j < pcnst_extd; ++j)
+              chat_dev(i, j) = chat[i][j];
+          for (int i = 0; i < nlev + 1; ++i)
+            for (int j = 0; j < pcnst_extd; ++j)
+              conu_dev(i, j) = conu[i][j];
+          for (int i = 0; i < nlev + 1; ++i)
+            for (int j = 0; j < pcnst_extd; ++j)
+              cond_dev(i, j) = cond[i][j];
+        });
+    // Check case of iflux_method == 2 which is not part of the e3sm tests.
+    set_output(output, "const", nlev, pcnst_extd, gath_host, gath_dev);
+    set_output(output, "chat", nlev + 1, pcnst_extd, chat_host, chat_dev);
+    set_output(output, "conu", nlev + 1, pcnst_extd, conu_host, conu_dev);
+    set_output(output, "cond", nlev + 1, pcnst_extd, cond_host, cond_dev);
+  });
+}

--- a/src/validation/convproc/initialize_tmr_array.cpp
+++ b/src/validation/convproc/initialize_tmr_array.cpp
@@ -69,7 +69,6 @@ void initialize_tmr_array(Ensemble *ensemble) {
     const int ncnst = input.get("ncnst");
     EKAT_ASSERT(ncnst == 40);
     const int iconvtype = input.get("iconvtype");
-    EKAT_ASSERT(iconvtype == 1);
 
     std::vector<Real> doconvproc_extd_host, q_i_host, gath_host, chat_host,
         conu_host, cond_host;

--- a/src/validation/convproc/update_qnew_ptend.cpp
+++ b/src/validation/convproc/update_qnew_ptend.cpp
@@ -1,0 +1,141 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <mam4xx/convproc.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+using namespace skywalker;
+using namespace mam4;
+
+namespace {
+void get_input(const Input &input, const std::string &name, const int size,
+               std::vector<Real> &host, ColumnView &dev) {
+  host = input.get_array(name);
+  dev = mam4::validation::create_column_view(size);
+
+  EKAT_ASSERT(host.size() == size);
+  auto host_view = Kokkos::create_mirror_view(dev);
+  for (int n = 0; n < size; ++n)
+    host_view[n] = host[n];
+  Kokkos::deep_copy(dev, host_view);
+}
+
+void set_output(Output &output, const std::string &name, const int size,
+                std::vector<Real> &host, const ColumnView &dev) {
+  auto host_view = Kokkos::create_mirror_view(dev);
+  Kokkos::deep_copy(host_view, dev);
+  for (int n = 0; n < size; ++n)
+    host[n] = host_view[n];
+  output.set(name, host);
+}
+
+void get_input(const Input &input, const std::string &name, const int rows,
+               const int cols, const bool col_major, std::vector<Real> &host,
+               Kokkos::View<Real **, Kokkos::MemoryUnmanaged> &dev) {
+  host = input.get_array(name);
+  ColumnView col_view = mam4::validation::create_column_view(rows * cols);
+  dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(col_view.data(), rows,
+                                                       cols);
+  std::cout << __FILE__ << ":" << __LINE__ << " " << name << " " << host.size()
+            << " " << rows << " " << cols << std::endl;
+  EKAT_ASSERT(host.size() == rows * cols);
+  {
+    std::vector<std::vector<Real>> matrix(rows, std::vector<Real>(cols));
+    if (col_major)
+      for (int j = 0, n = 0; j < cols; ++j)
+        for (int i = 0; i < rows; ++i, ++n)
+          matrix[i][j] = host[n];
+    else
+      for (int i = 0, n = 0; i < rows; ++i)
+        for (int j = 0; j < cols; ++j, ++n)
+          matrix[i][j] = host[n];
+    auto host_view = Kokkos::create_mirror_view(dev);
+    for (int i = 0; i < rows; ++i)
+      for (int j = 0; j < cols; ++j)
+        host_view(i, j) = matrix[i][j];
+    Kokkos::deep_copy(dev, host_view);
+  }
+}
+
+void set_output(Output &output, const std::string &name, const int rows,
+                const int cols, const bool col_major, std::vector<Real> &host,
+                const Kokkos::View<Real **, Kokkos::MemoryUnmanaged> &dev) {
+  auto host_view = Kokkos::create_mirror_view(dev);
+  Kokkos::deep_copy(host_view, dev);
+  if (col_major)
+    for (int j = 0, n = 0; j < cols; ++j)
+      for (int i = 0; i < rows; ++i, ++n)
+        host[n] = host_view(i, j);
+  else
+    for (int i = 0, n = 0; i < rows; ++i)
+      for (int j = 0; j < cols; ++j, ++n)
+        host[n] = host_view(i, j);
+  output.set(name, host);
+}
+} // namespace
+void update_qnew_ptend(Ensemble *ensemble) {
+
+  // We don't need any settings for this particular test.
+  // Settings settings = ensemble->settings();
+
+  // Run the ensemble.
+  ensemble->process([=](const Input &input, Output &output) {
+    const int gas_pcnst = ConvProc::gas_pcnst;
+    // Fetch ensemble parameters
+
+    // delta t (model time increment) [s]
+    const Real dt = input.get("dt");
+    EKAT_ASSERT(dt == 3600);
+    const bool is_update_ptend = input.get("is_update_ptend");
+    std::cout << __FILE__ << ":" << __LINE__
+              << " is_update_ptend:" << is_update_ptend << std::endl;
+    // index of sub timesteps from the outer loop
+
+    // flag for doing convective transport
+    std::vector<Real> dotend_host, dqdt_host, ptend_lq_host, ptend_q_host,
+        qnew_host;
+    ColumnView dotend_dev, ptend_lq_dev, dqdt_dev, ptend_q_dev, qnew_dev;
+
+    get_input(input, "dotend", gas_pcnst, dotend_host, dotend_dev);
+    get_input(input, "dqdt", gas_pcnst, dqdt_host, dqdt_dev);
+    get_input(input, "ptend_lq", gas_pcnst, ptend_lq_host, ptend_lq_dev);
+    get_input(input, "ptend_q", gas_pcnst, ptend_q_host, ptend_q_dev);
+    get_input(input, "qnew", gas_pcnst, qnew_host, qnew_dev);
+
+    Kokkos::parallel_for(
+        "update_qnew_ptend", 1, KOKKOS_LAMBDA(int) {
+          bool dotend[gas_pcnst];
+          for (int n = 0; n < gas_pcnst; ++n)
+            dotend[n] = dotend_dev[n];
+          bool ptend_lq[gas_pcnst];
+          for (int n = 0; n < gas_pcnst; ++n)
+            ptend_lq[n] = ptend_lq_dev[n];
+
+          Real dqdt[gas_pcnst];
+          for (int j = 0; j < gas_pcnst; ++j)
+            dqdt[j] = dqdt_dev(j);
+          Real ptend_q[gas_pcnst];
+          for (int j = 0; j < gas_pcnst; ++j)
+            ptend_q[j] = ptend_q_dev(j);
+          Real qnew[gas_pcnst];
+          for (int j = 0; j < gas_pcnst; ++j)
+            qnew[j] = qnew_dev(j);
+
+          convproc::update_qnew_ptend(dotend, is_update_ptend, dqdt, dt,
+                                      ptend_lq, ptend_q, qnew);
+          for (int n = 0; n < gas_pcnst; ++n)
+            ptend_lq_dev[n] = ptend_lq[n];
+          for (int j = 0; j < gas_pcnst; ++j)
+            ptend_q_dev(j) = ptend_q[j];
+          for (int j = 0; j < gas_pcnst; ++j)
+            qnew_dev(j) = qnew[j];
+        });
+
+    set_output(output, "ptend_lq", gas_pcnst, ptend_lq_host, ptend_lq_dev);
+    set_output(output, "ptend_q", gas_pcnst, ptend_q_host, ptend_q_dev);
+    set_output(output, "qnew", gas_pcnst, qnew_host, qnew_dev);
+  });
+}


### PR DESCRIPTION
@jeff-cohere ,
I would like to get this branch merged into main so I could continue to add functions without bloating an already large merge request.  I would have already merged but for a problem with a couple of Skywalker validation tests which are commented out in the CMakeLists.txt file. I'm working with Balwinder to figure out why my results differ from the e3sm Skywalker python files and my best guess at this point is that the e3sm Skywalker files need to be regenerated.  

There are quite a few functions added, some of which could be parallel over layers within a column and some not.  I've added comments at the top of the functions for how parallelizable the function is:
* Some functions apply a non-trivial algorithm (non-associative, non-binary operator) to the previous layer to determine the values for the current layer so can not be parallel over the layers.
* Some functions use data from adjacent layers but in a read-only way and only set values on the current layer. These take a layer number, kk, as input but can be called in parallel.
* Some functions only access data in the current layer even though there is an input layer number, kk, as part of the function signature. The function signature could be changed to subscript the data outside of the function.

My plan is to determine how to call these over a Kokkos team object once the higher level functions that call these lower level functions are ported.

One thing to think about is how to call functions in other processes.  There are a few functions in wetdep that are used by convproc.   These should be stand-alone functions with simple signatures that are independent of any Atmosphere, Diagnostic or Prognostic classes. Once wetdep exists should convproc call them directly or should they be factored out into a separate translation unit?  
