### PR TITLE
Add check to throw on divide by zero.

### DIFF
--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -1603,9 +1603,9 @@ void dropmixnuc(
       });                                                 // end k
   Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, 1, pver), KOKKOS_LAMBDA(int k) {
-        EKAT_KERNEL_ASSERT_MSG(
-            0 < zm(k - 1) - zm(k),
-            "Error: Geopotential height at level should be monotonically decreasing.\n");
+        EKAT_KERNEL_ASSERT_MSG(0 < zm(k - 1) - zm(k),
+                               "Error: Geopotential height at level should be "
+                               "monotonically decreasing.\n");
       });
   team.team_barrier();
   Kokkos::parallel_for(

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -1601,6 +1601,12 @@ void dropmixnuc(
                            raercol_cw[k][nsav].data(),    // inout
                            nsource(k), factnum_k.data()); // inout
       });                                                 // end k
+  Kokkos::parallel_for(
+      Kokkos::TeamThreadRange(team, 1, pver), KOKKOS_LAMBDA(int k) {
+        EKAT_KERNEL_ASSERT_MSG(
+            0 < zm(k - 1) - zm(k),
+            "Error: Geopotential height at level should be monotonically decreasing.\n");
+      });
   team.team_barrier();
   Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, top_lev, pver), KOKKOS_LAMBDA(int k) {


### PR DESCRIPTION
Prints a message about the Geopotential height not being decreasing as the ndrop algorithm divides by the difference in two adjacent levels.