### PR TITLE
Adds NUM_VERTICAL_LEVELS as a CMake parameter that defines mam4::nlev.

### DIFF
--- a/.github/pnnl-ci/ci.sh
+++ b/.github/pnnl-ci/ci.sh
@@ -55,6 +55,7 @@ git submodule update --init || exit
 
 cmake \
   -DMAM4XX_HAERO_DIR=$HAERO_INSTALL \
+  -DNUM_VERTICAL_LEVELS=72 \
   -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
   -DCMAKE_C_COMPILER=$CC \

--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -80,6 +80,7 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=`pwd`/install \
           -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} \
           -DMAM4XX_HAERO_DIR=`pwd`/haero_install \
+          -DNUM_VERTICAL_LEVELS=72 \
           -DENABLE_COVERAGE=ON \
           -G "Unix Makefiles"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,17 @@ else() #CPU
   message(STATUS "Building for CPU")
 endif()
 
+#----------------------
+# Configurable options
+#----------------------
+
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 option(ENABLE_SKYWALKER "Enable Skywalker cross validation" ON)
+set(NUM_VERTICAL_LEVELS 72 CACHE STRING "the number of vertical levels per column")
+
+if (NUM_VERTICAL_LEVELS LESS 72)
+  message(FATAL_ERROR "NUM_VERTICAL_LEVELS must be at least 72")
+endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
@@ -68,6 +77,7 @@ include_directories(${HAERO_INCLUDE_DIRS})
 include_directories("${PROJECT_BINARY_DIR}")
 include_directories("${MAM4XX_HAERO_DIR}/include")
 include_directories(${PROJECT_SOURCE_DIR}/src)
+include_directories(${PROJECT_BINARY_DIR}/src)
 
 link_directories("${MAM4XX_HAERO_DIR}/lib")
 

--- a/setup
+++ b/setup
@@ -53,6 +53,13 @@ PREFIX=$PWD/$1
 HAERO_DIR=$DIR_HAERO
 
 #-----------------------------------------------------------------------------
+#                       Aerosol parameterization settings
+#-----------------------------------------------------------------------------
+
+# the number of vertical levels in each column
+NUM_VERTICAL_LEVELS=72
+
+#-----------------------------------------------------------------------------
 #                         Build features and parameters
 #-----------------------------------------------------------------------------
 
@@ -90,6 +97,7 @@ cmake \
  -DCMAKE_INSTALL_PREFIX:PATH=\$PREFIX \
  -DCMAKE_BUILD_TYPE=\$BUILD_TYPE \
  -DMAM4XX_HAERO_DIR=\$HAERO_DIR \
+ -DNUM_VERTICAL_LEVELS=\$NUM_VERTICAL_LEVELS \
  -DENABLE_SKYWALKER=ON \
  \$OPTIONS \
  -G "\$GENERATOR" \

--- a/src/mam4xx/CMakeLists.txt
+++ b/src/mam4xx/CMakeLists.txt
@@ -1,9 +1,16 @@
 include(GNUInstallDirs)
 
+# Generate aero_config.hpp, which contains build-time parameters.
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/aero_config.hpp.in
+  ${CMAKE_CURRENT_BINARY_DIR}/aero_config.hpp
+  @ONLY
+)
+
 # Most of mam4xx is implemented in C++ headers, so we must
 # install them for a client.
 install(FILES
-        aero_config.hpp
+        ${CMAKE_CURRENT_BINARY_DIR}/aero_config.hpp
         aero_model.hpp
         aero_modes.hpp
         calcsize.hpp

--- a/src/mam4xx/aero_config.hpp.in
+++ b/src/mam4xx/aero_config.hpp.in
@@ -19,6 +19,10 @@ class Diagnostics; // fwd decl
 // Tendencies are identical in structure to prognostics.
 using Tendencies = Prognostics; // fwd decl
 
+// Number of vertical levels per column (must match the number in the
+// host model)
+constexpr int nlev = @NUM_VERTICAL_LEVELS@;
+
 /// @struct MAM4::AeroConfig: for use with all MAM4 process implementations
 class AeroConfig final {
 public:
@@ -74,6 +78,9 @@ public:
 
   /// Creates a container for prognostic variables on the specified number of
   /// vertical levels. All views must be set manually.
+  /// NOTE: it's currently possible to configure a Prognostics object with a
+  /// NOTE: number of vertical levels different from mam4::nlev above, in order
+  /// NOTE: to support various testing configurations.
   explicit Prognostics(int num_levels) : nlev_(num_levels) {}
 
   Prognostics() = default; // use only for creating containers of Prognostics!
@@ -164,6 +171,9 @@ public:
 
   /// Creates a container for diagnostic variables on the specified number of
   /// vertical levels. All views must be set manually.
+  /// NOTE: it's currently possible to configure a Prognostics object with a
+  /// NOTE: number of vertical levels different from mam4::nlev above, in order
+  /// NOTE: to support various testing configurations.
   explicit Diagnostics(int num_levels) : nlev_(num_levels) {}
 
   Diagnostics() = default; // use only for creating containers of Diagnostics!

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -376,9 +376,9 @@ public:
 
     bool convproc_do_aer = true;
     bool convproc_do_gas = false;
-    int nlev = 72;
-    int ktop = 47;
-    int kbot = 71;
+    int nlev = mam4::nlev;
+    int ktop = 47; // BAD_CONSTANT: only true for nlev == 72
+    int kbot = mam4::nlev - 1;
     // Flags are defined in "enum ConvProc::species_class".
     int species_class[ConvProc::gas_pcnst] = {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2,

--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -2,6 +2,7 @@
 #define MAM4XX_MO_PHOTO_HPP
 
 #include <haero/math.hpp>
+#include <mam4xx/aero_config.hpp>
 #include <mam4xx/mam4_types.hpp>
 #include <mam4xx/utils.hpp>
 

--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -10,7 +10,7 @@ namespace mam4 {
 namespace mo_photo {
 
 // number of vertical levels
-constexpr int pver = 72;
+constexpr int pver = mam4::nlev;
 constexpr int pverm = pver - 1;
 
 using View5D = Kokkos::View<Real *****>;

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -20,7 +20,7 @@ using View1D = DeviceType::view_1d<Real>;
 using View2D = DeviceType::view_2d<Real>;
 
 // number of vertical levels
-constexpr int pver = 72;
+constexpr int pver = mam4::nlev;
 // Top level for troposphere cloud physics
 constexpr int top_lev = 7;
 constexpr int psat = 6; //  number of supersaturations to calc ccn concentration

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1166,7 +1166,7 @@ public:
     Config(const Config &) = default;
     ~Config() = default;
     Config &operator=(const Config &) = default;
-    int nlev = 72;
+    int nlev = mam4::nlev;
 
     // mam_prevap_resusp_optcc values control the prevap_resusp calculations in
     // wetdepa_v2:

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -43,7 +43,7 @@ EkatCreateUnitTest(mam4_rename_unit_tests mam4_rename_unit_tests.cpp
   LIBS mam4xx_tests ${HAERO_LIBRARIES} EXCLUDE_TEST_SESSION)
 EkatCreateUnitTest(mam4_aging_unit_tests mam4_aging_unit_tests.cpp
   LIBS mam4xx_tests ${HAERO_LIBRARIES} EXCLUDE_TEST_SESSION)
-EkatCreateUnitTest(mam4_hetfrz_unit_tests mam4_hetfrz_unit_tests.cpp  
+EkatCreateUnitTest(mam4_hetfrz_unit_tests mam4_hetfrz_unit_tests.cpp
   LIBS mam4xx_tests ${HAERO_LIBRARIES} EXCLUDE_TEST_SESSION)
 EkatCreateUnitTest(mam4_amicphys_1gridcell_tests mam4_amicphys_1gridcell.cpp
   LIBS mam4xx_tests ${HAERO_LIBRARIES} EXCLUDE_TEST_SESSION)


### PR DESCRIPTION
Because of the way we use automatic C++ arrays in some of our parameterizations, it is necessary for us to have the number of vertical levels as a compile-time constant. While this is undesirable in an ideal situation, it's actually fine in the short term because EAMxx also has a compile-time-configured number of vertical levels.

mam4::nlev now contains the number of vertical levels used internally within mam4xx's C++ parameterizations.  I haven't changed any of the test or validation code to set the number of vertical levels to mam4::nlev, since that would imply that we have datasets for other numbers of vertical levels. To make it possible for us to run validations tests in situations where mam4::nlev != 72, I have added the constraint that mam4::nlev >= 72. As long as we are zeroing our views before using them, that should allow these tests to run and pass.

**NOTE: This means that `aero_config.hpp` is now generated from `aero_config.hpp.in`.**

I've also adjusted our CI workflow scripts to explicitly set the number of vertical levels to 72. Strictly speaking, this isn't necessary, because 72 is the default value for this parameter. But I think it helps to have these things made explicit.

Closes #223