### PR TITLE
Adding more gas IDs to reflect E3SM's MAM4 configuration.

### DIFF
--- a/src/mam4xx/aero_config.hpp.in
+++ b/src/mam4xx/aero_config.hpp.in
@@ -56,12 +56,12 @@ public:
   /// Returns the number of aerosol modes.
   static constexpr int num_modes() { return 4; }
 
-  /// Returns the number of aerosol ids. This is the number of enums in
+  /// Returns the number of aerosol ids. This is the number of valid enums in
   /// mam4::AeroId.
   static constexpr int num_aerosol_ids() { return 7; }
 
-  /// Returns the number of gas ids. This is the number of enums in mam4::GasId.
-  static constexpr int num_gas_ids() { return 3; }
+  /// Returns the number of gas ids. This is the number of valid enums in mam4::GasId.
+  static constexpr int num_gas_ids() { return 6; }
 
   /// Returns the number of aging pairs
   static constexpr int max_agepair() { return 1; }

--- a/src/mam4xx/aero_modes.hpp
+++ b/src/mam4xx/aero_modes.hpp
@@ -68,6 +68,7 @@ enum class ModeIndex {
   Aitken = 1,
   Coarse = 2,
   PrimaryCarbon = 3,
+  None = 4, // invalid index
 };
 
 /// Map ModeIndex to string (for logging, e.g.)
@@ -261,15 +262,15 @@ bool mode_contains_species(ModeIndex mode, AeroId aero_id) {
   return -1 != aerosol_index_for_mode(mode, aero_id);
 }
 
-// Identifiers for gas species in MAM4, specified in the same order as they
-// appear in the set_gas_and_aer_names_and_indices subroutine within the
-// modal_aero_microp_species F90 module (assuming nsoa == 1). It looks like MAM4
-// only tracks SOAG and H2SO4. We keep NH3 around because ternary nucleation
-// requires it, is already ported, and may be required in the future.
+// Identifiers for gas species in MAM4
 enum class GasId {
-  SOAG = 0,  // secondary organic aerosol precursor
-  H2SO4 = 1, // sulfuric acid
-  NH3 = 2,   // ammonia
+  O3 = 0,    // ozone
+  H2O2 = 1,  // hydrogen peroxide
+  H2SO4 = 2, // sulfuric acid
+  SO2 = 3,   // sulfur dioxide
+  DMS = 4,   // dimethyl sulfide
+  SOAG = 5,  // secondary organic aerosol precursor
+  None = 6,  // invalid gas id
 };
 
 /// Molecular weight of carbon dioxide [kg/mol]

--- a/src/mam4xx/gasaerexch_soaexch.hpp
+++ b/src/mam4xx/gasaerexch_soaexch.hpp
@@ -31,8 +31,8 @@ void soa_equilib_mixing_ratio_no_solute(const Real &T_in_K,     // in
                                         Real &g0_soa) {         // out
 
   // clang-format off
-  // T_in_K         temperature in Kelvin 
-  // p_in_Pa        air pressure in Pascal 
+  // T_in_K         temperature in Kelvin
+  // p_in_Pa        air pressure in Pascal
   // pstd_in_Pa     standard air pressure in Pascal
   // r_universal    universal gas constant in J/K/mol
   // g0_soa         ambient soa gas equilib mixing ratio (mol/mol at actual mw)
@@ -80,7 +80,7 @@ Real soa_exch_substepsize(
     Real &t_cur)                                          // inout
 {
   // clang-format off
-  // ntot_soaspec 
+  // ntot_soaspec
   //  "last" gas species that can be SOA, MAM4 had this variable but it was
   //  a work in progress and not suported in mam4xx but it was desired to
   //  keep these variables around to help support variable number of SOA
@@ -89,13 +89,13 @@ Real soa_exch_substepsize(
   // ntot_soamode  "last" mode on which soa is allowed to condense
   //
   // skip_soamode          true if this mode does not have soa
-  // uptkaer_soag_tmpmodes evolving SOA aerosol mixrat (mol/mol at actual mw), 
+  // uptkaer_soag_tmpmodes evolving SOA aerosol mixrat (mol/mol at actual mw),
   //                       part of the unknowns of the ODEs
   // a_soa                 soa aerosol mixrat (mol/mol at actual mw)
   // a_opoa                oxidized-poa aerosol mixrat (mol/mol at actual mw)
-  // g_soa                 evolving SOA gas mixrat (mol/mol at actual mw), 
+  // g_soa                 evolving SOA gas mixrat (mol/mol at actual mw),
   //                       part of the unknowns of the ODEs
-  // g0_soa                ambient soa gas equilib mixrat (mol/mol at actual mw), 
+  // g0_soa                ambient soa gas equilib mixrat (mol/mol at actual mw),
   //                       length based on ntot_soaspec=1
   // alpha_astem           error control parameter for sub-timesteps
   // dt_fulln              host model dt (s)
@@ -226,20 +226,20 @@ void mam_soaexch_advance_in_time(
     int &niter)                               // out
 {
   // clang-format off
-  // int ntot_soamode 
+  // int ntot_soamode
   // int ntot_soaspec  "last" gas species that can be SOA
   // int soaspec[ntot_soaspec]
-  // const AeroId gas_to_aer[GasAerExch::num_gas], 
+  // const AeroId gas_to_aer[GasAerExch::num_gas],
   // dt_full       Host model dt (s)
   // dt_sub_fixed  Fixed sub-step. A negative value means using adaptive step sizes
   // niter_max     Maximum number of substeps
   // alpha_astem   Error control parameter for sub-timesteps
   // uptkaer       Uptake rate coefficient
-  // g0_soa        Ambient soa gas equilib mixrat (mol/mol at / actual mw), 
+  // g0_soa        Ambient soa gas equilib mixrat (mol/mol at / actual mw),
   //               len ntot_soaspec=1 since multiple soa not currently supported
   // qgas_cur
   // a_opoa        Oxidized-poa aerosol mixrat (mol/mol at actual mw)
-  // qaer_cur 
+  // qaer_cur
   // qgas_avg
   // niter         Total number of sub-steps
   // clang-format on
@@ -559,10 +559,10 @@ void mam_soaexch_1subarea(const int mode_pca,          // in
 
   // clang-format off
   // mode_pca         mam4::ModeIndex::PrimaryCarbon
-  // ntot_soamode      
-  // ntot_soaspec      
+  // ntot_soamode
+  // ntot_soaspec
   // soaspec[ntot_soaspec]
-  // const AeroId gas_to_aer[GasAerExch::num_gas], 
+  // const AeroId gas_to_aer[GasAerExch::num_gas],
   // dt               time step size used by parent subroutine
   // dt_sub_soa_fixed fixed sub-step in s. A negative value  means using adaptive step sizes
   // pstd             standard atmosphere in Pa
@@ -572,7 +572,7 @@ void mam_soaexch_1subarea(const int mode_pca,          // in
   // uptkaer          uptake rate
   // qaer_poa         POA mixing ratio (mol/mol at actual mw)
   // qgas_cur         current gas mixing ratio
-  // qgas_avg               
+  // qgas_avg
   // qaer_cur         current aerosol mass mix ratio (mol/mol)
   // niter
   // g0_soa           ambient soa gas equilib mixrat (mol/mol at actual mw)

--- a/src/tests/mam4_amicphys_1gridcell.cpp
+++ b/src/tests/mam4_amicphys_1gridcell.cpp
@@ -31,7 +31,7 @@ static constexpr int iqtend_coag = 3;
 static constexpr int iqtend_cond_only = 4;
 static constexpr int iqqcwtend_rnam = 0;
 static constexpr int maxsubarea = 2;
-const Real fcvt_gas[AeroConfig::num_gas_ids()] = {1, 1, 1};
+const Real fcvt_gas[AeroConfig::num_gas_ids()] = {1, 1, 1, 1, 1, 1};
 const Real fcvt_aer[AeroConfig::num_aerosol_ids()] = {1, 1, 1, 1, 1, 1, 1};
 // leave number mix-ratios unchanged (#/kmol-air)
 const Real fcvt_num = 1.0;
@@ -99,15 +99,18 @@ void mam_amicphys_1subarea_clear(
   static constexpr int iaer_pom = static_cast<int>(AeroId::POM);
   static constexpr int newnuc_h2so4_conc_optaa = 2;
 
-  const AeroId gas_to_aer[num_gas_ids] = {AeroId::SOA, AeroId::SO4,
-                                          AeroId::None};
+  const AeroId gas_to_aer[num_gas_ids] = {AeroId::None, AeroId::None,
+                                          AeroId::SO4,  AeroId::None,
+                                          AeroId::None, AeroId::SOA};
 
   const bool l_gas_condense_to_mode[num_gas_ids][num_modes] = {
-      {true, true, true, true},
-      {true, true, true, true},
-      {false, false, false, false}};
+      {false, false, false, false}, {false, false, false, false},
+      {true, true, true, true}, // H2SO4
+      {false, false, false, false}, {false, false, false, false},
+      {true, true, true, true}}; // SOAG
   enum { NA, ANAL, IMPL };
-  const int eqn_and_numerics_category[num_gas_ids] = {IMPL, ANAL, ANAL};
+  const int eqn_and_numerics_category[num_gas_ids] = {NA, NA, ANAL,
+                                                      NA, NA, IMPL};
 
   // air molar density (kmol/m3)
   // const Real r_universal = Constants::r_gas; // [mJ/(K mol)]
@@ -115,7 +118,7 @@ void mam_amicphys_1subarea_clear(
   const Real aircon = pmid / (1000 * r_universal * temp);
   const Real alnsg_aer[num_modes] = {0.58778666490211906, 0.47000362924573563,
                                      0.58778666490211906, 0.47000362924573563};
-  const Real uptk_rate_factor[num_gas_ids] = {0.81, 1.0, 1.0};
+  const Real uptk_rate_factor[num_gas_ids] = {0, 0, 1.0, 0, 0, 0.81};
   // calculates changes to gas and aerosol sub-area TMRs (tracer mixing ratios)
   // qgas3, qaer3, qnum3 are the current incoming TMRs
   // qgas4, qaer4, qnum4 are the updated outgoing TMRs
@@ -600,14 +603,17 @@ void mam_amicphys_1subarea_cloudy(
   static constexpr int iaer_pom = static_cast<int>(AeroId::POM);
   static constexpr int newnuc_h2so4_conc_optaa = 2;
 
-  const AeroId gas_to_aer[num_gas_ids] = {AeroId::SOA, AeroId::SO4,
-                                          AeroId::None};
+  const AeroId gas_to_aer[num_gas_ids] = {AeroId::None, AeroId::None,
+                                          AeroId::SO4,  AeroId::None,
+                                          AeroId::None, AeroId::SOA};
   const bool l_gas_condense_to_mode[num_gas_ids][num_modes] = {
-      {true, true, true, true},
-      {true, true, true, true},
-      {false, false, false, false}};
+      {false, false, false, false}, {false, false, false, false},
+      {true, true, true, true}, // H2SO4
+      {false, false, false, false}, {false, false, false, false},
+      {true, true, true, true}}; // SOAG
   enum { NA, ANAL, IMPL };
-  const int eqn_and_numerics_category[num_gas_ids] = {IMPL, ANAL, ANAL};
+  const int eqn_and_numerics_category[num_gas_ids] = {NA, NA, ANAL,
+                                                      NA, NA, IMPL};
   // air molar density (kmol/m3)
   // In order to try to match the results in mam_refactor
   // set r_universal as  [mJ/(mol)] as in mam_refactor.
@@ -616,7 +622,7 @@ void mam_amicphys_1subarea_cloudy(
   const Real aircon = pmid / (1000 * r_universal * temp);
   const Real alnsg_aer[num_modes] = {0.58778666490211906, 0.47000362924573563,
                                      0.58778666490211906, 0.47000362924573563};
-  const Real uptk_rate_factor[num_gas_ids] = {0.81, 1.0, 1.0};
+  const Real uptk_rate_factor[num_gas_ids] = {0, 0, 1.0, 0, 0, 0.81};
 
   Real qgas_cur[num_gas_ids];
   for (int i = 0; i < num_gas_ids; ++i)
@@ -1779,11 +1785,13 @@ TEST_CASE("clear", "test_mam4_amicphys") {
       1.2730137346646958e-007, 2.9756030032807321e-008, 2.3266870254473761e-006, 5.2963711345420440e-008};
   Real wetdens[AeroConfig::num_modes()] = {
       1311.3148168539929, 1377.8279737773473, 1310.8221954835647, 1490.5543769930989};
-  const Real qgas1[AeroConfig::num_gas_ids()] = {9.6553333333333350e-011, 1.9196785428799816e-011, 0};
-  const Real qgas3[AeroConfig::num_gas_ids()] = {9.6553333333333350e-011, 1.9196785428799816e-011, 0};
-  Real qgas4[AeroConfig::num_gas_ids()] =       {9.6553333333333350e-011, 1.9196785428799816e-011, 0};
-  Real qgas_delaa[AeroConfig::num_gas_ids()][nqtendaa] = {
-      {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}, {0, 0, 0, 0, 0}};
+  const Real qgas1[AeroConfig::num_gas_ids()] = {0, 0, 1.9196785428799816e-011,
+                                                 0, 0, 9.6553333333333350e-011};
+  const Real qgas3[AeroConfig::num_gas_ids()] = {0, 0, 1.9196785428799816e-011,
+                                                 0, 0, 9.6553333333333350e-011};
+  Real qgas4[AeroConfig::num_gas_ids()] = {0, 0, 1.9196785428799816e-011,
+                                           0, 0, 9.6553333333333350e-011};
+  Real qgas_delaa[AeroConfig::num_gas_ids()][nqtendaa] = {};
   const Real qnum3[AeroConfig::num_modes()] = {
     2253176148.8415728, 22531761488.415726, 2253176.1488415725, 4506352297.6831455};
   Real qnum4[AeroConfig::num_modes()] = {
@@ -1830,11 +1838,13 @@ TEST_CASE("clear", "test_mam4_amicphys") {
       1.2730137346646958e-007, 2.9756030032807321e-008, 2.3266870254473761e-006, 5.2963711345420440e-008};
   const Real check_wetdens[AeroConfig::num_modes()] = {
       1311.3148168539929, 1377.8279737773473, 1310.8221954835647, 1490.5543769930989};
-  const Real check_qgas4[AeroConfig::num_gas_ids()] = {9.6509455923714994e-011, 1.9012167647987512e-011, 0};
+  const Real check_qgas4[AeroConfig::num_gas_ids()] = {0, 0, 1.9012167647987512e-011,
+                                                       0, 0, 9.6509455923714994e-011};
   const Real check_qgas_delaa[AeroConfig::num_gas_ids()][nqtendaa] = {
-      {-4.3877409618355718e-014, 0.0000000000000000,  0.0000000000000000,      0.0000000000000000, -4.3877409618355718e-014 },
+      {}, {},
       {-1.0806949256924317e-014, 0.0000000000000000, -1.7431083155538128e-013, 0.0000000000000000, -1.0806949256924317e-014 },
-      { 0.0000000000000000,      0.0000000000000000,  0.0000000000000000,      0.0000000000000000,  0.0000000000000000,    }};
+      {}, {},
+      {-4.3877409618355718e-014, 0.0000000000000000,  0.0000000000000000,      0.0000000000000000, -4.3877409618355718e-014 }};
   const Real check_qnum4[AeroConfig::num_modes()] = {
       2276787216.2584395l, 31806406005.471962, 2253176.1488415725, 4484126983.6989059};
   const Real check_qnum_delaa[AeroConfig::num_modes()][nqtendaa] = {
@@ -2077,9 +2087,10 @@ TEST_CASE("cloudy", "test_mam4_amicphys") {
   Real qgas4[num_gas_ids] = {};
   // clang-format off
   Real qgas_delaa[num_gas_ids][nqtendaa] = {
-      {-4.3877409618355718e-014, 0.0000000000000000, 0.0000000000000000, 0.0000000000000000, -4.3877409618355718e-014},
+      {}, {},
       {-1.0806949256924317e-014, 0.0000000000000000, -1.7431083155538128e-013, 0.0000000000000000, -1.0806949256924317e-014},
-      {}};
+      {}, {},
+      {-4.3877409618355718e-014, 0.0000000000000000, 0.0000000000000000, 0.0000000000000000, -4.3877409618355718e-014}};
   const Real qnum3[num_modes] = {2253176148.8415728, 22531761488.415726, 2253176.1488415725, 4506352297.6831455};
   Real qnum4[num_modes] = {2253176148.8415728, 22531761488.415726, 2253176.1488415725, 4506352297.6831455};
   Real qnum_delaa[num_modes][nqtendaa] = {
@@ -2161,11 +2172,10 @@ TEST_CASE("cloudy", "test_mam4_amicphys") {
       1.2730137346646958e-007, 2.9756030032807321e-008, 2.3266870254473761e-006, 5.2963711345420440e-008};
   const Real check_wetdens[num_modes] = {
       1311.3148168539929, 1377.8279737773473, 1310.8221954835647, 1490.5543769930989};
-  const Real check_qgas4[num_gas_ids] = {1.1708228956931740e-016, 0.00000000000};
+  const Real check_qgas4[num_gas_ids] = {0.0, 0.0, 0.0, 0.0, 0.0, 1.1708228956931740e-016};
   const Real check_qgas_delaa[num_gas_ids][nqtendaa] = {
-      {1.1708228956931740e-016,  0.0000000000000000, 0.0000000000000000, 0.0000000000000000, 1.1708228956931740e-016},
-      {0.0000000000000000     ,  0.0000000000000000, 0.0000000000000000, 0.0000000000000000, 0.0000000000000000},
-      {}};
+      {}, {}, {}, {}, {},
+      {1.1708228956931740e-016,  0.0000000000000000, 0.0000000000000000, 0.0000000000000000, 1.1708228956931740e-016}};
   const Real check_qnum4[num_modes] = {
       2253176148.8415728, 22531761488.415726, 2253176.1488415725, 4506352297.6831455};
   const Real check_qnum_delaa[num_modes][nqtendaa] = {
@@ -2175,12 +2185,12 @@ TEST_CASE("cloudy", "test_mam4_amicphys") {
       {-7.7571933637159115e-003,  0.0000000000000000, 0.0000000000000000, 0.0000000000000000, 0.0000000000000000}};
 
   const Real check_qaer4[num_aerosol_ids][num_modes] = {
-    {2.6484020766304678e-011,  1.9963154347230245e-012,   1.5918312144742561e-010,   0.0000000000000000      }, 
-    {3.4543891238118804e-011,  2.6039003387624206e-012,   1.3841779609564254e-010,   0.0000000000000000      }, 
-    {8.8280308243457502e-012,  0.0000000000000000     ,   5.3061041769150948e-011,   1.8930709966802244e-012 }, 
-    {1.6293574938721667e-022,  0.0000000000000000     ,   0.0000000000000000     ,   9.4653549834011203e-011 }, 
-    {6.8037089632647984e-011,  6.8381333387002322e-012,   5.4525090614694088e-010,   0.0000000000000000      }, 
-    {0.0000000000000000     ,  0.0000000000000000     ,   0.0000000000000000     ,   0.0000000000000000      }, 
+    {2.6484020766304678e-011,  1.9963154347230245e-012,   1.5918312144742561e-010,   0.0000000000000000      },
+    {3.4543891238118804e-011,  2.6039003387624206e-012,   1.3841779609564254e-010,   0.0000000000000000      },
+    {8.8280308243457502e-012,  0.0000000000000000     ,   5.3061041769150948e-011,   1.8930709966802244e-012 },
+    {1.6293574938721667e-022,  0.0000000000000000     ,   0.0000000000000000     ,   9.4653549834011203e-011 },
+    {6.8037089632647984e-011,  6.8381333387002322e-012,   5.4525090614694088e-010,   0.0000000000000000      },
+    {0.0000000000000000     ,  0.0000000000000000     ,   0.0000000000000000     ,   0.0000000000000000      },
     {0.0000000000000000     ,  0.0000000000000000     ,   0.0000000000000000     ,   0.0000000000000000      }
   };
   const Real check_qaer_delaa[num_aerosol_ids][num_modes][nqtendaa] = {
@@ -2403,7 +2413,7 @@ TEST_CASE("modal_aero_amicphys_intr", "test_mam4_amicphys") {
   const Real qv = 2.6351112225030129e-003;
   const Real cld = 0.4;
   // clang-format off
-  Real q[gas_pcnst] = 
+  Real q[gas_pcnst] =
     {0.0000000000000000, 1.9197285428799817e-011, 4.5213596233813260e-005, 0.0000000000000000, 1.2058113396053620e-009,
      3.4543891238118811e-011, 1.1035038530428116e-010, 3.3105115591284347e-010, 0.0000000000000000, 0.0000000000000000,
      6.8037089632647997e-011, 0.0000000000000000, 2253176148.8415728, 2.6039003387624210e-012, 2.4954461878281674e-011,
@@ -2411,30 +2421,30 @@ TEST_CASE("modal_aero_amicphys_intr", "test_mam4_amicphys") {
      1.3841779609564252e-010, 0.0000000000000000, 6.6326302211438671e-010, 1.9897890663431605e-009, -2.6523783784846809e-029,
      2253176.1488415725, 2.3663387458543536e-011, 9.4653549834174144e-011, 0.0000000000000000, 4506352297.6831455};
   Real qqcw[gas_pcnst] = {};
-  const Real q_pregaschem[gas_pcnst] = 
+  const Real q_pregaschem[gas_pcnst] =
         {0.0000000000000000, 1.9196785428799816e-011, 4.5213596233813260e-005, 0.0000000000000000, 1.2058113396053620e-009,
-         3.4543891238118811e-011, 1.1035038530428116e-010, 3.3105115591284347e-010, 0.0000000000000000, 0.0000000000000000, 
-         6.8037089632647997e-011, 0.0000000000000000, 2253176148.8415728, 2.6039003387624210e-012, 2.4954461878281674e-011, 
-         6.8381333387002338e-012, 0.0000000000000000, 22531761488.415726, 0.0000000000000000, 5.4525090614694077e-010, 
-         1.3841779609564252e-010, 0.0000000000000000, 6.6326302211438671e-010, 1.9897890663431605e-009, -2.6523783784846809e-029, 
+         3.4543891238118811e-011, 1.1035038530428116e-010, 3.3105115591284347e-010, 0.0000000000000000, 0.0000000000000000,
+         6.8037089632647997e-011, 0.0000000000000000, 2253176148.8415728, 2.6039003387624210e-012, 2.4954461878281674e-011,
+         6.8381333387002338e-012, 0.0000000000000000, 22531761488.415726, 0.0000000000000000, 5.4525090614694077e-010,
+         1.3841779609564252e-010, 0.0000000000000000, 6.6326302211438671e-010, 1.9897890663431605e-009, -2.6523783784846809e-029,
          2253176.1488415725, 2.3663387458543536e-011, 9.4653549834174144e-011, 0.0000000000000000, 4506352297.6831455};
-  const Real q_precldchem[gas_pcnst] = 
-       { 0.0000000000000000, 1.9197285428799817e-011, 4.5213596233813260e-005, 0.0000000000000000, 1.2058113396053620e-009, 
-         3.4543891238118811e-011, 1.1035038530428116e-010, 3.3105115591284347e-010, 0.0000000000000000, 0.0000000000000000, 
-         6.8037089632647997e-011, 0.0000000000000000, 2253176148.8415728, 2.6039003387624210e-012, 2.4954461878281674e-011, 
-         6.8381333387002338e-012, 0.0000000000000000, 22531761488.415726, 0.0000000000000000, 5.4525090614694077e-010, 
-         1.3841779609564252e-010, 0.0000000000000000, 6.6326302211438671e-010, 1.9897890663431605e-009, -2.6523783784846809e-029, 
+  const Real q_precldchem[gas_pcnst] =
+       { 0.0000000000000000, 1.9197285428799817e-011, 4.5213596233813260e-005, 0.0000000000000000, 1.2058113396053620e-009,
+         3.4543891238118811e-011, 1.1035038530428116e-010, 3.3105115591284347e-010, 0.0000000000000000, 0.0000000000000000,
+         6.8037089632647997e-011, 0.0000000000000000, 2253176148.8415728, 2.6039003387624210e-012, 2.4954461878281674e-011,
+         6.8381333387002338e-012, 0.0000000000000000, 22531761488.415726, 0.0000000000000000, 5.4525090614694077e-010,
+         1.3841779609564252e-010, 0.0000000000000000, 6.6326302211438671e-010, 1.9897890663431605e-009, -2.6523783784846809e-029,
          2253176.1488415725, 2.3663387458543536e-011, 9.4653549834174144e-011, 0.0000000000000000, 4506352297.6831455};
   const Real qqcw_precldchem[gas_pcnst] = {};
   Real q_tendbb[gas_pcnst][nqtendbb] = {};
   Real qqcw_tendbb[gas_pcnst][nqtendbb] = {};
-  Real dgncur_a[AeroConfig::num_modes()] = 
+  Real dgncur_a[AeroConfig::num_modes()] =
      {1.1944240222260541e-007, 2.5790443175784844e-008, 2.1718927087931639e-006, 5.2939491368692156e-008};
-  Real dgncur_awet[AeroConfig::num_modes()] = 
+  Real dgncur_awet[AeroConfig::num_modes()] =
      {1.2705960055085835e-007, 2.7734941184652717e-008, 2.3266884562632178e-006, 5.2963714752164382e-008};
-  Real wetdens_host[AeroConfig::num_modes()] = 
+  Real wetdens_host[AeroConfig::num_modes()] =
      {1311.2951371145170, 1380.1581535473508, 1310.8217483170163, 1490.5543769911476};
-  Real qaerwat[AeroConfig::num_modes()] = 
+  Real qaerwat[AeroConfig::num_modes()] =
      {6.7869256482212516e-011, 5.7791168928194034e-012, 4.5651595092659412e-010, 4.5048502047402045e-014};
   // clang-format on
   modal_aero_amicphys_intr(mdo_gasaerexch, mdo_rename, mdo_newnuc, mdo_coag,

--- a/src/tests/mam4_amicphys_1gridcell.cpp
+++ b/src/tests/mam4_amicphys_1gridcell.cpp
@@ -2280,14 +2280,14 @@ TEST_CASE("cloudy", "test_mam4_amicphys") {
               Approx(check_qgas_delaa[i][j]).epsilon(epsilon).scale(scale));
     }
   }
-  for (int i = 0; i < num_gas_ids; ++i) {
+  for (int i = 0; i < num_modes; ++i) {
     if (!(qnum4[i] == Approx(check_qnum4[i])))
       std::cout << "qnum4[i] != Approx(check_qnum4[i])): "
                 << std::setprecision(14) << qnum4[i] << " != " << check_qnum4[i]
                 << std::endl;
     REQUIRE(qnum4[i] == Approx(check_qnum4[i]));
   }
-  for (int i = 0; i < num_gas_ids; ++i) {
+  for (int i = 0; i < num_modes; ++i) {
     for (int j = 0; j < nqtendaa; ++j) {
 #ifdef HAERO_DOUBLE_PRECISION
       const double epsilon = 0.001;

--- a/src/tests/mam4_gasaerexch_unit_tests.cpp
+++ b/src/tests/mam4_gasaerexch_unit_tests.cpp
@@ -496,7 +496,7 @@ TEST_CASE("mam_gasaerexch_1subarea", "mam_gasaerexch") {
   const Real pmid = 100000.0;
   const Real aircon = 4.4055781358372036e-02;
   const int ngas = GasAerExch::num_gas_to_aer;
-  const Real qgas_netprod_otrproc[num_gas] = {0.0, 5.00e-16, 0.0};
+  const Real qgas_netprod_otrproc[num_gas] = {0, 0, 5.00e-16, 0, 0, 0};
 
   Real modes_mean_std_dev[num_mode];
   for (int imode = 0; imode < num_mode; ++imode)

--- a/src/tests/mam4_gasaerexch_unit_tests.cpp
+++ b/src/tests/mam4_gasaerexch_unit_tests.cpp
@@ -96,7 +96,7 @@ TEST_CASE("test_multicol_compute_tendencies", "mam4_gasaerexch_process") {
 TEST_CASE("gas_aer_uptkrates_1box1gas", "mam_gasaerexch") {
 
   ekat::Comm comm;
-  ekat::logger::Logger<> logger("nucleation unit tests",
+  ekat::logger::Logger<> logger("gasaerexch unit tests",
                                 ekat::logger::LogLevel::debug, comm);
 
   const int num_mode = mam4::GasAerExch::num_mode;
@@ -243,7 +243,7 @@ TEST_CASE("mam_gasaerexch_1subarea_1gas_nonvolatile", "mam_gasaerexch") {
                              : std::numeric_limits<float>::epsilon() * 100;
 
   ekat::Comm comm;
-  ekat::logger::Logger<> logger("nucleation unit tests",
+  ekat::logger::Logger<> logger("gasaerexch unit tests",
                                 ekat::logger::LogLevel::debug, comm);
 
   const int num_mode = mam4::GasAerExch::num_mode;
@@ -426,14 +426,12 @@ void GasAerExch_init(const GasAerExch::Config &config,
   const int num_gas = AeroConfig::num_gas_ids();
   const int igas_h2so4 = static_cast<int>(GasId::H2SO4);
   const int igas_soag = static_cast<int>(GasId::SOAG);
-  const int igas_nh3 = static_cast<int>(GasId::NH3);
   const int num_mode = GasAerExch::num_mode;
 
   for (int k = 0; k < num_gas; ++k)
     eqn_and_numerics_category[k] = mam4::GasAerExch::NA;
   eqn_and_numerics_category[igas_soag] = mam4::GasAerExch::IMPL;
   eqn_and_numerics_category[igas_h2so4] = mam4::GasAerExch::ANAL;
-  eqn_and_numerics_category[igas_nh3] = mam4::GasAerExch::ANAL;
 
   for (int igas = 0; igas < num_gas; ++igas)
     for (int imode = 0; imode < num_mode; ++imode)
@@ -471,7 +469,7 @@ TEST_CASE("mam_gasaerexch_1subarea", "mam_gasaerexch") {
                              : std::numeric_limits<float>::epsilon() * 100;
 
   ekat::Comm comm;
-  ekat::logger::Logger<> logger("nucleation unit tests",
+  ekat::logger::Logger<> logger("gasaerexch unit tests",
                                 ekat::logger::LogLevel::debug, comm);
 
   const int num_mode = mam4::GasAerExch::num_mode;
@@ -720,6 +718,8 @@ TEST_CASE("mam_gasaerexch_1subarea", "mam_gasaerexch") {
        {0.0000000000000000, 0.0000000000000000, 0.0000000000000000, 0.0000000000000000},
        {0.0000000000000000, 0.0000000000000000, 0.0000000000000000, 0.0000000000000000}}};
 
+  // FIXME: the following two arrays probably need to be modified to reflect the changes
+  // FIXME: in our gas IDs
   const Real in_uptkaer[10][AeroConfig::num_gas_ids()][num_mode] = {
       {{0.0000000000000000, 0.0000000000000000, 0.0000000000000000, 0.0000000000000000},
        {0.0000000000000000, 0.0000000000000000, 0.0000000000000000, 0.0000000000000000},
@@ -805,8 +805,8 @@ TEST_CASE("mam_gasaerexch_1subarea", "mam_gasaerexch") {
     }
     AeroId gas_to_aer[num_gas];
     for (int i = 0; i < num_gas; ++i) {
-      const AeroId air = GasAerExch::gas_to_aer(static_cast<GasId>(i));
-      gas_to_aer[i] = air;
+      const AeroId aero = GasAerExch::gas_to_aer(static_cast<GasId>(i));
+      gas_to_aer[i] = aero;
     }
 
     Real uptk_rate_factor[num_gas];

--- a/src/validation/gasaerexch/skywkr_gasaerexch_timestepping.cpp
+++ b/src/validation/gasaerexch/skywkr_gasaerexch_timestepping.cpp
@@ -194,16 +194,15 @@ int main(int argc, char **argv) {
   //  prepare output
   // =======================================================================
   ensemble->process([=](const Input &input, Output &output) {
-    Real qgas_netprod_otrproc[num_gas];
-    Real qgas_cur[num_gas];
+    Real qgas_netprod_otrproc[num_gas] = {};
+    Real qgas_cur[num_gas] = {};
     // ----------------------------------------
     //  Process input for this ensemble member
-    // -----------------------------------saerexch_module_va-----
+    // ----------------------------------------
     //  Ambient conditions
 
     const Real pmid = input.get("pmid"); // air pressure
     const Real temp = input.get("temp"); // air temperature
-    // const Real aircon = pmid/(Constants::r_gas*temp); // air density
 
     // gas production rates and mixing ratio ICs
 
@@ -334,7 +333,7 @@ int main(int argc, char **argv) {
       //  tendencies after the subroutine call.
       // Note: qgas_cur[num_gas] is out of bounds but the constructor is for
       // [begin,end)
-      const std::vector<Real> zqgas_bef(&qgas_cur[0], &qgas_cur[num_mode]);
+      const std::vector<Real> zqgas_bef(&qgas_cur[0], &qgas_cur[num_gas]);
 
       // Call the MAM subroutine. Gas and aerosol mixing ratios will be updated
       // during the call

--- a/src/validation/gasaerexch/skywkr_gasaerexch_timestepping.cpp
+++ b/src/validation/gasaerexch/skywkr_gasaerexch_timestepping.cpp
@@ -179,15 +179,16 @@ int main(int argc, char **argv) {
     exit(1);
   }
 
-  const int h2so4 = static_cast<int>(mam4::GasId::H2SO4);
+  const int i_h2so4 = static_cast<int>(mam4::GasId::H2SO4);
+  const int i_soag = static_cast<int>(mam4::GasId::SOAG);
 
-  const int soa = static_cast<int>(mam4::AeroId::SOA);
-  const int so4 = static_cast<int>(mam4::AeroId::SO4);
-  const int pom = static_cast<int>(mam4::AeroId::POM);
-  const int bc = static_cast<int>(mam4::AeroId::BC);
-  const int ncl = static_cast<int>(mam4::AeroId::NaCl);
-  const int dst = static_cast<int>(mam4::AeroId::DST);
-  const int mom = static_cast<int>(mam4::AeroId::MOM);
+  const int i_soa = static_cast<int>(mam4::AeroId::SOA);
+  const int i_so4 = static_cast<int>(mam4::AeroId::SO4);
+  const int i_pom = static_cast<int>(mam4::AeroId::POM);
+  const int i_bc = static_cast<int>(mam4::AeroId::BC);
+  const int i_ncl = static_cast<int>(mam4::AeroId::NaCl);
+  const int i_dst = static_cast<int>(mam4::AeroId::DST);
+  const int i_mom = static_cast<int>(mam4::AeroId::MOM);
   // =======================================================================
   //  Loop over all members of the ensemble. Process input, do calculations, and
   //  prepare output
@@ -206,11 +207,11 @@ int main(int argc, char **argv) {
 
     // gas production rates and mixing ratio ICs
 
-    qgas_netprod_otrproc[h2so4] = input.get("qgas_prod_rate_h2so4");
-    qgas_netprod_otrproc[soa] = input.get("qgas_prod_rate_soag");
+    qgas_netprod_otrproc[i_h2so4] = input.get("qgas_prod_rate_h2so4");
+    qgas_netprod_otrproc[i_soag] = input.get("qgas_prod_rate_soag");
 
-    qgas_cur[h2so4] = input.get("qgas_cur_h2so4");
-    qgas_cur[soa] = input.get("qgas_cur_soag");
+    qgas_cur[i_h2so4] = input.get("qgas_cur_h2so4");
+    qgas_cur[i_soag] = input.get("qgas_cur_soag");
 
     // aerosol mixing ratio ICs
     Real qnum_cur[num_mode];
@@ -230,13 +231,13 @@ int main(int argc, char **argv) {
       val[5] = input.get_array("qaer_dst");
       val[6] = input.get_array("qaer_mom");
       for (int i = 0; i < num_mode; ++i) {
-        qaer_cur[soa][i] = val[0][i];
-        qaer_cur[so4][i] = val[1][i];
-        qaer_cur[pom][i] = val[2][i];
-        qaer_cur[bc][i] = val[3][i];
-        qaer_cur[ncl][i] = val[4][i];
-        qaer_cur[dst][i] = val[5][i];
-        qaer_cur[mom][i] = val[6][i];
+        qaer_cur[i_soa][i] = val[0][i];
+        qaer_cur[i_so4][i] = val[1][i];
+        qaer_cur[i_pom][i] = val[2][i];
+        qaer_cur[i_bc][i] = val[3][i];
+        qaer_cur[i_ncl][i] = val[4][i];
+        qaer_cur[i_dst][i] = val[5][i];
+        qaer_cur[i_mom][i] = val[6][i];
       }
     }
     // Time-stepping
@@ -278,12 +279,12 @@ int main(int argc, char **argv) {
     {
       const int istep = 0;
       time[istep] = 0;
-      so4g[istep] = qgas_cur[h2so4];
-      soag[istep] = qgas_cur[soa];
+      so4g[istep] = qgas_cur[i_h2so4];
+      soag[istep] = qgas_cur[i_soag];
       for (int i = 0; i < n_mode; ++i)
-        so4a[istep] += qaer_cur[so4][i];
+        so4a[istep] += qaer_cur[i_so4][i];
       for (int i = 0; i < n_mode; ++i)
-        soaa[istep] += qaer_cur[soa][i];
+        soaa[istep] += qaer_cur[i_soa][i];
       // ------------------------------------------------------------------
       //  Time loop, in which the MAM subroutine we want to test is called.
       // ------------------------------------------------------------------
@@ -314,7 +315,8 @@ int main(int argc, char **argv) {
       //  advection). This is done here for SOA only, because the production
       //  rate of H2SO4 gas is handled inside the MAM subroutine we are testing.
       // ------------------------------------------------------------------
-      qgas_cur[soa] = qgas_cur[soa] + qgas_netprod_otrproc[soa] * dt_mam;
+      qgas_cur[i_soag] =
+          qgas_cur[i_soag] + qgas_netprod_otrproc[i_soag] * dt_mam;
 
       // ------------------------------------------------------------------
       //  Calculate/update wet geometric mean diameter of each aerosol mode
@@ -413,25 +415,25 @@ int main(int argc, char **argv) {
       time[istep] = istep * dt_mam;
 
       // so4
-      so4g[istep] = qgas_cur[h2so4];
+      so4g[istep] = qgas_cur[i_h2so4];
       so4a[istep] = 0;
       for (int n = 0; n < num_mode; ++n)
-        so4a[istep] += qaer_cur[so4][n];
+        so4a[istep] += qaer_cur[i_so4][n];
 
-      so4g_ddt_exch[istep] = (qgas_cur[h2so4] - zqgas_bef[h2so4]) / dt_mam -
-                             qgas_netprod_otrproc[h2so4];
+      so4g_ddt_exch[istep] = (qgas_cur[i_h2so4] - zqgas_bef[i_h2so4]) / dt_mam -
+                             qgas_netprod_otrproc[i_h2so4];
 
       // soa
-      soag[istep] = qgas_cur[soa];
+      soag[istep] = qgas_cur[i_soag];
       soaa[istep] = 0;
       for (int n = 0; n < num_mode; ++n)
-        soaa[istep] += qaer_cur[soa][n];
-      soag_ddt_exch[istep] = (qgas_cur[soa] - zqgas_bef[soa]) / dt_mam;
+        soaa[istep] += qaer_cur[i_soa][n];
+      soag_ddt_exch[istep] = (qgas_cur[i_soag] - zqgas_bef[i_soag]) / dt_mam;
       soag_amb_qsat[istep] = g0_soa;
       soag_niter[istep] = niter;
       // Print some numbers to stdout for quick checks
       std::cout << "step " << istep << ", dqSOAG/dt = " << soag_ddt_exch[istep]
-                << ", qSOAG after = " << qgas_cur[soa]
+                << ", qSOAG after = " << qgas_cur[i_soag]
                 << ", g0_soa = " << g0_soa << ", niter = " << niter
                 << std::endl;
       // ----------------------------------------------

--- a/src/validation/gasaerexch/skywkr_gasaerexch_timestepping.cpp
+++ b/src/validation/gasaerexch/skywkr_gasaerexch_timestepping.cpp
@@ -195,7 +195,7 @@ int main(int argc, char **argv) {
   // =======================================================================
   ensemble->process([=](const Input &input, Output &output) {
     Real qgas_netprod_otrproc[num_gas];
-    Real qgas_cur[num_mode];
+    Real qgas_cur[num_gas];
     // ----------------------------------------
     //  Process input for this ensemble member
     // -----------------------------------saerexch_module_va-----


### PR DESCRIPTION
While only two gases (H2SO4 and SOAG) interact directly with aerosols in mam4xx, E3SM's version of MAM4 actually has four other gases that we haven't added to mam4xx yet. These other gases interact only indirectly with aerosols via the chemical mechanism we're porting.

This PR adds the other four gases to mam4xx. It also adds `None` enums for mode indices and gas ids, like aerosol ids have. This allows us to use integer indices to indicate that something is not a valid gas/aerosol/mode index, which is important because MAM4 routinely stuffs all of these quantities interchangeably into arrays as part of its spaghetti design pattern.