### PR TITLE
Long-awaited Port of `mo_setinv`

### DIFF
--- a/src/mam4xx/CMakeLists.txt
+++ b/src/mam4xx/CMakeLists.txt
@@ -47,8 +47,9 @@ install(FILES
         mo_setsox.hpp
         tropopause.hpp
         modal_aer_opt.hpp
-        aer_rad_props.hpp 
-        modal_aero_calcsize.hpp 
+        aer_rad_props.hpp
+        modal_aero_calcsize.hpp
+        mo_setinv.hpp
         DESTINATION include/mam4xx)
 
 add_library(mam4xx aero_modes.cpp)

--- a/src/mam4xx/mam4.hpp
+++ b/src/mam4xx/mam4.hpp
@@ -26,6 +26,7 @@
 #include <mam4xx/mo_chm_diags.hpp>
 #include <mam4xx/mo_photo.hpp>
 #include <mam4xx/mo_setext.hpp>
+#include <mam4xx/mo_setinv.hpp>
 #include <mam4xx/mo_setsox.hpp>
 #include <mam4xx/modal_aer_opt.hpp>
 #include <mam4xx/modal_aero_calcsize.hpp>

--- a/src/mam4xx/mo_setinv.hpp
+++ b/src/mam4xx/mo_setinv.hpp
@@ -20,8 +20,7 @@ struct Config {
   // FIXME: BAD CONSTANTS!
   // conversion factor for Pascals to dyne/cm^2
   Real Pa_xfac = 10.0;
-  // presumably, the boltzman constant, in CGS units
-  // NOTE: passed in via yaml input file for now
+  // presumably, the boltzmann constant, in CGS units
   Real boltz_cgs = 0.13806500000000001E-015;
   // NOTE: the indices (xyz_ndx) are translated to zero-indexed in the
   // constructor

--- a/src/mam4xx/mo_setinv.hpp
+++ b/src/mam4xx/mo_setinv.hpp
@@ -1,0 +1,123 @@
+#ifndef MAM4XX_MO_SETINV_HPP
+#define MAM4XX_MO_SETINV_HPP
+
+#include <haero/atmosphere.hpp>
+
+#include <mam4xx/aero_config.hpp>
+#include <mam4xx/mam4_types.hpp>
+
+namespace mam4 {
+namespace mo_setinv {
+// number of invariants
+static const int nfs = 8;
+static const int num_tracer_cnst = 4;
+
+struct Config {
+  // FIXME: BAD CONSTANTS!
+  // conversion factor for Pascals to dyne/cm^2
+  Real Pa_xfac = 10.0;
+  // presumably, the boltzman constant, in CGS units
+  // NOTE: passed in via yaml input file for now
+  Real boltz_cgs = 0.13806500000000001E-015;
+  // NOTE: the indices (xyz_ndx) are translated to zero-indexed in the
+  // constructor
+  bool has_n2 = true;
+  int m_ndx = 0;
+  int n2_ndx = 1;
+  bool has_o2 = true;
+  int o2_ndx = 2;
+  bool has_h2o = true;
+  int h2o_ndx = 3;
+  // FIXME: this will likely need to be changed to match the order of how the
+  // "cnst_offline" species are passed in
+  int coff_idx_list[num_tracer_cnst] = {7, 4, 5, 6};
+
+  Config() = default;
+  Config(const Config &) = default;
+  ~Config() = default;
+  Config &operator=(const Config &) = default;
+};
+
+// NOTE: vmr isn't actually used in the fortran code, but I've kept it here to
+// keep the function signature the same
+KOKKOS_INLINE_FUNCTION
+void setinv_single_level(Real invariants[nfs], const Real tfld,
+                         const Real h2ovmr,
+                         const Real vmr[AeroConfig::num_gas_phase_species()],
+                         const Real pmid,
+                         const Real cnst_offline[num_tracer_cnst],
+                         const Config config_) {
+  // -----------------------------------------------------------------
+  //  set the invariant densities (molecules/cm**3)
+  // -----------------------------------------------------------------
+
+  for (int i = 0; i < nfs; ++i) {
+    invariants[i] = 0.0;
+  }
+
+  const int m_idx = config_.m_ndx;
+  // NOTE: these species index are <xyz>_ndx =  <xyz_fortran>_ndx - 1
+  // NOTE: invariants are in cgs density units. => the pmid array is in pascals
+  // and must be multiplied by 10 (Pa_xfac) to yield dynes/cm**2.
+  invariants[m_idx] = config_.Pa_xfac * pmid / (config_.boltz_cgs * tfld);
+  const Real inv_m = invariants[m_idx];
+  // FIXME: BAD CONSTANTS!!
+  if (config_.has_n2) {
+    invariants[config_.n2_ndx] = 0.79 * inv_m;
+  }
+  if (config_.has_o2) {
+    invariants[config_.o2_ndx] = 0.21 * inv_m;
+  }
+  if (config_.has_h2o) {
+    invariants[config_.h2o_ndx] = h2ovmr * inv_m;
+  }
+  const auto c_off = cnst_offline;
+  for (int i = 0; i < num_tracer_cnst; ++i) {
+    invariants[config_.coff_idx_list[i]] = c_off[i] * inv_m;
+  }
+
+  // NOTE: not porting for now
+  // Writing out diagnostics
+  // do ifs = 1,nfs
+  //   tmp_out(:ncol,:) =  invariants(:ncol,:,ifs)
+  //   call outfld( trim(inv_lst(ifs))//'_dens', tmp_out(:ncol,:), ncol, lchnk )
+  //   tmp_out(:ncol,:) =  invariants(:ncol,:,ifs) / invariants(:ncol,:,m_ndx)
+  //   call outfld( trim(inv_lst(ifs))//'_vmr',  tmp_out(:ncol,:), ncol, lchnk )
+  // enddo
+} // end setinv_single_level()
+
+KOKKOS_INLINE_FUNCTION
+void setinv(const ThreadTeam &team, const ColumnView invariants[nfs],
+            const ColumnView &tfld, const ColumnView &h2ovmr,
+            const ColumnView vmr[AeroConfig::num_gas_phase_species()],
+            const ColumnView cnst_offline[num_tracer_cnst],
+            const ColumnView &pmid) {
+
+  Config setinv_config_;
+  constexpr int nk = mam4::nlev;
+
+  Kokkos::parallel_for(
+      Kokkos::TeamThreadRange(team, nk), KOKKOS_LAMBDA(int k) {
+        const Real tfld_k = tfld(k);
+        const Real h2ovmr_k = h2ovmr(k);
+        const Real pmid_k = pmid(k);
+        Real invariants_k[nfs];
+        const int nspec = AeroConfig::num_gas_phase_species();
+        Real vmr_k[nspec];
+        for (int i = 0; i < nspec; ++i) {
+          vmr_k[i] = vmr[i](k);
+        }
+        Real cnst_offline_k[num_tracer_cnst];
+        for (int i = 0; i < num_tracer_cnst; ++i) {
+          cnst_offline_k[i] = cnst_offline[i](k);
+        }
+        setinv_single_level(invariants_k, tfld_k, h2ovmr_k, vmr_k, pmid_k,
+                            cnst_offline_k, setinv_config_);
+        for (int i = 0; i < nfs; ++i) {
+          invariants[i](k) = invariants_k[i];
+        }
+      }); // end kokkos::parfor(k)
+} // end setinv_nlev()
+} // namespace mo_setinv
+} // namespace mam4
+#endif

--- a/src/mam4xx/mo_setinv.hpp
+++ b/src/mam4xx/mo_setinv.hpp
@@ -4,12 +4,13 @@
 #include <haero/atmosphere.hpp>
 
 #include <mam4xx/aero_config.hpp>
+#include <mam4xx/gas_chem_mechanism.hpp>
 #include <mam4xx/mam4_types.hpp>
 
 namespace mam4 {
 namespace mo_setinv {
 // number of invariants
-static const int nfs = 8;
+constexpr int nfs = mam4::gas_chemistry::nfs;
 static const int num_tracer_cnst = 4;
 
 struct Config {

--- a/src/validation/CMakeLists.txt
+++ b/src/validation/CMakeLists.txt
@@ -35,4 +35,4 @@ add_subdirectory(mo_setext)
 add_subdirectory(mo_setsox)
 add_subdirectory(tropopause)
 add_subdirectory(aerosol_optics)
-
+add_subdirectory(mo_setinv)

--- a/src/validation/mo_setinv/CMakeLists.txt
+++ b/src/validation/mo_setinv/CMakeLists.txt
@@ -1,0 +1,59 @@
+set(MO_SETINV_VALIDATION_DIR ${MAM_X_VALIDATION_DIR}/mo_setinv)
+set(MO_SETINV_VALIDATION_SCRIPTS_DIR ${MAM_X_VALIDATION_DIR}/scripts)
+
+
+# These subdirectories contain Skywalker drivers for MAM4 parameterizations.
+# Include directory for .mod files.
+
+include_directories(${PROJECT_BINARY_DIR}/validation)
+
+# We use a single driver for all mo_setinv-related parameterizations.
+add_executable(mo_setinv_driver
+               mo_setinv_driver.cpp
+               setinv_test_single_level.cpp
+               setinv_test_nlev.cpp
+               )
+
+target_link_libraries(mo_setinv_driver skywalker;validation;${HAERO_LIBRARIES})
+
+# Copy some Python scripts from mam_x_validation to our binary directory.
+foreach(script
+        compare_mam4xx_mam4.py)
+  configure_file(
+    ${MO_SETINV_VALIDATION_SCRIPTS_DIR}/${script}
+    ${CMAKE_CURRENT_BINARY_DIR}/${script}
+    COPYONLY
+  )
+endforeach()
+
+# Run the driver in several configurations to produce datasets.
+set(TEST_LIST
+    setinv_merged
+    setinv_nlev
+    )
+
+set(DEFAULT_TOL 1e-8)
+
+set(ERROR_THRESHOLDS
+    ${DEFAULT_TOL}
+    ${DEFAULT_TOL}
+   )
+
+foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
+  # copy the baseline file into place.
+
+  configure_file(
+    ${MO_SETINV_VALIDATION_DIR}/mam_${input}.py
+    ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
+    COPYONLY
+  )
+
+  # add a test to run the skywalker driver
+  add_test(run_${input} mo_setinv_driver ${MO_SETINV_VALIDATION_DIR}/${input}.yaml)
+
+  # add a test to validate mam4xx's results against the baseline.
+  # Select a threshold error slightly bigger than the largest relative error for the threshold error.
+  # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
+  add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+endforeach()

--- a/src/validation/mo_setinv/mo_setinv_driver.cpp
+++ b/src/validation/mo_setinv/mo_setinv_driver.cpp
@@ -1,0 +1,71 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <mam4xx/mo_setinv.hpp>
+
+#include <iostream>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+void usage() {
+  std::cerr << "mo_setinv_driver: a Skywalker driver for validating the "
+               "MAM4 mo_setinv parameterizations."
+            << std::endl;
+  std::cerr << "mo_setinv_driver: usage:" << std::endl;
+  std::cerr << "mo_setinv_driver <input.yaml>" << std::endl;
+  exit(0);
+}
+
+using namespace skywalker;
+using namespace mam4;
+
+// Parameterizations used by the mo_setinv() process.
+void setinv_test_single_level(Ensemble *ensemble);
+void setinv_test_nlev(Ensemble *ensemble);
+
+int main(int argc, char **argv) {
+  if (argc == 1) {
+    usage();
+  }
+  validation::initialize(argc, argv);
+  std::string input_file = argv[1];
+  std::string output_file = validation::output_name(input_file);
+  std::cout << argv[0] << ": reading " << input_file << std::endl;
+
+  // Load the ensemble. Any error encountered is fatal.
+  Ensemble *ensemble = skywalker::load_ensemble(input_file, "mam4xx");
+
+  // the settings.
+  Settings settings = ensemble->settings();
+  if (!settings.has("function")) {
+    std::cerr << "No function specified in mam4xx.settings!" << std::endl;
+    exit(1);
+  }
+
+  // Dispatch to the requested function.
+  auto func_name = settings.get("function");
+  try {
+    if (func_name == "setinv_test_single_level") {
+      setinv_test_single_level(ensemble);
+    } else if (func_name == "setinv_test_nlev") {
+      setinv_test_nlev(ensemble);
+    } else {
+      std::cerr << "Error: Function name '" << func_name
+                << "' does not have an implemented test!" << std::endl;
+      exit(1);
+    }
+
+  } catch (std::exception &e) {
+    std::cerr << argv[0] << ": Error: " << e.what() << std::endl;
+  }
+
+  // Write out a Python module.
+  std::cout << argv[0] << ": writing " << output_file << std::endl;
+  ensemble->write(output_file);
+
+  // Clean up.
+  delete ensemble;
+  validation::finalize();
+}

--- a/src/validation/mo_setinv/setinv_test_nlev.cpp
+++ b/src/validation/mo_setinv/setinv_test_nlev.cpp
@@ -1,0 +1,117 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <mam4xx/mam4.hpp>
+
+#include <mam4xx/aero_config.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+using namespace skywalker;
+using namespace mam4;
+using namespace haero;
+void setinv_test_nlev(Ensemble *ensemble) {
+  ensemble->process([=](const Input &input, Output &output) {
+    // Ensemble parameters
+    // Declare array of strings for input names
+    std::string input_arrays[] = {
+        "tfld",      "h2ovmr",  "vmr",       "pmid",
+        "ncol",      "lchnk",   "pcols",     "pver",
+        "gas_pcnst", "nfs",     "boltz_cgs", "num_tracer_cnst",
+        "has_n2",    "m_ndx",   "n2_ndx",    "has_o2",
+        "o2_ndx",    "has_h2o", "h2o_ndx",   "cnst_offline_yaml"};
+
+    // Iterate over input_arrays and error if not in input
+    for (std::string name : input_arrays) {
+      if (!input.has_array(name.c_str())) {
+        std::cerr << "Required name for array: " << name << std::endl;
+        exit(1);
+      }
+    }
+
+    const Real tfld_in = input.get_array("tfld")[0];
+    const Real h2ovmr_in = input.get_array("h2ovmr")[0];
+    // NOTE: vmr turns out to be unused, but still in the fxn signature for now
+    auto vmr_in = input.get_array("vmr");
+    const Real pmid_in = input.get_array("pmid")[0];
+    auto c_off_in = input.get_array("cnst_offline_yaml");
+
+    const int nlev = mam4::nlev;
+    const int nspec = AeroConfig::num_gas_phase_species();
+    const int nfs = mam4::mo_setinv::nfs;
+    const int num_tracer_cnst = mam4::mo_setinv::num_tracer_cnst;
+
+    ColumnView tfld = haero::testing::create_column_view(nlev);
+    auto tfld_h = Kokkos::create_mirror_view(tfld);
+    ColumnView h2ovmr = haero::testing::create_column_view(nlev);
+    auto h2ovmr_h = Kokkos::create_mirror_view(h2ovmr);
+    ColumnView pmid = haero::testing::create_column_view(nlev);
+    auto pmid_h = Kokkos::create_mirror_view(pmid);
+
+    using View1DHost = typename HostType::view_1d<Real>;
+    ColumnView invariants[nfs];
+    View1DHost invariants_h[nfs];
+    ColumnView vmr[nspec];
+    View1DHost vmr_h[nspec];
+    ColumnView c_off[num_tracer_cnst];
+    View1DHost c_off_h[num_tracer_cnst];
+
+    for (int i = 0; i < nfs; ++i) {
+      invariants[i] = haero::testing::create_column_view(nlev);
+      invariants_h[i] = Kokkos::create_mirror_view(invariants[i]);
+    }
+    for (int i = 0; i < nspec; ++i) {
+      vmr[i] = haero::testing::create_column_view(nlev);
+      vmr_h[i] = Kokkos::create_mirror_view(vmr[i]);
+    }
+    for (int i = 0; i < num_tracer_cnst; ++i) {
+      c_off[i] = haero::testing::create_column_view(nlev);
+      c_off_h[i] = Kokkos::create_mirror_view(c_off[i]);
+    }
+
+    for (int k = 0; k < nlev; ++k) {
+      tfld_h(k) = tfld_in;
+      h2ovmr_h(k) = h2ovmr_in;
+      pmid_h(k) = pmid_in;
+      for (int i = 0; i < nspec; ++i) {
+        vmr_h[i](k) = vmr_in[i];
+      }
+      for (int i = 0; i < num_tracer_cnst; ++i) {
+        c_off_h[i](k) = c_off_in[i];
+      }
+    }
+
+    Kokkos::deep_copy(tfld, tfld_h);
+    Kokkos::deep_copy(h2ovmr, h2ovmr_h);
+    Kokkos::deep_copy(pmid, pmid_h);
+
+    for (int i = 0; i < nspec; ++i) {
+      Kokkos::deep_copy(vmr[i], vmr_h[i]);
+    }
+    for (int i = 0; i < num_tracer_cnst; ++i) {
+      Kokkos::deep_copy(c_off[i], c_off_h[i]);
+    }
+
+    // Single-column dispatch.
+    auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
+    Kokkos::parallel_for(
+        team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
+          mam4::mo_setinv::setinv(team, invariants, tfld, h2ovmr, vmr, c_off,
+                                  pmid);
+        });
+
+    std::vector<Real> invariants_out(nfs);
+    for (int i = 0; i < nfs; ++i) {
+      Kokkos::deep_copy(invariants_h[i], invariants[i]);
+      invariants_out[i] = invariants_h[i](0);
+      for (int k = 0; k < nlev; ++k) {
+        // make sure every level got the same answer
+        EKAT_ASSERT(invariants_h[i](0) == invariants_h[i](k));
+      }
+    }
+
+    output.set("invariants", invariants_out);
+  });
+}

--- a/src/validation/mo_setinv/setinv_test_single_level.cpp
+++ b/src/validation/mo_setinv/setinv_test_single_level.cpp
@@ -37,14 +37,6 @@ void setinv_test_single_level(Ensemble *ensemble) {
     auto vmr = input.get_array("vmr");
     const Real pmid = input.get_array("pmid")[0];
     const int nfs = input.get_array("nfs")[0];
-    const Real boltz_cgs = input.get_array("boltz_cgs")[0];
-    const int has_n2 = input.get_array("has_n2")[0];
-    const int m_ndx = input.get_array("m_ndx")[0];
-    const int n2_ndx = input.get_array("n2_ndx")[0];
-    const int has_o2 = input.get_array("has_o2")[0];
-    const int o2_ndx = input.get_array("o2_ndx")[0];
-    const int has_h2o = input.get_array("has_h2o")[0];
-    const int h2o_ndx = input.get_array("h2o_ndx")[0];
     auto cnst_offline = input.get_array("cnst_offline_yaml");
 
     const mam4::mo_setinv::Config setinv_config_;

--- a/src/validation/mo_setinv/setinv_test_single_level.cpp
+++ b/src/validation/mo_setinv/setinv_test_single_level.cpp
@@ -1,0 +1,65 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <mam4xx/mam4.hpp>
+
+#include <mam4xx/aero_config.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+using namespace skywalker;
+using namespace mam4;
+using namespace haero;
+void setinv_test_single_level(Ensemble *ensemble) {
+  ensemble->process([=](const Input &input, Output &output) {
+    // Ensemble parameters
+    // Declare array of strings for input names
+    std::string input_arrays[] = {
+        "tfld",      "h2ovmr",  "vmr",       "pmid",
+        "ncol",      "lchnk",   "pcols",     "pver",
+        "gas_pcnst", "nfs",     "boltz_cgs", "num_tracer_cnst",
+        "has_n2",    "m_ndx",   "n2_ndx",    "has_o2",
+        "o2_ndx",    "has_h2o", "h2o_ndx",   "cnst_offline_yaml"};
+
+    // Iterate over input_arrays and error if not in input
+    for (std::string name : input_arrays) {
+      if (!input.has_array(name.c_str())) {
+        std::cerr << "Required name for array: " << name << std::endl;
+        exit(1);
+      }
+    }
+
+    const Real tfld = input.get_array("tfld")[0];
+    const Real h2ovmr = input.get_array("h2ovmr")[0];
+    // NOTE: vmr turns out to be unused, but still in the fxn signature for now
+    auto vmr = input.get_array("vmr");
+    const Real pmid = input.get_array("pmid")[0];
+    const int nfs = input.get_array("nfs")[0];
+    const Real boltz_cgs = input.get_array("boltz_cgs")[0];
+    const int has_n2 = input.get_array("has_n2")[0];
+    const int m_ndx = input.get_array("m_ndx")[0];
+    const int n2_ndx = input.get_array("n2_ndx")[0];
+    const int has_o2 = input.get_array("has_o2")[0];
+    const int o2_ndx = input.get_array("o2_ndx")[0];
+    const int has_h2o = input.get_array("has_h2o")[0];
+    const int h2o_ndx = input.get_array("h2o_ndx")[0];
+    auto cnst_offline = input.get_array("cnst_offline_yaml");
+
+    const mam4::mo_setinv::Config setinv_config_;
+
+    Real invariants[nfs];
+
+    mam4::mo_setinv::setinv_single_level(invariants, tfld, h2ovmr, vmr.data(),
+                                         pmid, cnst_offline.data(),
+                                         setinv_config_);
+
+    std::vector<Real> inv_out;
+    for (int i = 0; i < nfs; ++i) {
+      inv_out.push_back(invariants[i]);
+    }
+
+    output.set("invariants", inv_out);
+  });
+}


### PR DESCRIPTION
This PR ports `mo_setinv`, which sets the "invariant species" within [`mo_gas_phase_chemdr.F90`](https://github.com/eagles-project/e3sm_mam4_refactor/blob/f6f291b80b9e245a04d422e7bcda5a9609c12107/components/eam/src/chemistry/mozart/mo_gas_phase_chemdr.F90#L375).

There are some idiosyncratic constants and indexing schemes that are used on the fortran side, and I'm not sure some of these will make it into EAMxx. For example, there's some convoluted combination of strings and indices used to get the `cnst_offline` quantities from some faraway source. So, I've stored these variables in a `Config` struct for now that's initialized in `setinv()` and passed as an argument to `setinv_single_level()`. 

There are two validation tests, `setinv_test_single_level.cpp` that runs data for a number of time steps, and `setinv_test_nlev.cpp` that duplicates a single one of these time-step inputs and runs that condition on a full column in a `parfor()` (the same workflow as used for `mo_setsox`).