### PR TITLE
Sets a fixed 90% code coverage threshold and adds badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # MAM4xx
 
+[![Build Status](https://github.com/eagles-project/mam4xx/workflows/auto_test/badge.svg)](https://github.com/eagles-project/mam4xx/actions)
+[![Code Coverage](https://codecov.io/gh/eagles-project/mam4xx/branch/main/graph/badge.svg?token=OI33WNBS7N)](https://codecov.io/gh/eagles-project/mam4xx)
+
 This repository contains the source code for a performance-portable C++
 implementation of the MAM4 modal aerosol model (with 4 fixed modes).
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# This file configures CodeCov to require 90% code coverage. New PRs can
+# increase or decrease coverage--only the total coverage threshold matters.
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+    patch: off # we can enable this if we figure out a reasonable policy
+


### PR DESCRIPTION
Unfortunately, the color scheme for the coverage status badge is fixed, which seems like something that should be configurable (the experts [haven't gotten to it yet](https://github.com/badges/shields/issues/994)).