### PR TITLE
fix second-order PBL nucleation rate

### DIFF
--- a/src/mam4xx/wang2008.hpp
+++ b/src/mam4xx/wang2008.hpp
@@ -31,7 +31,7 @@ Real first_order_pbl_nucleation_rate(Real c_h2so4) { return 1e-6 * c_h2so4; }
 /// Shito et al (2006).
 /// @param [in] c_h2so4 The number concentration of H2SO4 gas [cm-3]
 KOKKOS_INLINE_FUNCTION
-Real second_order_pbl_nucleation_rate(Real c_h2so4) { return 1e-12 * c_h2so4; }
+Real second_order_pbl_nucleation_rate(Real c_h2so4) { return 1e-12 * c_h2so4 * c_h2so4; }
 
 } // namespace mam4::wang2008
 


### PR DESCRIPTION
This small PR fixes an issue with the Wang et al 2008 second-order PBL nucleation process.

For it to be second order, the H2SO4 term must be squared. See the reference [implementation in EAM's MAM](https://github.com/E3SM-Project/E3SM/blob/4fb8eddcf457d18d5619dd4a1c4785ed7c45f725/components/eam/src/chemistry/modal_aero/modal_aero_newnuc.F90#L1216C1-L1223C15) as well as the the [cited paper](https://doi.org/10.5194/acp-9-239-2009). 

Fix #210 

This bug was first identified in the review of a PR to EAMxx, xref https://github.com/E3SM-Project/scream/pull/2429.