### PR TITLE
This tiny fix makes sure mam4xx's gas chemistry headers are installed.

### DIFF
--- a/src/mam4xx/CMakeLists.txt
+++ b/src/mam4xx/CMakeLists.txt
@@ -11,6 +11,8 @@ install(FILES
         convproc.hpp
         gasaerexch.hpp
         gasaerexch_soaexch.hpp
+        gas_chem.hpp
+        gas_chem_mechanism.hpp
         kerminen2002.hpp
         kohler.hpp
         mam4.hpp


### PR DESCRIPTION
I am trying to keep our eamxx integration work up to date with the haero and mam4xx repos, and occasionally I discover that we're not installing everything we need for eamxx. :-)