### PR TITLE
Adding new argument to Atmosphere constructors in tests.

### DIFF
--- a/src/tests/atmosphere_utils.cpp
+++ b/src/tests/atmosphere_utils.cpp
@@ -73,8 +73,8 @@ Atmosphere init_atm_const_tv_lapse_rate(int num_levels, const Real pblh,
   Kokkos::deep_copy(d_height, h_height);
   Kokkos::deep_copy(d_hdp, h_hdp);
 
-  Atmosphere atm(d_temperature, d_pressure, d_mix, d_liq, d_nliq, d_ice, d_nice,
-                 d_height, d_hdp, d_cf, d_w, pblh);
+  Atmosphere atm(num_levels, d_temperature, d_pressure, d_mix, d_liq, d_nliq,
+                 d_ice, d_nice, d_height, d_hdp, d_cf, d_w, pblh);
 
   return atm;
 }

--- a/src/validation/hetfrz/hetfrz_rates_1box.cpp
+++ b/src/validation/hetfrz/hetfrz_rates_1box.cpp
@@ -663,7 +663,7 @@ void hetfrz_rates_1box(Ensemble *ensemble) {
     auto d_hydrostatic_dp = validation::create_column_view(nlev);
     auto d_cloud_fraction = validation::create_column_view(nlev);
     auto d_updraft_vel_ice_nucleation = validation::create_column_view(nlev);
-    Atmosphere atm(d_temperature, d_pressure, d_vapor_mixing_ratio,
+    Atmosphere atm(nlev, d_temperature, d_pressure, d_vapor_mixing_ratio,
                    d_liquid_mixing_ratio, d_cloud_liquid_number_mixing_ratio,
                    d_ice_mixing_ratio, d_cloud_ice_number_mixing_ratio,
                    d_height, d_hydrostatic_dp, d_cloud_fraction,


### PR DESCRIPTION
This is a companion PR to a Haero PR with the same purpose. NOTE: this PR will fail until the Haero PR goes in.