### PR TITLE
More GPU-related fixes

### DIFF
--- a/src/mam4xx/aero_config.hpp.in
+++ b/src/mam4xx/aero_config.hpp.in
@@ -97,11 +97,15 @@ public:
   KOKKOS_INLINE_FUNCTION
   explicit Prognostics(int num_levels) : nlev_(num_levels) {}
 
+  KOKKOS_INLINE_FUNCTION
   Prognostics() = default; // use only for creating containers of Prognostics!
+  KOKKOS_INLINE_FUNCTION
   ~Prognostics() = default;
 
   // these are used to populate containers of Prognostics objects
+  KOKKOS_INLINE_FUNCTION
   Prognostics(const Prognostics &rhs) = default;
+  KOKKOS_INLINE_FUNCTION
   Prognostics &operator=(const Prognostics &rhs) = default;
 
   ///  modal interstitial aerosol number mixing ratios (see aero_mode.hpp for
@@ -191,13 +195,18 @@ public:
   KOKKOS_INLINE_FUNCTION
   explicit Diagnostics(int num_levels) : nlev_(num_levels) {}
 
+  KOKKOS_INLINE_FUNCTION
   Diagnostics() = default; // use only for creating containers of Diagnostics!
+  KOKKOS_INLINE_FUNCTION
   ~Diagnostics() = default;
 
   // these are used to populate containers of Diagnostics objects
+  KOKKOS_INLINE_FUNCTION
   Diagnostics(const Diagnostics &rhs) = default;
+  KOKKOS_INLINE_FUNCTION
   Diagnostics &operator=(const Diagnostics &rhs) = default;
 
+  KOKKOS_INLINE_FUNCTION
   int num_levels() const { return nlev_; }
 
   /// Hygroscopicity is a modal mass-weighted average over all species
@@ -487,15 +496,21 @@ public:
   /// NOTE: it's currently possible to configure a Sources object with a
   /// NOTE: number of vertical levels different from mam4::nlev above, in order
   /// NOTE: to support various testing configurations.
+  KOKKOS_INLINE_FUNCTION
   explicit Sources(int num_levels) : nlev_(num_levels) {}
 
+  KOKKOS_INLINE_FUNCTION
   Sources() = default; // use only for creating containers of Sources!
+  KOKKOS_INLINE_FUNCTION
   ~Sources() = default;
 
   // these are used to populate containers of Sources objects
+  KOKKOS_INLINE_FUNCTION
   Sources(const Sources &rhs) = default;
+  KOKKOS_INLINE_FUNCTION
   Sources &operator=(const Sources &rhs) = default;
 
+  KOKKOS_INLINE_FUNCTION
   int num_levels() const { return nlev_; }
 
   /// surface number mixing ratio fluxes (per mode) [#/m2/s]

--- a/src/mam4xx/aging.hpp
+++ b/src/mam4xx/aging.hpp
@@ -146,8 +146,7 @@ void mam_pcarbon_aging_frac(
   const Real fac_volsfc = haero::exp(
       2.5 * haero::square(haero::log(mam4::modes(imom_pc).mean_std_dev)));
 
-  const Real xferfrac_max =
-      1.0 - 10.0 * std::numeric_limits<Real>::epsilon(); //  1-eps
+  const Real xferfrac_max = 1.0 - 10.0 * haero::epsilon(); //  1-eps
 
   Real xferfrac_tmp1 = vol_shell * dgn_a[imom_pc] * fac_volsfc;
   Real xferfrac_tmp2 =

--- a/src/mam4xx/coagulation.hpp
+++ b/src/mam4xx/coagulation.hpp
@@ -886,7 +886,7 @@ void mam_coag_aer_update(
   const Real bijqnumj2 = haero::max(0.0, ybetaij3[2] * qnum_tavg[npca]);
   Real decay_const = bijqnumj1 + bijqnumj2;
 
-  constexpr Real epsilonx2 = std::numeric_limits<Real>::epsilon() * 2.0;
+  constexpr Real epsilonx2 = haero::epsilon() * 2.0;
   Real decay_factor =
       deltat * decay_const; // calculate coag-induced changes only when this
                             // number is not ~= zero

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -133,17 +133,17 @@ void ndrop_int(Real exp45logsig[AeroConfig::num_modes()],
 } // end ndrop_int
 
 KOKKOS_INLINE_FUNCTION
-void activate_modal(
-    const Real w_in, const Real wmaxf, const Real tair, const Real rhoair,
-    Real na[AeroConfig::num_modes()],
-    const Real volume[AeroConfig::num_modes()],
-    const Real hygro[AeroConfig::num_modes()],
-    const Real exp45logsig[AeroConfig::num_modes()],
-    const Real alogsig[AeroConfig::num_modes()], const Real aten,
-    Real fn[AeroConfig::num_modes()], Real fm[AeroConfig::num_modes()],
-    Real fluxn[AeroConfig::num_modes()], Real fluxm[AeroConfig::num_modes()],
-    Real &flux_fullact,
-    const Real smax_prescribed = haero::max()) {
+void activate_modal(const Real w_in, const Real wmaxf, const Real tair,
+                    const Real rhoair, Real na[AeroConfig::num_modes()],
+                    const Real volume[AeroConfig::num_modes()],
+                    const Real hygro[AeroConfig::num_modes()],
+                    const Real exp45logsig[AeroConfig::num_modes()],
+                    const Real alogsig[AeroConfig::num_modes()],
+                    const Real aten, Real fn[AeroConfig::num_modes()],
+                    Real fm[AeroConfig::num_modes()],
+                    Real fluxn[AeroConfig::num_modes()],
+                    Real fluxm[AeroConfig::num_modes()], Real &flux_fullact,
+                    const Real smax_prescribed = haero::max()) {
   // 	  !---------------------------------------------------------------------------------
   // !Calculates number, surface, and mass fraction of aerosols activated as CCN
   // !calculates flux of cloud droplets, surface area, and aerosol mass into

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -143,7 +143,7 @@ void activate_modal(
     Real fn[AeroConfig::num_modes()], Real fm[AeroConfig::num_modes()],
     Real fluxn[AeroConfig::num_modes()], Real fluxm[AeroConfig::num_modes()],
     Real &flux_fullact,
-    const Real smax_prescribed = std::numeric_limits<Real>::max()) {
+    const Real smax_prescribed = haero::max()) {
   // 	  !---------------------------------------------------------------------------------
   // !Calculates number, surface, and mass fraction of aerosols activated as CCN
   // !calculates flux of cloud droplets, surface area, and aerosol mass into
@@ -316,7 +316,7 @@ void activate_modal(
   // Find maximum supersaturation
   // Use smax_prescribed if it is present; otherwise get smax from subr maxsat
   Real smax = smax_prescribed;
-  if (smax_prescribed == std::numeric_limits<Real>::max())
+  if (smax_prescribed == haero::max())
     ndrop::maxsat(zeta, eta, nmode, smc, smax);
 
   // FIXME [unitless] ? lnsmax maybe has units of log(unit of smax ([fraction]))
@@ -464,8 +464,8 @@ public:
     // clang-format off
     const Real specdens_amode[maxd_aspectype] = {
       mam4::mam4_density_so4,
-      std::numeric_limits<Real>::max(),
-      std::numeric_limits<Real>::max(),
+      haero::max(),
+      haero::max(),
       mam4::mam4_density_pom,
       mam4::mam4_density_soa,
       mam4::mam4_density_bc ,
@@ -484,8 +484,8 @@ public:
     // clang-format off
     const Real spechygro[maxd_aspectype] = {
        mam4::mam4_hyg_so4,
-       std::numeric_limits<Real>::max(),
-       std::numeric_limits<Real>::max(),
+       haero::max(),
+       haero::max(),
        mam4::mam4_hyg_pom,
        // (BAD CONSTANT) mam4::mam4_hyg_soa = 0.1
        0.1400000000e+00,

--- a/src/mam4xx/nucleate_ice.hpp
+++ b/src/mam4xx/nucleate_ice.hpp
@@ -359,7 +359,7 @@ public:
 
             const Real zero = 0;
             const Real half = 0.5;
-            const Real sqrt_two = haero::sqrt(2);
+            const Real sqrt_two = haero::sqrt(2.0);
 
             const Real pmid = atmosphere.pressure(kk);
             const Real air_density =

--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -649,6 +649,7 @@ public:
 
   // init -- initializes the implementation with MAM4's configuration and with
   // a process-specific configuration.
+  KOKKOS_INLINE_FUNCTION
   void init(const AeroConfig &aero_config,
             const Config &nucl_config = Config()) {
     // Set nucleation-specific config parameters.

--- a/src/mam4xx/rename.hpp
+++ b/src/mam4xx/rename.hpp
@@ -185,8 +185,7 @@ void compute_xfer_fractions(const Real b4_growth_dryvol,
   // BAD CONSTANT
   // 1-eps (this number is little less than 1, e.g. 0.99) // FIXME: this comment
   // is nonsense
-  constexpr Real xferfrac_max =
-      Real(1.0) - 10.0 * std::numeric_limits<Real>::epsilon();
+  constexpr Real xferfrac_max = Real(1.0) - 10.0 * haero::epsilon();
   // assume we have fractions to transfer, so we will not skip the rest of the
   // calculations
   is_xfer_frac_zero = false;

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -918,7 +918,7 @@ void wetdepa_v2(const Real deltat, const Real pdel, const Real cmfdqr,
   // as X such that 1 + E > 1.
   // C++ Returns the machine epsilon, that is, the difference between 1.0
   // and the next value representable by the floating-point type T.
-  const Real omsm = 1.0 - 2 * std::numeric_limits<Real>::epsilon();
+  const Real omsm = 1.0 - 2 * haero::epsilon();
 
   // initiate variables
   // strat precip from above [kg/m2/s]


### PR DESCRIPTION
This PR uses the new GPU-sensible `min()`, `max()`, and `epsilon()` functions offered by Haero. It also annotates some more functions with `KOKKOS_INLINE_FUNCTION` to make them callable on-device.