### PR TITLE
Setting a non-zero default for the density of sulfate aerosol in nucleation.

### DIFF
--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -605,7 +605,7 @@ public:
 
     // default constructor -- sets default values for parameters
     Config()
-        : dens_so4a_host(0), mw_nh4a_host(mw_nh4a), mw_so4a_host(mw_so4a),
+        : dens_so4a_host(1770.0), mw_nh4a_host(mw_nh4a), mw_so4a_host(mw_so4a),
           newnuc_method_user_choice(2), pbl_nuc_wang2008_user_choice(1),
           adjust_factor_bin_tern_ratenucl(1.0), adjust_factor_pbl_ratenucl(1.0),
           accom_coef_h2so4(1.0), newnuc_adjust_factor_dnaitdt(1.0) {}


### PR DESCRIPTION
This was being set to zero, which I didn't catch till now, because our nucleation validation tests don't include the computed tendencies for sulfate and H2SO4 gas.