### PR TITLE
limit cmake core count

### DIFF
--- a/.github/pnnl-ci/ci.sh
+++ b/.github/pnnl-ci/ci.sh
@@ -63,7 +63,7 @@ cmake \
   -B build -S $(pwd) \
   -G "Unix Makefiles" && \
 
-cmake --build build -- -j && \
+cmake --build build -- -j 8 && \
 cd build && ctest -V 
 
 EXIT_CODE=$?

--- a/.github/pnnl-ci/pnnl.gitlab-ci.yml
+++ b/.github/pnnl-ci/pnnl.gitlab-ci.yml
@@ -52,7 +52,7 @@ variables:
   # We can hard code the SLURM_Q, or have a perl script find any idle partition at runtime.
   # This is a magic string that matches a conditional in the job script
     SLURM_Q: "dl_gpu"
-    SLURM_ARGS: "--ntasks=3 --gres=gpu:1"
+    SLURM_ARGS: "-N 1 --ntasks=8 --gres=gpu:1"
     SCRIPT_NAME: ci.sh
 
 # Generic haero rebuild template


### PR DESCRIPTION
PNNL HPC staff reported 1000 nvcc calls in a recent pipeline, and so instead of the `cmake --build build -- -j` I have updated that command to be limited to 8 cores. Might slow things down a little, but will prevent this job fork bombing any shared nodes...