### PR TITLE
wet_dep.hpp is now installed.

### DIFF
--- a/src/mam4xx/CMakeLists.txt
+++ b/src/mam4xx/CMakeLists.txt
@@ -38,6 +38,7 @@ install(FILES
         wv_sat_methods.hpp
         drydep.hpp
         water_uptake.hpp
+        wet_dep.hpp
         ndrop.hpp
         mo_photo.hpp
         DESTINATION include/mam4xx)


### PR DESCRIPTION
Found this omission when I updated the mam4xx submodule in EAMxx.