### PR TITLE
Add a page to the docs explaining how to get `clang-format` v14 via Homebrew

### DIFF
--- a/docs/clang-format.md
+++ b/docs/clang-format.md
@@ -1,0 +1,32 @@
+# Getting `clang-format` version 14
+
+If you don't have the `mam4xx`-required version 14 of `clang-format` on your system and you're a Mac user, the likely easiest way to obtain it (because `clang-format@14` is not available on its own) is by using [`homebrew`](https://brew.sh) to install [`llvm@14`](https://formulae.brew.sh/formula/llvm@14#default)  and then adding it to your path. e.g.,
+```bash
+$ brew install llvm@14
+$ export PATH="/opt/homebrew/opt/llvm@14/bin/clang-format:$PATH"
+# Note: this is where it is for me on M1 mac--may be different on another system
+# you can confirm where yours is with 'brew info llvm@14'
+$ which clang-format
+/opt/homebrew/opt/llvm@14/bin/clang-format
+```
+For non-mac users, I'd first check to see if `llvm v14` (or `clang-format v14`) is provided by your package manager. If not, you can always manually install and build `llvm v14`, though it's a slightly heavier lift than the above. First steps are:
+```bash
+git clone git@github.com:llvm/llvm-project.git
+git checkout llvmorg-14.0.6 # version tag
+```
+Here is the [github repo](https://github.com/llvm/llvm-project/tree/llvmorg-14.0.6) for `llvm v14`, and it'll build faster/smaller if you use the flag `-DLLVM_ENABLE_PROJECTS="clang"` to only build `clang` and it's friends, rather than all of `llvm`. Other than that, the README offers solid guidance.
+
+### Unnecessary but Convenient Workflow Customization
+
+If you'd like to add a layer of automation/complexity to ensure you only use `clang-format v14` on `mam4xx` and/or want to use a newer version on the rest of your system, I'm a big fan of a terminal tool called [direnv](https://direnv.net/) (`brew install direnv`) that allows you to automatically load and unload environment variables based on `$PWD` using a `.envrc` file. As an example, here's my `.envrc` that adds `clang-format v14` to the path when I'm working on `mam4xx`.
+```
+PATH_add /opt/homebrew/opt/llvm@14/bin/clang-format
+
+# also, since I often forget to load a python environment that's required for
+# running ctest, this creates or loads a python 3 virtual environment with numpy
+layout python3
+pip install --upgrade pip
+# the upgrade isn't strictly necessary but trades a little extra setup on the front end to avoid pip endlessly reminding you to update
+pip install numpy
+```
+This file is placed in the top-level `mam4xx` directory and runs when I `cd mam4xx`, stays loaded in any subdirectories, and clears everything it does when exiting to a directory above or outside of `mam4xx`. Then run `direnv allow` to enable the functionality. For the `conda` people, I've also used this tool to auto-load a pre-configured `conda` environment since the `.envrc` is basically a bash script with a few bells and whistles added. In case anyone's curious, here's a [fancier version](dot_envrc.md) that I use to setup an environment for a jupyter notebook (no promises on robustness of this script 🙂).

--- a/docs/development.md
+++ b/docs/development.md
@@ -248,7 +248,7 @@ you can run from your build directory:
 These targets are only available if you have `clang-format` on your system, and
 they only perform their work if you have the version we support. If you have an
 unsupported version of `clang-format`, the targets will tell you the right
-version to install.
+version to install. [Here](clang-format.md) is a guide to getting the supported version of `clang-format` that is a bit more geared toward Mac users than others.
 
 ### Best practices
 

--- a/docs/dot_envrc.md
+++ b/docs/dot_envrc.md
@@ -1,0 +1,60 @@
+# Example `.envrc` for Jupyter Notebook Virtual Environment
+
+```bash
+echo '=================================='
+echo 'loading .envrc virtual environment'
+echo '=================================='
+
+# this (more or less) creates a python 3 virtual environment
+layout python3
+
+# this and the similar bit below is my hacky way of trying to not re-update pip
+# or reinstall packages
+export pip_flagDir=${PWD}/.direnv/python-3.11.4/pip_flags
+mkdir -p $pip_flagDir
+echo "UPDATE PIP?"
+# if the flag file is there, don't update
+if [ ! -f "${pip_flagDir}/.pip_updated" ]; then
+  echo 'updating pip now'
+  pip install --upgrade pip
+  pip_success=$?
+  if (( pip_success < 1 )); then
+    touch $pip_flagDir/.pip_updated
+  fi
+else
+  echo 'pip previously updated'
+fi
+
+# declare an array of pip packages
+pip_installs=(
+              "ipython"
+              "ipykernel"
+              "numpy"
+              )
+# now loop through the above array and only install if there's no flag file
+for pkg in "${pip_installs[@]}"
+do
+  echo "INSTALL ${pkg}?"
+  if [ ! -f "${pip_flagDir}/.${pkg}_installed" ]; then
+    echo "installing ${pkg} now"
+    pip install $pkg
+    pkg_installed=$?
+    if (( pkg_installed < 1 )); then
+      touch $pip_flagDir/.${pkg}_installed
+    fi
+  else
+    echo "${pkg} previously installed"
+  fi
+done
+
+# enables debug mode
+# export DEBUG=1
+
+# Set the ipython and jupyter notebook config directories to be local
+export IPYTHONDIR=$PWD/.ipython
+export JUPYTER_CONFIG_DIR=$PWD/.jupyter
+
+echo '=================================='
+echo '        environment loaded        '
+echo '=================================='
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ the rest.
 
 For example, to download the relevant software on your Mac using Homebrew, type
 
-```
+```bash
 brew install cmake openmpi
 ```
 
@@ -45,11 +45,11 @@ First, go get the [source code](https://github.com/eagles-project/mam4xx)
 at GitHub:
 
 === "SSH"
-    ```
+    ```bash
     git clone git@github.com:eagles-project/mam4xx.git
     ```
 === "HTTPS"
-    ```
+    ```bash
     git clone https://github.com/eagles-project/mam4xx.git
     ```
 
@@ -66,7 +66,7 @@ To configure MAM4xx:
 
 1. Create a build directory by running the `setup` script from the top-level
    source directory:
-   ```
+   ```bash
    ./setup build
    ```
 2. Change to your build directory and edit the `config.sh` file to select
@@ -100,7 +100,7 @@ you work in order to be productive in this kind of environment.
 When you make a code change, make sure you build from the build directory that
 you created in step 1 above:
 
-```
+```bash
 cd /path/to/mam4xx/build
 make -j
 ```


### PR DESCRIPTION
Added a cleaned up version of the message I previously sent in slack. I retained the bit about `direnv` since it could be useful, but not sure if it belongs here and can ditch it if not. Also added bash syntax specifiers to a few code blocks that I noticed while scrolling around.