### PR TITLE
Refactor the main loops within Wet Deposition.

### DIFF
--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -1603,6 +1603,13 @@ void dropmixnuc(
       });                                                 // end k
   team.team_barrier();
   Kokkos::parallel_for(
+      Kokkos::TeamThreadRange(team, 1, pver), KOKKOS_LAMBDA(int k) {
+        EKAT_REQUIRE_MSG(
+            0 < zm(k - 1) - zm(k),
+            "Geopotential height at level should be monotonically decreasing.");
+      });
+
+  Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, top_lev, pver), KOKKOS_LAMBDA(int k) {
         zn(k) = gravity * rpdel[k];
         if (k < pver - 1) {

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -1603,13 +1603,6 @@ void dropmixnuc(
       });                                                 // end k
   team.team_barrier();
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, 1, pver), KOKKOS_LAMBDA(int k) {
-        EKAT_REQUIRE_MSG(
-            0 < zm(k - 1) - zm(k),
-            "Geopotential height at level should be monotonically decreasing.");
-      });
-
-  Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, top_lev, pver), KOKKOS_LAMBDA(int k) {
         zn(k) = gravity * rpdel[k];
         if (k < pver - 1) {

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1437,6 +1437,9 @@ void compute_q_tendencies(
           }
         }
         const int k_p1 = static_cast<int>(haero::min(k + 1, nlev - 1));
+	// OK, this is from the old mam4: Phase 2 is before Phase 1.
+	// Note that the phase loops goes from 2 to 1 in reverse order
+	// and the qqcw_sav is set first in phase 2 the used in phase 1.
         if (lphase == 1) {
           // traces reflects changes from modal_aero_calcsize and is the
           // "most current" q

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1437,9 +1437,9 @@ void compute_q_tendencies(
           }
         }
         const int k_p1 = static_cast<int>(haero::min(k + 1, nlev - 1));
-	// OK, this is from the old mam4: Phase 2 is before Phase 1.
-	// Note that the phase loops goes from 2 to 1 in reverse order
-	// and the qqcw_sav is set first in phase 2 the used in phase 1.
+        // OK, this is from the old mam4: Phase 2 is before Phase 1.
+        // Note that the phase loops goes from 2 to 1 in reverse order
+        // and the qqcw_sav is set first in phase 2 the used in phase 1.
         if (lphase == 1) {
           // traces reflects changes from modal_aero_calcsize and is the
           // "most current" q

--- a/src/validation/wetdep/compute_tendencies.cpp
+++ b/src/validation/wetdep/compute_tendencies.cpp
@@ -106,9 +106,9 @@ void test_compute_tendencies(std::unique_ptr<Ensemble> &ensemble) {
     diagnostics.evaporation_of_falling_precipitation =
         mam4::validation::create_column_view(nlev);
     diagnostics.aerosol_wet_deposition_interstitial =
-        mam4::validation::create_column_view(nlev);
+        mam4::validation::create_column_view(gas_pcnst);
     diagnostics.aerosol_wet_deposition_cloud_water =
-        mam4::validation::create_column_view(nlev);
+        mam4::validation::create_column_view(gas_pcnst);
     for (int i = 0; i < AeroConfig::num_modes(); ++i)
       diagnostics.wet_geometric_mean_diameter_i[i] =
           mam4::validation::create_column_view(nlev);
@@ -133,12 +133,15 @@ void test_compute_tendencies(std::unique_ptr<Ensemble> &ensemble) {
           diagnostics.shallow_convective_detrainment[i] = 0;
           diagnostics.shallow_convective_ratio[i] = 0;
           diagnostics.evaporation_of_falling_precipitation[i] = 0;
-          diagnostics.aerosol_wet_deposition_interstitial[i] = 0;
-          diagnostics.aerosol_wet_deposition_cloud_water[i] = 0;
           for (int j = 0; j < gas_pcnst; ++j) {
             diagnostics.tracer_mixing_ratio(i, j) = 0;
             diagnostics.d_tracer_mixing_ratio_dt(i, j) = 0;
           }
+        });
+    Kokkos::parallel_for(
+        "init_column_views", gas_pcnst, KOKKOS_LAMBDA(int i) {
+          diagnostics.aerosol_wet_deposition_interstitial[i] = 0;
+          diagnostics.aerosol_wet_deposition_cloud_water[i] = 0;
         });
     Kokkos::fence();
     std::vector<Real> temperature_host, pdel_host, pmid_host, cldfrac_host,


### PR DESCRIPTION
Wet deposition has loops within loops within loops
with column levels within species within phase
within modes. Previously I had tried to put the outer loop
to be the levels as this was the approach at the time.
This resulted in awkward code and restrictions
on the number of threads that could be run.

Now the inner loop is over levels with outer loops are over
modes, phases and species.  This requires a lot of parallel_for
loops on teams but since it is all within compute_tendencies
which is already on device, these are not a kernel launches
and should be just as fast as before.