### PR TITLE
Added a single-level version of lin_strat_sfcsink.

### DIFF
--- a/src/mam4xx/lin_strat_chem.hpp
+++ b/src/mam4xx/lin_strat_chem.hpp
@@ -260,6 +260,20 @@ void lin_strat_chem_solve(
 } // lin_strat_chem_solve
 
 KOKKOS_INLINE_FUNCTION
+void lin_strat_sfcsink_kk(const Real delta_t, const Real pdel, // in
+                          Real &o3l_vmr, const Real o3_sfc, const int o3_lbl,
+                          const Real o3_tau, Real &do3mass) {
+  const Real mass = pdel(kk) * rgrav; //   air mass in kg/m2
+  const Real o3l_old = o3l_vmr(kk);   // vmr
+  const Real efactor =
+      (one - haero::exp(-delta_t / o3_tau));     // !compute time scale factor
+  const Real do3 = (o3_sfc - o3l_old) * efactor; // vmr
+  o3l_vmr = o3l_old + do3;
+  do3mass += do3 * mass * mwo3 / mwdry; // loss in kg/m2 summed over boundary
+                                        // layers within one time step
+}
+
+KOKKOS_INLINE_FUNCTION
 void lin_strat_sfcsink(const Real delta_t, const ColumnView &pdel, // in
                        const ColumnView &o3l_vmr, const Real o3_sfc,
                        const int o3_lbl, const Real o3_tau, Real &o3l_sfcsink) {
@@ -280,19 +294,10 @@ void lin_strat_sfcsink(const Real delta_t, const ColumnView &pdel, // in
   constexpr Real rgrav =
       one / haero::Constants::gravity; // reciprocal of gravit
 
-  const Real efactor =
-      (one - haero::exp(-delta_t / o3_tau)); // !compute time scale factor
   Real do3mass_icol = 0;
   for (int kk = pver - 1; kk > pver - o3_lbl - 1; --kk) {
-    const Real mass = pdel(kk) * rgrav; //   air mass in kg/m2
-
-    const Real o3l_old = o3l_vmr(kk);              // vmr
-    const Real do3 = (o3_sfc - o3l_old) * efactor; // vmr
-    const Real o3l_new = o3l_old + do3;
-    do3mass_icol +=
-        do3 * mass * mwo3 / mwdry; //   loss in kg/m2 summed over boundary
-                                   //   layers within one time step
-    o3l_vmr(kk) = o3l_new;
+    lin_strat_sfcsink_kk(delta_t, pdel(kk), o3l_vmr(kk), o3_sfc, o3_lbl, o3_tau,
+                         do3mass_icol);
   }
 
   // Two parameters are applied to Linoz O3 for surface sink, O3l is not coupled

--- a/src/mam4xx/lin_strat_chem.hpp
+++ b/src/mam4xx/lin_strat_chem.hpp
@@ -295,7 +295,7 @@ void lin_strat_sfcsink(const Real delta_t, const ColumnView &pdel, // in
 
   Real do3mass_icol = 0;
   for (int kk = pver - 1; kk > pver - o3_lbl - 1; --kk) {
-    lin_strat_sfcsink_kk(delta_t, pdel(kk), o3l_vmr(kk), o3_sfc, o3_lbl, o3_tau,
+    lin_strat_sfcsink_kk(delta_t, pdel(kk), o3l_vmr(kk), o3_sfc, o3_tau,
                          do3mass_icol);
   }
 

--- a/src/mam4xx/lin_strat_chem.hpp
+++ b/src/mam4xx/lin_strat_chem.hpp
@@ -261,8 +261,8 @@ void lin_strat_chem_solve(
 
 KOKKOS_INLINE_FUNCTION
 void lin_strat_sfcsink_kk(const Real delta_t, const Real pdel, // in
-                          Real &o3l_vmr, const Real o3_sfc, const int o3_lbl,
-                          const Real o3_tau, Real &do3mass) {
+                          Real &o3l_vmr, const Real o3_sfc, const Real o3_tau,
+                          Real &do3mass) {
   constexpr Real one = 1.0;
   // BAD CONSTANT
   constexpr Real mwo3 = 48.; // molecular weight O3

--- a/src/mam4xx/lin_strat_chem.hpp
+++ b/src/mam4xx/lin_strat_chem.hpp
@@ -263,10 +263,18 @@ KOKKOS_INLINE_FUNCTION
 void lin_strat_sfcsink_kk(const Real delta_t, const Real pdel, // in
                           Real &o3l_vmr, const Real o3_sfc, const int o3_lbl,
                           const Real o3_tau, Real &do3mass) {
-  const Real mass = pdel(kk) * rgrav; //   air mass in kg/m2
-  const Real o3l_old = o3l_vmr(kk);   // vmr
+  constexpr Real one = 1.0;
+  // BAD CONSTANT
+  constexpr Real mwo3 = 48.; // molecular weight O3
+  constexpr Real mwdry = haero::Constants::molec_weight_dry_air *
+                         1e3; //     ! molecular weight dry air ~ kg/kmole;//!
+  constexpr Real rgrav =
+      one / haero::Constants::gravity; // reciprocal of gravit
   const Real efactor =
       (one - haero::exp(-delta_t / o3_tau));     // !compute time scale factor
+                                                 //
+  const Real mass = pdel * rgrav;                //   air mass in kg/m2
+  const Real o3l_old = o3l_vmr;                  // vmr
   const Real do3 = (o3_sfc - o3l_old) * efactor; // vmr
   o3l_vmr = o3l_old + do3;
   do3mass += do3 * mass * mwo3 / mwdry; // loss in kg/m2 summed over boundary
@@ -284,15 +292,6 @@ void lin_strat_sfcsink(const Real delta_t, const ColumnView &pdel, // in
   // !inten in-outs
   // @param[inout]:: o3l_vmr(ncol ,pver)             ! ozone volume mixing ratio
   // [vmr]
-
-  constexpr Real one = 1.0;
-  // BAD CONSTANT
-  constexpr Real mwo3 = 48.; // molecular weight O3
-  constexpr Real mwdry = haero::Constants::molec_weight_dry_air *
-                         1e3; //     ! molecular weight dry air ~ kg/kmole;//!
-                              //     molecular weight dry air
-  constexpr Real rgrav =
-      one / haero::Constants::gravity; // reciprocal of gravit
 
   Real do3mass_icol = 0;
   for (int kk = pver - 1; kk > pver - o3_lbl - 1; --kk) {


### PR DESCRIPTION
It turns out that the work in the `lin_strat_sfcsink` function is independent of levels in the sense that none of the work in a level `k` depends on work in another level `k`, and that there's an accumulation that is order-independent. It also turns out that it's better for us to be able to call this function in the context of a single vertical level, rather than as a whole-column operation. This PR adds a new single-level version of the function.