### PR TITLE
`mo_sethet` pt 2 - `sethet`

### DIFF
--- a/src/mam4xx/mo_chm_diags.hpp
+++ b/src/mam4xx/mo_chm_diags.hpp
@@ -2,12 +2,14 @@
 #define MAM4XX_MO_CHM_DIAGS_HPP
 
 #include <haero/math.hpp>
+#include <haero/atmosphere.hpp>
+#include <mam4xx/aero_config.hpp>
+#include <mam4xx/aero_model.hpp>
 #include <mam4xx/gas_chem.hpp>
 #include <mam4xx/mam4_types.hpp>
 #include <mam4xx/utils.hpp>
 
 namespace mam4 {
-
 namespace mo_chm_diags {
 
 using Real = haero::Real;
@@ -25,7 +27,7 @@ constexpr Real rgrav =
     1.0 / 9.80616; // reciprocal of acceleration of gravity ~ m/s^2
 constexpr Real avogadro = haero::Constants::avogadro;
 constexpr int gas_pcnst = gas_chemistry::gas_pcnst;
-constexpr int pcnst = mam4::aero_model::pcnst;
+constexpr int pcnst = aero_model::pcnst;
 // number of vertical levels
 constexpr int pver = mam4::nlev;
 

--- a/src/mam4xx/mo_chm_diags.hpp
+++ b/src/mam4xx/mo_chm_diags.hpp
@@ -24,10 +24,10 @@ constexpr Real rearth = 6.37122e6;
 constexpr Real rgrav =
     1.0 / 9.80616; // reciprocal of acceleration of gravity ~ m/s^2
 constexpr Real avogadro = haero::Constants::avogadro;
-constexpr const int gas_pcnst = gas_chemistry::gas_pcnst;
-constexpr const int pcnst = mam4::modal_aer_opt::pcnst;
+constexpr int gas_pcnst = gas_chemistry::gas_pcnst;
+constexpr int pcnst = mam4::aero_model::pcnst;
 // number of vertical levels
-constexpr const int pver = mam4::nlev;
+constexpr int pver = mam4::nlev;
 
 KOKKOS_INLINE_FUNCTION
 void het_diags(

--- a/src/mam4xx/mo_chm_diags.hpp
+++ b/src/mam4xx/mo_chm_diags.hpp
@@ -25,8 +25,7 @@ constexpr Real rgrav =
     1.0 / 9.80616; // reciprocal of acceleration of gravity ~ m/s^2
 constexpr Real avogadro = haero::Constants::avogadro;
 constexpr const int gas_pcnst = gas_chemistry::gas_pcnst;
-constexpr const int pcnst = 80; // FIXME, 80 is the only value I found for this
-                                // in the fortran, but using 41 in the test
+constexpr const int pcnst = mam4::modal_aer_opt::pcnst;
 // number of vertical levels
 constexpr const int pver = mam4::nlev;
 

--- a/src/mam4xx/mo_chm_diags.hpp
+++ b/src/mam4xx/mo_chm_diags.hpp
@@ -1,15 +1,13 @@
 #ifndef MAM4XX_MO_CHM_DIAGS_HPP
 #define MAM4XX_MO_CHM_DIAGS_HPP
 
-#include <haero/atmosphere.hpp>
 #include <haero/math.hpp>
-#include <mam4xx/aero_config.hpp>
-#include <mam4xx/aero_model.hpp>
 #include <mam4xx/gas_chem.hpp>
 #include <mam4xx/mam4_types.hpp>
 #include <mam4xx/utils.hpp>
 
 namespace mam4 {
+
 namespace mo_chm_diags {
 
 using Real = haero::Real;
@@ -26,10 +24,11 @@ constexpr Real rearth = 6.37122e6;
 constexpr Real rgrav =
     1.0 / 9.80616; // reciprocal of acceleration of gravity ~ m/s^2
 constexpr Real avogadro = haero::Constants::avogadro;
-constexpr int gas_pcnst = gas_chemistry::gas_pcnst;
-constexpr int pcnst = aero_model::pcnst;
+constexpr const int gas_pcnst = gas_chemistry::gas_pcnst;
+constexpr const int pcnst = 80; // FIXME, 80 is the only value I found for this
+                                // in the fortran, but using 41 in the test
 // number of vertical levels
-constexpr int pver = mam4::nlev;
+constexpr const int pver = mam4::nlev;
 
 KOKKOS_INLINE_FUNCTION
 void het_diags(

--- a/src/mam4xx/mo_chm_diags.hpp
+++ b/src/mam4xx/mo_chm_diags.hpp
@@ -1,8 +1,8 @@
 #ifndef MAM4XX_MO_CHM_DIAGS_HPP
 #define MAM4XX_MO_CHM_DIAGS_HPP
 
-#include <haero/math.hpp>
 #include <haero/atmosphere.hpp>
+#include <haero/math.hpp>
 #include <mam4xx/aero_config.hpp>
 #include <mam4xx/aero_model.hpp>
 #include <mam4xx/gas_chem.hpp>

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -183,17 +183,17 @@ KOKKOS_INLINE_FUNCTION
 void sethet(
     const ThreadTeam &team,
     const ColumnView
-        het_rates[gas_pcnst],  //[pver][gas_pcnst], rainout rates [1/s] //out
-    const Real rlat,                 // latitude in radians for columns
-    const ColumnView press,          // pressure [pascals] //in
-    const ColumnView zmid,           // midpoint geopot [km]  //in
-    const Real phis,                 // surf geopotential //in
-    const ColumnView tfld,           // temperature [K]  //in
-    const ColumnView cmfdqr,         // dq/dt for convection [kg/kg/s] //in
-    const ColumnView nrain,          // stratoform precip [kg/kg/s] //in
-    const ColumnView nevapr,         // evaporation [kg/kg/s] //in
-    const Real delt,                 // time step [s] //in
-    const ColumnView xhnm,           // total atms density [cm^-3] //in
+        het_rates[gas_pcnst], //[pver][gas_pcnst], rainout rates [1/s] //out
+    const Real rlat,          // latitude in radians for columns
+    const ColumnView press,   // pressure [pascals] //in
+    const ColumnView zmid,    // midpoint geopot [km]  //in
+    const Real phis,          // surf geopotential //in
+    const ColumnView tfld,    // temperature [K]  //in
+    const ColumnView cmfdqr,  // dq/dt for convection [kg/kg/s] //in
+    const ColumnView nrain,   // stratoform precip [kg/kg/s] //in
+    const ColumnView nevapr,  // evaporation [kg/kg/s] //in
+    const Real delt,          // time step [s] //in
+    const ColumnView xhnm,    // total atms density [cm^-3] //in
     const ColumnView qin[gas_pcnst], // xported species [vmr]  //in
     // working variables
     const ColumnView xeqca, // var for gas_washout
@@ -202,24 +202,18 @@ void sethet(
         xgas2, // gas phase species for h2o2 (2) and so2 (3) [molecules/cm^3]
     const ColumnView
         xgas3, // gas phase species for h2o2 (2) and so2 (3) [molecules/cm^3]
-    const ColumnView delz,      // layer depth about interfaces [cm]
-    const ColumnView xh2o2,     // h2o2 concentration [molecules/cm^3]
-    const ColumnView xso2,      // so2 concentration [molecules/cm^3]
-    const ColumnView xliq,      // liquid rain water content in a grid cell [gm/m^3]
-    const ColumnView rain,      // precipitation (rain) rate [molecules/cm^3/s]
+    const ColumnView delz,  // layer depth about interfaces [cm]
+    const ColumnView xh2o2, // h2o2 concentration [molecules/cm^3]
+    const ColumnView xso2,  // so2 concentration [molecules/cm^3]
+    const ColumnView xliq,  // liquid rain water content in a grid cell [gm/m^3]
+    const ColumnView rain,  // precipitation (rain) rate [molecules/cm^3/s]
     const ColumnView precip,    // precipitation rate [kg/kg/s]
     const ColumnView xhen_h2o2, // henry law constants
     const ColumnView xhen_hno3, // henry law constants
     const ColumnView xhen_so2,  // henry law constants
-    const ColumnView tmp_hetrates[gas_pcnst],
-    const int spc_h2o2_ndx,
-    const int spc_so2_ndx,
-    const int h2o2_ndx,
-    const int so2_ndx,
-    const int h2so4_ndx,
-    const int gas_wetdep_cnt,
-    const int wetdep_map[3]) {
-
+    const ColumnView tmp_hetrates[gas_pcnst], const int spc_h2o2_ndx,
+    const int spc_so2_ndx, const int h2o2_ndx, const int so2_ndx,
+    const int h2so4_ndx, const int gas_wetdep_cnt, const int wetdep_map[3]) {
 
   //-----------------------------------------------------------------------
   //       ... compute rainout loss rates (1/s)
@@ -245,12 +239,12 @@ void sethet(
   Real m3_2_cm3 = 1.0e6;            // convert m^3 to cm^3
   Real MISSING = -999999.0;
   Real large_value_lifetime = 1.0e29; // a large lifetime value if no washout
-  //Real gas_wetdep_cnt = mam4::modal_aer_opt::gas_pcnst;
+  // Real gas_wetdep_cnt = mam4::modal_aer_opt::gas_pcnst;
 
   // character(len=3) :: hetratestrg
   // int icol, kk, kk2  // indicies
   // int mm, mm2        // indicies
-  int ktop; // tropopause level, 100mb for lat < 60 and 300mb for lat > 60
+  int ktop;  // tropopause level, 100mb for lat < 60 and 300mb for lat > 60
   Real xkgm; // mass flux on rain drop
   Real stay; // fraction of layer traversed by falling drop in timestep delt
   Real xdtm; // the traveling time in each dz [s]
@@ -293,13 +287,13 @@ void sethet(
 
   // if ( .not. do_wetdep) return
 
-  for(int mm=0; mm < gas_wetdep_cnt; mm++) {
-      int mm2 = wetdep_map[mm];
-      if ( mm2 > 0 ) {
-        for(int kk = 0; kk < pver; kk++) {
-          het_rates[mm2](kk) = MISSING;
-        }
+  for (int mm = 0; mm < gas_wetdep_cnt; mm++) {
+    int mm2 = wetdep_map[mm];
+    if (mm2 > 0) {
+      for (int kk = 0; kk < pver; kk++) {
+        het_rates[mm2](kk) = MISSING;
       }
+    }
   }
 
   //-----------------------------------------------------------------
@@ -323,7 +317,7 @@ void sethet(
       Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
         rain(kk) = mass_air * precip(kk) * xhnm(kk) / mass_h2o;
         xliq(kk) = precip(kk) * delt * xhnm(kk) / avo * mass_air * m3_2_cm3;
-        xh2o2(kk) = qin[spc_h2o2_ndx](kk) * xhnm(kk); 
+        xh2o2(kk) = qin[spc_h2o2_ndx](kk) * xhnm(kk);
         xso2(kk) = qin[spc_so2_ndx](kk) * xhnm(kk);
       });
 
@@ -467,7 +461,7 @@ void sethet(
   //	... Set rates above tropopause = 0.
   //-----------------------------------------------------------------
 
-  for(int mm=0; mm < gas_wetdep_cnt; mm++) {
+  for (int mm = 0; mm < gas_wetdep_cnt; mm++) {
     int mm2 = wetdep_map[mm];
     for (int kk = 0; kk < ktop; kk++) {
       het_rates[mm2](kk) = 0.0;
@@ -475,15 +469,15 @@ void sethet(
     for (int kk = 0; kk < pver; kk++) {
       if (het_rates[mm2](kk) == MISSING) {
         return; // maybe?
-      } 
+      }
     }
-      //Didn't port
-      // if ( any( het_rates(:ncol,:,mm2) == MISSING) ) then
-      //    write(hetratestrg,'(I3)') mm2
-      //    call endrun('sethet: het_rates (wet dep) not set for het reaction
-      //    number : '//hetratestrg)
-      // endif
-  } 
+    // Didn't port
+    //  if ( any( het_rates(:ncol,:,mm2) == MISSING) ) then
+    //     write(hetratestrg,'(I3)') mm2
+    //     call endrun('sethet: het_rates (wet dep) not set for het reaction
+    //     number : '//hetratestrg)
+    //  endif
+  }
 } // end subroutine sethet
 
 } // namespace mo_sethet

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -87,14 +87,14 @@ void calc_precip_rescale(
 
   if (total_rain <= 0.0) {
     Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
-        precip(kk) = 0.0; // set all levels to zero
-    });
+        Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
+          precip(kk) = 0.0; // set all levels to zero
+        });
   } else {
-     Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
-        precip(kk) = precip(kk) * total_rain / total_pos;
-    });
+    Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
+          precip(kk) = precip(kk) * total_rain / total_pos;
+        });
   }
 
 } // end subroutine calc_precip_rescale
@@ -194,9 +194,9 @@ void sethet(
     const ColumnView &xhnm,   // total atms density [cm^-3] //in
     const ColumnView qin[gas_pcnst], // xported species [vmr]  //in
     // working variables
-    const ColumnView &t_factor, // temperature factor to calculate henry's law parameters
-    const ColumnView &xk0_hno3,
-    const ColumnView &xk0_so2,
+    const ColumnView
+        &t_factor, // temperature factor to calculate henry's law parameters
+    const ColumnView &xk0_hno3, const ColumnView &xk0_so2,
     const ColumnView &so2_diss, // so2 dissociation constant
     const ColumnView
         &xgas2, // gas phase species for h2o2 (2) and so2 (3) [molecules/cm^3]
@@ -271,7 +271,7 @@ void sethet(
   // FORTRAN refactor note: current MAM4 only have three species in default:
   // 'H2O2','H2SO4','SO2'.  Options for other species are then removed
   //-----------------------------------------------------------------
-    
+
   for (int mm = 0; mm < gas_pcnst; mm++) {
     for (int kk = 0; kk < pver; kk++) {
       het_rates[mm](kk) = 0.0;
@@ -337,21 +337,21 @@ void sethet(
   //-----------------------------------------------------------------
   Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, ktop, pver), KOKKOS_LAMBDA(int kk) {
-    //-----------------------------------------------------------------
-    // 	... effective henry''s law constants:
-    //	hno3, h2o2  (brasseur et al., 1999)
-    //-----------------------------------------------------------------
-    // temperature factor
-    t_factor(kk) = (t0 - tfld(kk)) / (t0 * tfld(kk));
-    xhen_h2o2(kk) = 7.45e4 * haero::exp(6620.0 * t_factor(kk));
-    // HNO3, for calculation of H2SO4 het rate use
-    xk0_hno3(kk) = 2.1e5 * haero::exp(8700.0 * t_factor(kk));
-    xhen_hno3(kk) = xk0_hno3(kk) * (1.0 + hno3_diss / xph0);
-    // SO2
-    xk0_so2(kk) = 1.23 * haero::exp(3120.0 * t_factor(kk));
-    so2_diss(kk) = 1.23e-2 * haero::exp(1960.0 * t_factor(kk));
-    xhen_so2(kk) = xk0_so2(kk) * (1.0 + so2_diss(kk) / xph0);
-  });
+        //-----------------------------------------------------------------
+        // 	... effective henry''s law constants:
+        //	hno3, h2o2  (brasseur et al., 1999)
+        //-----------------------------------------------------------------
+        // temperature factor
+        t_factor(kk) = (t0 - tfld(kk)) / (t0 * tfld(kk));
+        xhen_h2o2(kk) = 7.45e4 * haero::exp(6620.0 * t_factor(kk));
+        // HNO3, for calculation of H2SO4 het rate use
+        xk0_hno3(kk) = 2.1e5 * haero::exp(8700.0 * t_factor(kk));
+        xhen_hno3(kk) = xk0_hno3(kk) * (1.0 + hno3_diss / xph0);
+        // SO2
+        xk0_so2(kk) = 1.23 * haero::exp(3120.0 * t_factor(kk));
+        so2_diss(kk) = 1.23e-2 * haero::exp(1960.0 * t_factor(kk));
+        xhen_so2(kk) = xk0_so2(kk) * (1.0 + so2_diss(kk) / xph0);
+      });
 
   //-----------------------------------------------------------------
   //       ... part 1, solve for high henry constant ( hno3, h2o2)
@@ -461,7 +461,7 @@ void sethet(
       if (het_rates[mm2](kk) == MISSING) {
         Kokkos::abort(
             "sethet: het_rates (wet dep) not set for het reaction number");
-        return; 
+        return;
       }
     }
     // Didn't port

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -114,13 +114,14 @@ void gas_washout(
   // calculate gas washout by cloud if not saturated
   //------------------------------------------------------------------------
   // FIXME: BAD CONSTANTS
-  Real allca = 0.0; // total of ca between level plev and kk [#/cm3]
-  Real const0 = boltz_cgs * 1.0e-6; // [atmospheres/deg k/cm^3]
-  Real geo_fac = 6.0; // geometry factor (surf area/volume = geo_fac/diameter)
-  Real xrm = .189;    // mean diameter of rain drop [cm]
-  Real xum = 748.0;   // mean rain drop terminal velocity [cm/s]
-  Real xeqca = 0.0;
-  Real xca = 0.0;
+  constexpr Real allca = 0.0; // total of ca between level plev and kk [#/cm3]
+  constexpr Real const0 = boltz_cgs * 1.0e-6; // [atmospheres/deg k/cm^3]
+  constexpr Real geo_fac =
+      6.0; // geometry factor (surf area/volume = geo_fac/diameter)
+  constexpr Real xrm = .189;  // mean diameter of rain drop [cm]
+  constexpr Real xum = 748.0; // mean rain drop terminal velocity [cm/s]
+  constexpr Real xeqca = 0.0;
+  constexpr Real xca = 0.0;
 
   // -----------------------------------------------------------------
   //       ... calculate the saturation concentration eqca
@@ -222,23 +223,24 @@ void sethet(
   //-----------------------------------------------------------------------
   //       ... local variables       //FIXME: BAD CONSTANT
   //-----------------------------------------------------------------------
-  Real xrm = .189;                  // mean diameter of rain drop [cm]
-  Real xum = 748.0;                 // mean rain drop terminal velocity [cm/s]
-  Real xvv = 6.18e-2;               // kinetic viscosity [cm^2/s]
-  Real xdg = .112;                  // mass transport coefficient [cm/s]
-  Real t0 = 298.0;                  // reference temperature [K]
-  Real xph0 = 1.0e-5;               // cloud [h+]
-  Real satf_hno3 = .016;            // saturation factor for hno3 in clouds
-  Real satf_h2o2 = .016;            // saturation factor for h2o2 in clouds
-  Real satf_so2 = .016;             // saturation factor for so2 in clouds
-  Real const0 = boltz_cgs * 1.0e-6; // [atmospheres/deg k/cm^3]
-  Real hno3_diss = 15.4;            // hno3 dissociation constant
-  Real mass_air = 29.0;             // mass of background atmosphere [amu]
-  Real km2cm = 1.0e5;               // convert km to cm
-  Real m2km = 1.0e-3;               // convert m to km
-  Real m3_2_cm3 = 1.0e6;            // convert m^3 to cm^3
-  Real MISSING = -999999.0;
-  Real large_value_lifetime = 1.0e29; // a large lifetime value if no washout
+  constexpr Real xrm = .189;       // mean diameter of rain drop [cm]
+  constexpr Real xum = 748.0;      // mean rain drop terminal velocity [cm/s]
+  constexpr Real xvv = 6.18e-2;    // kinetic viscosity [cm^2/s]
+  constexpr Real xdg = .112;       // mass transport coefficient [cm/s]
+  constexpr Real t0 = 298.0;       // reference temperature [K]
+  constexpr Real xph0 = 1.0e-5;    // cloud [h+]
+  constexpr Real satf_hno3 = .016; // saturation factor for hno3 in clouds
+  constexpr Real satf_h2o2 = .016; // saturation factor for h2o2 in clouds
+  constexpr Real satf_so2 = .016;  // saturation factor for so2 in clouds
+  constexpr Real const0 = boltz_cgs * 1.0e-6; // [atmospheres/deg k/cm^3]
+  constexpr Real hno3_diss = 15.4;            // hno3 dissociation constant
+  constexpr Real mass_air = 29.0;  // mass of background atmosphere [amu]
+  constexpr Real km2cm = 1.0e5;    // convert km to cm
+  constexpr Real m2km = 1.0e-3;    // convert m to km
+  constexpr Real m3_2_cm3 = 1.0e6; // convert m^3 to cm^3
+  constexpr Real MISSING = -999999.0;
+  constexpr Real large_value_lifetime =
+      1.0e29; // a large lifetime value if no washout
 
   int ktop;  // tropopause level, 100mb for lat < 60 and 300mb for lat > 60
   Real xkgm; // mass flux on rain drop
@@ -278,8 +280,6 @@ void sethet(
       tmp_hetrates[mm](kk) = 0.0; // initiate temporary array
     }
   }
-
-  // if ( .not. do_wetdep) return
 
   for (int mm = 0; mm < gas_wetdep_cnt; mm++) {
     int mm2 = wetdep_map[mm];
@@ -464,12 +464,6 @@ void sethet(
         return;
       }
     }
-    // Didn't port
-    //  if ( any( het_rates(:ncol,:,mm2) == MISSING) ) then
-    //     write(hetratestrg,'(I3)') mm2
-    //     call endrun('sethet: het_rates (wet dep) not set for het reaction
-    //     number : '//hetratestrg)
-    //  endif
   }
 } // end subroutine sethet
 

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -11,12 +11,8 @@ namespace mam4 {
 
 namespace mo_sethet {
 
-// const int ktop = ConvProc::Config::ktop;
 constexpr Real avo = haero::Constants::avogadro;
 const Real pi = haero::Constants::pi;
-// constexpr Real rgrav =
-//   mo_chm_diags::rgrav; // reciprocal of acceleration of gravity ~ m/s^2
-//  reciprocal of gravity
 constexpr Real rga = 1.0 / haero::Constants::gravity;
 constexpr int gas_pcnst = gas_chemistry::gas_pcnst;
 const Real boltz_cgs = haero::Constants::boltzmann * 1.e7; // erg/K
@@ -125,13 +121,13 @@ void gas_washout(
   // -----------------------------------------------------------------
   for (int k = plev; k < pver; k++) {
     xeqca_r = xgas(k) /
-                  (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
-                   xliq_ik * avo2;
+              (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
+              xliq_ik * avo2;
     //-----------------------------------------------------------------
     //       ... calculate ca; inside cloud concentration in  #/cm3(air)
     //-----------------------------------------------------------------
-    xca_r = geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq_ik * cm3_2_m3; 
-
+    xca_r =
+        geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq_ik * cm3_2_m3;
 
     // -----------------------------------------------------------------
     //       ... if is not saturated (take hno3 as an example)
@@ -233,11 +229,7 @@ void sethet(
   Real m3_2_cm3 = 1.0e6;            // convert m^3 to cm^3
   Real MISSING = -999999.0;
   Real large_value_lifetime = 1.0e29; // a large lifetime value if no washout
-  // Real gas_wetdep_cnt = mam4::modal_aer_opt::gas_pcnst;
 
-  // character(len=3) :: hetratestrg
-  // int icol, kk, kk2  // indicies
-  // int mm, mm2        // indicies
   int ktop;  // tropopause level, 100mb for lat < 60 and 300mb for lat > 60
   Real xkgm; // mass flux on rain drop
   Real stay; // fraction of layer traversed by falling drop in timestep delt
@@ -300,7 +292,6 @@ void sethet(
   //	... Find the level index that only calculate het_rates below
   //-----------------------------------------------------------------
   find_ktop(rlat, press, ktop); // populate ktop
-  // ktop_all = minval( ktop(:) )
 
   // this is added to rescale the variable precip (which can only be positive)
   // to the actual vertical integral of positive and negative values.  This
@@ -378,7 +369,7 @@ void sethet(
                   xgas2);                   // inout
       gas_washout(team, kk, xkgm, xliq(kk), // in
                   xhen_so2, tfld, delz,     // in
-                  xgas3); // inout
+                  xgas3);                   // inout
     }
     //-----------------------------------------------------------------
     //       ... calculate the lifetime of washout (second)

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -31,6 +31,14 @@ constexpr Real liter_per_gram = 1.0e-3;
 constexpr Real avo2 =
     avo * liter_per_gram * cm3_2_m3; // [liter/gm/mol*(m/cm)^3]
 
+//FIXME: is this right??
+const int spc_h2o2_ndx = static_cast<int>(mam4::GasId::H2O2);
+const int spc_so2_ndx = static_cast<int>(mam4::GasId::SO2);
+const int h2o2_ndx = static_cast<int>(mam4::GasId::H2O2);
+const int so2_ndx = static_cast<int>(mam4::GasId::SO2);
+const int h2so4_ndx = static_cast<int>(mam4::GasId::H2SO4);
+
+
 using Real = haero::Real;
 using View1D = DeviceType::view_1d<Real>;
 
@@ -236,15 +244,14 @@ void sethet(
   Real km2cm = 1.0e5;               // convert km to cm
   Real m2km = 1.0e-3;               // convert m to km
   Real m3_2_cm3 = 1.0e6;            // convert m^3 to cm^3
-  Real MISSING = -999999.0;
+  //Real MISSING = -999999.0;
   Real large_value_lifetime = 1.0e29; // a large lifetime value if no washout
-  Real gas_wetdep_cnt = mam4::modal_aer_opt::pcnst;
+  //Real gas_wetdep_cnt = mam4::modal_aer_opt::pcnst;
 
   // character(len=3) :: hetratestrg
   // int icol, kk, kk2  // indicies
   // int mm, mm2        // indicies
   int ktop; // tropopause level, 100mb for lat < 60 and 300mb for lat > 60
-  int ktop_all;
   Real xkgm; // mass flux on rain drop
   Real stay; // fraction of layer traversed by falling drop in timestep delt
   Real xdtm; // the traveling time in each dz [s]
@@ -318,7 +325,7 @@ void sethet(
       Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
         rain(kk) = mass_air * precip(kk) * xhnm(kk) / mass_h2o;
         xliq(kk) = precip(kk) * delt * xhnm(kk) / avo * mass_air * m3_2_cm3;
-        xh2o2(kk) = qin[spc_h2o2_ndx](kk) * xhnm(kk);
+        xh2o2(kk) = qin[spc_h2o2_ndx](kk) * xhnm(kk); 
         xso2(kk) = qin[spc_so2_ndx](kk) * xhnm(kk);
       });
 
@@ -460,8 +467,10 @@ void sethet(
     //-----------------------------------------------------------------
     //	... Set rates above tropopause = 0.
     //-----------------------------------------------------------------
+    /*
     for (int mm = 0; mm < gas_wetdep_cnt; mm++) {
-      mm2 = wetdep_map(mm);
+      //FIXME: what is wetdep_map?
+      int mm2 = wetdep_map(mm);
       for (int kk = 0; kk < ktop; kk++) {
         het_rates[mm2](kk) = 0.0;
       }
@@ -477,6 +486,7 @@ void sethet(
       //    call endrun('sethet: het_rates (wet dep) not set for het reaction
       //    number : '//hetratestrg)
       // endif
+      */
     }
 
   } // end subroutine sethet

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -120,8 +120,8 @@ void gas_washout(
   // -----------------------------------------------------------------
   for (int k = plev; k < pver; k++) {
     xeqca = xgas(k) /
-              (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
-              xliq_ik * avo2;
+            (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
+            xliq_ik * avo2;
     //-----------------------------------------------------------------
     //       ... calculate ca; inside cloud concentration in  #/cm3(air)
     //-----------------------------------------------------------------

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -123,7 +123,6 @@ void gas_washout(
   Real xca = 0.0;
   Real allca = 0.0; // total of ca between level plev and kk [#/cm3]
 
-
   // -----------------------------------------------------------------
   //       ... calculate the saturation concentration eqca
   // -----------------------------------------------------------------
@@ -234,11 +233,11 @@ void sethet(
   constexpr Real satf_h2o2 = .016; // saturation factor for h2o2 in clouds
   constexpr Real satf_so2 = .016;  // saturation factor for so2 in clouds
   const Real const0 = boltz_cgs * 1.0e-6; // [atmospheres/deg k/cm^3]
-  constexpr Real hno3_diss = 15.4;            // hno3 dissociation constant
-  constexpr Real mass_air = 29.0;  // mass of background atmosphere [amu]
-  constexpr Real km2cm = 1.0e5;    // convert km to cm
-  constexpr Real m2km = 1.0e-3;    // convert m to km
-  constexpr Real m3_2_cm3 = 1.0e6; // convert m^3 to cm^3
+  constexpr Real hno3_diss = 15.4;        // hno3 dissociation constant
+  constexpr Real mass_air = 29.0;         // mass of background atmosphere [amu]
+  constexpr Real km2cm = 1.0e5;           // convert km to cm
+  constexpr Real m2km = 1.0e-3;           // convert m to km
+  constexpr Real m3_2_cm3 = 1.0e6;        // convert m^3 to cm^3
   constexpr Real MISSING = -999999.0;
   constexpr Real large_value_lifetime =
       1.0e29; // a large lifetime value if no washout

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -60,10 +60,10 @@ void calc_het_rates(const Real satf, // saturation fraction in cloud //in
 //=================================================================================
 KOKKOS_INLINE_FUNCTION
 void calc_precip_rescale(
-    const ColumnView cmfdqr,   // dq/dt for convection [kg/kg/s] //in
-    const ColumnView nrain,    // stratoform precip [kg/kg/s] //in
-    const ColumnView nevapr,   // evaporation [kg/kg/s] // in
-    const ColumnView precip) { // precipitation [kg/kg/s] // out
+    const ColumnView &cmfdqr,   // dq/dt for convection [kg/kg/s] //in
+    const ColumnView &nrain,    // stratoform precip [kg/kg/s] //in
+    const ColumnView &nevapr,   // evaporation [kg/kg/s] // in
+    const ColumnView &precip) { // precipitation [kg/kg/s] // out
   // -----------------------------------------------------------------------
   // calculate precipitation rate at each grid
   // this is added to rescale the variable precip (which can only be positive)
@@ -103,12 +103,12 @@ void gas_washout(
     const int plev,          // calculate from this level below //in
     const Real xkgm,         // mass flux on rain drop //in
     const Real xliq_ik,      // liquid rain water content [gm/m^3] // in
-    const ColumnView xhen_i, // henry's law constant
-    const ColumnView tfld_i, // temperature [K]
-    const ColumnView delz_i, // layer depth about interfaces [cm]  // in
-    const ColumnView xeqca,  // internal variable
-    const ColumnView xca,    // internal variable
-    const ColumnView xgas) { // gas concentration // inout
+    const ColumnView &xhen_i, // henry's law constant
+    const ColumnView &tfld_i, // temperature [K]
+    const ColumnView &delz_i, // layer depth about interfaces [cm]  // in
+    const ColumnView &xeqca,  // internal variable
+    const ColumnView &xca,    // internal variable
+    const ColumnView &xgas) { // gas concentration // inout
   //------------------------------------------------------------------------
   // calculate gas washout by cloud if not saturated
   //------------------------------------------------------------------------
@@ -143,7 +143,7 @@ void gas_washout(
   //           otherwise
   //               hno3(gas)_new = hno3(gas)_old
   //-----------------------------------------------------------------
-  for (int kk = 0; kk < plev; kk++) {
+  for (int kk = plev; kk < pver; kk++) {
     allca += xca(kk);
     if (allca < xeqca(kk)) {
       xgas(kk) = haero::max(xgas(kk) - xca(kk), 0.0);
@@ -155,7 +155,7 @@ void gas_washout(
 KOKKOS_INLINE_FUNCTION
 void find_ktop(
     Real rlat,        // latitude in radians for columns
-    ColumnView press, // pressure [Pa] // in
+    const ColumnView &press, // pressure [Pa] // in
     int &ktop) { // index that only calculate het_rates above this level //out
   //---------------------------------------------------------------------------
   // -------- find the top level that het_rates are set as 0 above it ---------
@@ -185,32 +185,32 @@ void sethet(
     const ColumnView
         het_rates[gas_pcnst], //[pver][gas_pcnst], rainout rates [1/s] //out
     const Real rlat,          // latitude in radians for columns
-    const ColumnView press,   // pressure [pascals] //in
-    const ColumnView zmid,    // midpoint geopot [km]  //in
+    const ColumnView &press,   // pressure [pascals] //in
+    const ColumnView &zmid,    // midpoint geopot [km]  //in
     const Real phis,          // surf geopotential //in
-    const ColumnView tfld,    // temperature [K]  //in
-    const ColumnView cmfdqr,  // dq/dt for convection [kg/kg/s] //in
-    const ColumnView nrain,   // stratoform precip [kg/kg/s] //in
-    const ColumnView nevapr,  // evaporation [kg/kg/s] //in
+    const ColumnView &tfld,    // temperature [K]  //in
+    const ColumnView &cmfdqr,  // dq/dt for convection [kg/kg/s] //in
+    const ColumnView &nrain,   // stratoform precip [kg/kg/s] //in
+    const ColumnView &nevapr,  // evaporation [kg/kg/s] //in
     const Real delt,          // time step [s] //in
-    const ColumnView xhnm,    // total atms density [cm^-3] //in
+    const ColumnView &xhnm,    // total atms density [cm^-3] //in
     const ColumnView qin[gas_pcnst], // xported species [vmr]  //in
     // working variables
-    const ColumnView xeqca, // var for gas_washout
-    const ColumnView xca,   // var for gas_washout
+    const ColumnView &xeqca, // var for gas_washout
+    const ColumnView &xca,   // var for gas_washout
     const ColumnView
-        xgas2, // gas phase species for h2o2 (2) and so2 (3) [molecules/cm^3]
+        &xgas2, // gas phase species for h2o2 (2) and so2 (3) [molecules/cm^3]
     const ColumnView
-        xgas3, // gas phase species for h2o2 (2) and so2 (3) [molecules/cm^3]
-    const ColumnView delz,  // layer depth about interfaces [cm]
-    const ColumnView xh2o2, // h2o2 concentration [molecules/cm^3]
-    const ColumnView xso2,  // so2 concentration [molecules/cm^3]
-    const ColumnView xliq,  // liquid rain water content in a grid cell [gm/m^3]
-    const ColumnView rain,  // precipitation (rain) rate [molecules/cm^3/s]
-    const ColumnView precip,    // precipitation rate [kg/kg/s]
-    const ColumnView xhen_h2o2, // henry law constants
-    const ColumnView xhen_hno3, // henry law constants
-    const ColumnView xhen_so2,  // henry law constants
+        &xgas3, // gas phase species for h2o2 (2) and so2 (3) [molecules/cm^3]
+    const ColumnView &delz,  // layer depth about interfaces [cm]
+    const ColumnView &xh2o2, // h2o2 concentration [molecules/cm^3]
+    const ColumnView &xso2,  // so2 concentration [molecules/cm^3]
+    const ColumnView &xliq,  // liquid rain water content in a grid cell [gm/m^3]
+    const ColumnView &rain,  // precipitation (rain) rate [molecules/cm^3/s]
+    const ColumnView &precip,    // precipitation rate [kg/kg/s]
+    const ColumnView &xhen_h2o2, // henry law constants
+    const ColumnView &xhen_hno3, // henry law constants
+    const ColumnView &xhen_so2,  // henry law constants
     const ColumnView tmp_hetrates[gas_pcnst], const int spc_h2o2_ndx,
     const int spc_so2_ndx, const int h2o2_ndx, const int so2_ndx,
     const int h2so4_ndx, const int gas_wetdep_cnt, const int wetdep_map[3]) {
@@ -434,22 +434,22 @@ void sethet(
       work1 = avo2 * xliq(kk);
       work2 = const0 * tfld(kk);
 
-      if (h2o2_ndx > 0) {
+      if (h2o2_ndx >= 0) {
         calc_het_rates(satf_h2o2, rain(kk), xhen_h2o2(kk), // in
                        tmp_hetrates[1](kk), work1, work2,  // in
                        het_rates[h2o2_ndx](kk));           // out
       }
 
       // if ( prog_modal_aero .and.
-      if (so2_ndx > 0 && h2o2_ndx > 0) {
+      if (so2_ndx >= 0 && h2o2_ndx >= 0) {
         het_rates[so2_ndx](kk) = het_rates[h2o2_ndx](kk);
-      } else if (so2_ndx > 0) {
+      } else if (so2_ndx >= 0) {
         calc_het_rates(satf_so2, rain(kk), xhen_so2(kk),  // in
                        tmp_hetrates[2](kk), work1, work2, // in
                        het_rates[so2_ndx](kk));           // out
       }
 
-      if (h2so4_ndx > 0) {
+      if (h2so4_ndx >= 0) {
         calc_het_rates(satf_hno3, rain(kk), xhen_hno3(kk), // in
                        tmp_hetrates[0](kk), work1, work2,  // in
                        het_rates[h2so4_ndx](kk));          // out

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -100,9 +100,9 @@ void calc_precip_rescale(
 KOKKOS_INLINE_FUNCTION
 void gas_washout(
     const ThreadTeam &team,
-    const int plev,          // calculate from this level below //in
-    const Real xkgm,         // mass flux on rain drop //in
-    const Real xliq_ik,      // liquid rain water content [gm/m^3] // in
+    const int plev,           // calculate from this level below //in
+    const Real xkgm,          // mass flux on rain drop //in
+    const Real xliq_ik,       // liquid rain water content [gm/m^3] // in
     const ColumnView &xhen_i, // henry's law constant
     const ColumnView &tfld_i, // temperature [K]
     const ColumnView &delz_i, // layer depth about interfaces [cm]  // in
@@ -154,7 +154,7 @@ void gas_washout(
 //=================================================================================
 KOKKOS_INLINE_FUNCTION
 void find_ktop(
-    Real rlat,        // latitude in radians for columns
+    Real rlat,               // latitude in radians for columns
     const ColumnView &press, // pressure [Pa] // in
     int &ktop) { // index that only calculate het_rates above this level //out
   //---------------------------------------------------------------------------
@@ -185,15 +185,15 @@ void sethet(
     const ColumnView
         het_rates[gas_pcnst], //[pver][gas_pcnst], rainout rates [1/s] //out
     const Real rlat,          // latitude in radians for columns
-    const ColumnView &press,   // pressure [pascals] //in
-    const ColumnView &zmid,    // midpoint geopot [km]  //in
+    const ColumnView &press,  // pressure [pascals] //in
+    const ColumnView &zmid,   // midpoint geopot [km]  //in
     const Real phis,          // surf geopotential //in
-    const ColumnView &tfld,    // temperature [K]  //in
-    const ColumnView &cmfdqr,  // dq/dt for convection [kg/kg/s] //in
-    const ColumnView &nrain,   // stratoform precip [kg/kg/s] //in
-    const ColumnView &nevapr,  // evaporation [kg/kg/s] //in
+    const ColumnView &tfld,   // temperature [K]  //in
+    const ColumnView &cmfdqr, // dq/dt for convection [kg/kg/s] //in
+    const ColumnView &nrain,  // stratoform precip [kg/kg/s] //in
+    const ColumnView &nevapr, // evaporation [kg/kg/s] //in
     const Real delt,          // time step [s] //in
-    const ColumnView &xhnm,    // total atms density [cm^-3] //in
+    const ColumnView &xhnm,   // total atms density [cm^-3] //in
     const ColumnView qin[gas_pcnst], // xported species [vmr]  //in
     // working variables
     const ColumnView &xeqca, // var for gas_washout
@@ -205,8 +205,8 @@ void sethet(
     const ColumnView &delz,  // layer depth about interfaces [cm]
     const ColumnView &xh2o2, // h2o2 concentration [molecules/cm^3]
     const ColumnView &xso2,  // so2 concentration [molecules/cm^3]
-    const ColumnView &xliq,  // liquid rain water content in a grid cell [gm/m^3]
-    const ColumnView &rain,  // precipitation (rain) rate [molecules/cm^3/s]
+    const ColumnView &xliq, // liquid rain water content in a grid cell [gm/m^3]
+    const ColumnView &rain, // precipitation (rain) rate [molecules/cm^3/s]
     const ColumnView &precip,    // precipitation rate [kg/kg/s]
     const ColumnView &xhen_h2o2, // henry law constants
     const ColumnView &xhen_hno3, // henry law constants

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -112,21 +112,20 @@ void gas_washout(
   Real geo_fac = 6.0; // geometry factor (surf area/volume = geo_fac/diameter)
   Real xrm = .189;    // mean diameter of rain drop [cm]
   Real xum = 748.0;   // mean rain drop terminal velocity [cm/s]
-
-  Real xeqca_r = 0.0;
-  Real xca_r = 0.0;
+  Real xeqca = 0.0;
+  Real xca = 0.0;
 
   // -----------------------------------------------------------------
   //       ... calculate the saturation concentration eqca
   // -----------------------------------------------------------------
   for (int k = plev; k < pver; k++) {
-    xeqca_r = xgas(k) /
+    xeqca = xgas(k) /
               (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
               xliq_ik * avo2;
     //-----------------------------------------------------------------
     //       ... calculate ca; inside cloud concentration in  #/cm3(air)
     //-----------------------------------------------------------------
-    xca_r =
+    xca =
         geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq_ik * cm3_2_m3;
 
     // -----------------------------------------------------------------
@@ -135,9 +134,9 @@ void gas_washout(
     //           otherwise
     //               hno3(gas)_new = hno3(gas)_old
     // -----------------------------------------------------------------
-    allca += xca_r;
-    if (allca < xeqca_r) {
-      xgas(k) = haero::max(xgas(k) - xca_r, 0.0);
+    allca += xca;
+    if (allca < xeqca) {
+      xgas(k) = haero::max(xgas(k) - xca, 0.0);
     }
   }
 

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -18,10 +18,10 @@ const Real pi = haero::Constants::pi;
 //   mo_chm_diags::rgrav; // reciprocal of acceleration of gravity ~ m/s^2
 //   reciprocal of gravity
 constexpr Real rga = mam4::modal_aer_opt::rga;
-constexpr const int pcnst = mam4::aero_model::pcnst;
+constexpr int pcnst = mam4::aero_model::pcnst;
 const Real boltz_cgs = haero::Constants::boltzmann * 1.e7; // erg/K
 // number of vertical levels
-constexpr const int pver = mam4::nlev;
+constexpr int pver = mam4::nlev;
 
 // FIXME: BAD CONSTANT
 // mass of water vapor [amu] //convert to g/mol from kg/mol

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -76,7 +76,7 @@ void calc_precip_rescale(
   total_pos = 0.0;
   // Kokkos::parallel_for(
   //     Kokkos::ThreadVectorRange(team, pver), KOKKOS_LAMBDA(int kk) { //team vector range
-        
+
   //     });
 
   Kokkos::parallel_reduce(
@@ -144,7 +144,7 @@ void gas_washout(
   //       ... calculate the saturation concentration eqca
   //-----------------------------------------------------------------
   Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, plev, pver_loc), [&](int k) { 
+      Kokkos::TeamVectorRange(team, plev, pver_loc), [&](int k) {
         // cal washout below cloud
         xeqca(k) = xgas(k) /
                    (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
@@ -166,14 +166,14 @@ void gas_washout(
   allca(0) = 0.0;
  for (int kk = plev; kk < pver; kk++) {
       Kokkos::single(Kokkos::PerTeam(team),
-                     [=]() { 
+                     [=]() {
             allca(0) += xca(kk);
             if (allca(0) < xeqca(kk)) {
                   xgas(kk) = haero::max(xgas(kk) - xca(kk), 0.0);
             }
     });
- } 
-            
+ }
+
 } // end subroutine gas_washout
 
 //=================================================================================
@@ -222,7 +222,7 @@ void sethet(
     const ColumnView qin[gas_pcnst], // xported species [vmr]  //in
     // working variables
     const ColumnView &xeqca,
-    const ColumnView &xca,   
+    const ColumnView &xca,
     const ColumnView &allca,  //total of ca between level plev and kk [#/cm3]
     const ColumnView
         &t_factor, // temperature factor to calculate henry's law parameters
@@ -314,7 +314,7 @@ void sethet(
   });
 
   //thread ranges are within a team range
-  //team range 
+  //team range
 
   for (int mm = 0; mm < gas_wetdep_cnt; mm++) {  // for w/ teamthreadrange
     int mm2 = wetdep_map[mm];
@@ -465,7 +465,7 @@ void sethet(
 
   for (int kk = ktop; kk < pver; kk++) {
     bool skip = false;
-    Kokkos::printf("kk = %d", kk);
+    // Kokkos::printf("kk = %d", kk);
     Kokkos::parallel_for(Kokkos::TeamVectorRange(team, gas_pcnst_loc),
                          [&](int mm) {
                            if (rain(kk) <= 0.0) {
@@ -474,7 +474,7 @@ void sethet(
                            }
                          });
     if (skip) {
-      Kokkos::printf("skipping");
+      // Kokkos::printf("skipping");
       continue;
     }
 

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -18,7 +18,7 @@ const Real pi = haero::Constants::pi;
 //   mo_chm_diags::rgrav; // reciprocal of acceleration of gravity ~ m/s^2
 //  reciprocal of gravity
 constexpr Real rga = 1.0 / haero::Constants::gravity;
-constexpr int pcnst = mam4::aero_model::pcnst;
+constexpr int gas_pcnst = gas_chemistry::gas_pcnst;
 const Real boltz_cgs = haero::Constants::boltzmann * 1.e7; // erg/K
 // number of vertical levels
 constexpr int pver = mam4::nlev;
@@ -183,7 +183,7 @@ KOKKOS_INLINE_FUNCTION
 void sethet(
     const ThreadTeam &team,
     const ColumnView
-        het_rates[pcnst],  //[pver][pcnst], rainout rates [1/s] //out
+        het_rates[gas_pcnst],  //[pver][gas_pcnst], rainout rates [1/s] //out
     const Real rlat,                 // latitude in radians for columns
     const ColumnView press,          // pressure [pascals] //in
     const ColumnView zmid,           // midpoint geopot [km]  //in
@@ -194,7 +194,7 @@ void sethet(
     const ColumnView nevapr,         // evaporation [kg/kg/s] //in
     const Real delt,                 // time step [s] //in
     const ColumnView xhnm,           // total atms density [cm^-3] //in
-    const ColumnView qin[pcnst], // xported species [vmr]  //in
+    const ColumnView qin[gas_pcnst], // xported species [vmr]  //in
     // working variables
     const ColumnView xeqca, // var for gas_washout
     const ColumnView xca,   // var for gas_washout
@@ -211,7 +211,7 @@ void sethet(
     const ColumnView xhen_h2o2, // henry law constants
     const ColumnView xhen_hno3, // henry law constants
     const ColumnView xhen_so2,  // henry law constants
-    const ColumnView tmp_hetrates[pcnst],
+    const ColumnView tmp_hetrates[gas_pcnst],
     const int spc_h2o2_ndx,
     const int spc_so2_ndx,
     const int h2o2_ndx,
@@ -245,7 +245,7 @@ void sethet(
   Real m3_2_cm3 = 1.0e6;            // convert m^3 to cm^3
   Real MISSING = -999999.0;
   Real large_value_lifetime = 1.0e29; // a large lifetime value if no washout
-  //Real gas_wetdep_cnt = mam4::modal_aer_opt::pcnst;
+  //Real gas_wetdep_cnt = mam4::modal_aer_opt::gas_pcnst;
 
   // character(len=3) :: hetratestrg
   // int icol, kk, kk2  // indicies
@@ -285,7 +285,7 @@ void sethet(
   // 'H2O2','H2SO4','SO2'.  Options for other species are then removed
   //-----------------------------------------------------------------
 
-  for (int mm = 0; mm < pcnst; mm++) {
+  for (int mm = 0; mm < gas_pcnst; mm++) {
     for (int kk = 0; kk < pver; kk++) {
       het_rates[mm](kk) = 0.0;
     }
@@ -365,7 +365,7 @@ void sethet(
     xhen_so2(kk) = xk0 * (1.0 + so2_diss / xph0);
 
     // initiate temporary array
-    for (int mm = 0; mm < pcnst; mm++) {
+    for (int mm = 0; mm < gas_pcnst; mm++) {
       tmp_hetrates[mm](kk) = 0.0;
     }
   }
@@ -408,7 +408,7 @@ void sethet(
     xdtm = delz(kk) / xum; // the traveling time in each dz
 
     xxx2 = (xh2o2(kk) - xgas2(kk));
-    if (xxx2 /= 0.0) { // if no washout lifetime = 1.e29
+    if (xxx2 != 0.0) { // if no washout lifetime = 1.e29
       yh2o2 = xh2o2(kk) / xxx2 * xdtm;
     } else {
       yh2o2 = large_value_lifetime;
@@ -416,7 +416,7 @@ void sethet(
     tmp_hetrates[1](kk) = haero::max(1.0 / yh2o2, 0.0) * stay;
 
     xxx3 = (xso2(kk) - xgas3(kk));
-    if (xxx3 /= 0.0) { // if no washout lifetime = 1.e29
+    if (xxx3 != 0.0) { // if no washout lifetime = 1.e29
       yso2 = xso2(kk) / xxx3 * xdtm;
     } else {
       yso2 = large_value_lifetime;
@@ -429,7 +429,7 @@ void sethet(
   //                   hno3 and h2o2 have both in and under cloud
   //-----------------------------------------------------------------
   for (int kk = ktop; kk < pver; kk++) {
-    for (int mm = 0; mm < pcnst; mm++) {
+    for (int mm = 0; mm < gas_pcnst; mm++) {
       if (rain(kk) <= 0.0) {
         het_rates[mm](kk) = 0.0;
       }

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -176,6 +176,305 @@ void find_ktop(
   } // k_loop
 
 } // end subroutine find_ktop
+
+
+
+KOKKOS_INLINE_FUNCTION
+void sethet(const ThreadTeam &team,
+            const ColumnView het_rates[gas_pcnst], //[pver][gas_pcnst], rainout rates [1/s] //out 
+            Real rlat,                  // latitude in radians for columns
+            ColumnView press,           // pressure [pascals] //in
+            ColumnView zmid,            // midpoint geopot [km]  //in
+            Real phis,                  // surf geopotential //in
+            ColumnView tfld,            // temperature [K]  //in
+            ColumnView cmfdqr,          // dq/dt for convection [kg/kg/s] //in
+            ColumnView nrain,           // stratoform precip [kg/kg/s] //in
+            ColumnView nevapr,          // evaporation [kg/kg/s] //in
+            Real delt,                  // time step [s] //in
+            ColumnView xhnm,            // total atms density [cm^-3] //in
+            ColumnView qin[gas_pcnst],  // xported species [vmr]  //in
+            int lchnk                   // chunk index //in
+            Real rlat                   // latitude in radians for columns
+            ) {
+
+    //-----------------------------------------------------------------------
+    //       ... compute rainout loss rates (1/s)
+    //-----------------------------------------------------------------------
+
+    //-----------------------------------------------------------------------
+    //       ... local variables       //FIXME: BAD CONSTANT
+    //-----------------------------------------------------------------------
+    Real xrm   = .189;             // mean diameter of rain drop [cm]
+    Real xum   = 748.0;             // mean rain drop terminal velocity [cm/s]
+    Real xvv   = 6.18e-2;          // kinetic viscosity [cm^2/s]
+    Real xdg   = .112;             // mass transport coefficient [cm/s]
+    Real t0    = 298.0;             // reference temperature [K]
+    Real xph0  = 1.0e-5;            // cloud [h+]
+    Real satf_hno3  = .016;        // saturation factor for hno3 in clouds
+    Real satf_h2o2  = .016;        // saturation factor for h2o2 in clouds
+    Real satf_so2   = .016;        // saturation factor for so2 in clouds
+    Real const0   = boltz_cgs * 1.0e-6; // [atmospheres/deg k/cm^3]
+    Real hno3_diss = 15.4;         // hno3 dissociation constant
+    Real mass_air = 29.0;           // mass of background atmosphere [amu]
+    Real km2cm    = 1.0e5;          // convert km to cm
+    Real m2km     = 1.0e-3;         // convert m to km
+    Real m3_2_cm3 = 1.0e6;          // convert m^3 to cm^3
+    Real MISSING = -999999.0;
+    Real large_value_lifetime = 1.0e29;  // a large lifetime value if no washout
+    Real gas_wetdep_cnt = pcnst
+
+    character(len=3) :: hetratestrg
+    //int icol, kk, kk2  // indicies
+    //int mm, mm2        // indicies
+    int ktop;     // tropopause level, 100mb for lat < 60 and 300mb for lat > 60
+    int ktop_all;
+    Real xkgm;           // mass flux on rain drop
+    Real stay;           // fraction of layer traversed by falling drop in timestep delt 
+    Real xdtm;           // the traveling time in each dz [s] 
+    Real xxx2, xxx3;     // working variables for h2o2 (2) and so2 (3) 
+    Real yso2, yh2o2;   // washout lifetime [s] 
+    Real work1, work2;   // working variables 
+    Real t_factor;      // temperature factor to calculate henry's law parameters 
+    Real xk0;           // working variable 
+    Real zsurf;         // surface height [km] 
+    Real so2_diss;      //so2 dissociation constant 
+    ColumnView xgas2, xgas3;  // gas phase species for h2o2 (2) and so2 (3) [molecules/cm^3] 
+    ColumnView delz;              // layer depth about interfaces [cm] 
+    ColumnView xh2o2;              // h2o2 concentration [molecules/cm^3] 
+    ColumnView xso2;            // so2 concentration [molecules/cm^3] 
+    ColumnView xliq;            // liquid rain water content in a grid cell [gm/m^3] 
+    ColumnView rain;            // precipitation (rain) rate [molecules/cm^3/s] 
+    ColumnView precip;            // precipitation rate [kg/kg/s] 
+    ColumnView xhen_h2o2, xhen_hno3, xhen_so2;    // henry law constants
+    ColumnView tmp_hetrates[8];
+
+    //-----------------------------------------------------------------
+    //        note: the press array is in pascals and must be
+    //              mutiplied by 10 to yield dynes/cm**2.
+    //-----------------------------------------------------------------
+    //       ... set wet deposition for
+    //           1. h2o2         2. hno3
+    //           3. ch2o         4. ch3ooh
+    //           5. pooh         6. ch3coooh
+    //           7. ho2no2       8. onit
+    //           9. mvk         10. macr
+    //          11. c2h5ooh     12. c3h7ooh
+    //          13. rooh        14. ch3cocho
+    //          15. pb          16. macrooh
+    //          17. xooh        18. onitr
+    //          19. isopooh     20. ch3oh
+    //          21. c2h5oh      22. glyald
+    //          23. hyac        24. hydrald
+    //          25. ch3cho      26. isopno3
+    //-----------------------------------------------------------------
+    // FORTRAN refactor note: current MAM4 only have three species in default:
+    // 'H2O2','H2SO4','SO2'.  Options for other species are then removed
+    //-----------------------------------------------------------------
+
+    for (int mm = 0; mm < gas_pcnst; mm++) {
+      for (int kk = 0; kk < pver; kk++) {
+         het_rates[mm](kk) = 0.0;
+      }
+    }
+
+    //if ( .not. do_wetdep) return
+
+   // is this needed?
+   /*
+    do mm = 1,gas_wetdep_cnt
+       mm2 = wetdep_map(mm)
+       if ( mm2>0 ) then
+          het_rates(:,:,mm2) = MISSING
+       endif
+    enddo
+    */
+
+    //-----------------------------------------------------------------
+    //	... the 2 and .6 multipliers are from a formula by frossling (1938)
+    //-----------------------------------------------------------------
+    xkgm = xdg/xrm * 2.0 + xdg/xrm * .6 * haero::sqrt(xrm * xum / xvv) * haero::pow((xvv/xdg), (1.0/3.0));
+
+    //-----------------------------------------------------------------
+    //	... Find the level index that only calculate het_rates below
+    //-----------------------------------------------------------------
+    find_ktop(rlat, press,   // in
+             ktop); // out
+    //ktop_all = minval( ktop(:) )
+
+    // this is added to rescale the variable precip (which can only be positive)
+    // to the actual vertical integral of positive and negative values.  This
+    // removes point storms
+    calc_precip_rescale(cmfdqr, nrain, nevapr, // in
+                        precip); // out
+
+    Kokkos::parallel_for(
+      Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
+       rain(kk)   = mass_air*precip(kk)*xhnm(kk) / mass_h2o;
+       xliq(kk)   = precip(kk) * delt * xhnm(kk) / avo*mass_air * m3_2_cm3;
+       xh2o2(kk)  = qin(kk)(spc_h2o2_ndx) * xhnm(kk);
+       xso2(kk)  = qin(kk)(spc_so2_ndx) * xhnm(kk);
+    });
+
+    zsurf = m2km * phis * rga;
+    
+    Kokkos::parallel_for(
+      Kokkos::TeamThreadRange(team, ktop, pver-1), KOKKOS_LAMBDA(int kk) {
+         delz(kk) = haero::abs((zmid(kk) - zmid(kk+1))*km2cm);
+    });
+    delz(pver-1) = haero::abs((zmid(pver-1) - zsurf)*km2cm);
+
+    //-----------------------------------------------------------------
+    //       ... part 0b,  for temperature dependent of henrys
+    //                     xxhe1 = henry con for hno3
+    //                     xxhe2 = henry con for h2o2
+    //lwh 10/00 -- take henry''s law constants from brasseur et al. [1999],
+    //             appendix j. for hno3, also consider dissociation to
+    //             get effective henry''s law constant; equilibrium
+    //             constant for dissociation from brasseur et al. [1999],
+    //             appendix k. assume ph=5 (set as xph0 above).
+    //             heff = h*k/[h+] for hno3 (complete dissociation)
+    //             heff = h for h2o2 (no dissociation)
+    //             heff = h * (1 + k/[h+]) (in general)
+    //-----------------------------------------------------------------
+    for (int kk = ktop; kk < pver; kk++) {
+       //-----------------------------------------------------------------
+       // 	... effective henry''s law constants:
+       //	hno3, h2o2  (brasseur et al., 1999)
+       //-----------------------------------------------------------------
+       // temperature factor
+       t_factor = (t0 - tfld(kk))/(t0*tfld(kk));
+       xhen_h2o2(kk) = 7.45e4 * haero::exp( 6620.0 * t_factor);
+       // HNO3, for calculation of H2SO4 het rate use
+       xk0 = 2.1e5 * haero::exp(8700.0*t_factor);
+       xhen_hno3(kk) = xk0 * ( 1.0 + hno3_diss / xph0 );
+       // SO2
+       xk0  = 1.23 * haero::exp(3120.0 * t_factor);
+       so2_diss = 1.23e-2 * haero::exp(1960.0 * t_factor);
+       xhen_so2(kk)   = xk0 * ( 1.0 + so2_diss / xph0 );
+
+       // initiate temporary array
+       for (int mm = 0; mm < gas_pcnst; mm++) {
+         tmp_hetrates[mm](kk) = 0.0;
+       }
+    }
+
+    //-----------------------------------------------------------------
+    //       ... part 1, solve for high henry constant ( hno3, h2o2)
+    //-----------------------------------------------------------------
+    Kokkos::parallel_for(
+      Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
+          xgas2(kk) = xh2o2(kk);                     // different levels wash
+          xgas3(kk) = xso2 (kk);
+      });
+
+    for (int kk = ktop; kk < pver; kk++) {
+      stay = 1.0;
+      if( rain(kk) != 0.0 ) {            // finding rain cloud
+          stay = ((zmid(kk) - zsurf)*km2cm)/(xum*delt);
+          stay = haero::min(stay,1.0);
+          // calculate gas washout by cloud
+          gas_washout(team, kk,  xkgm,   xliq(kk),       // in
+              xhen_h2o2, tfld, delz, // in
+              xgas2);                                           // inout
+          gas_washout(team, kk,  xkgm,   xliq(kk),        // in
+              xhen_so2, tfld, delz,   // in
+              xgas3);                                           // inout
+      }
+      //-----------------------------------------------------------------
+      //       ... calculate the lifetime of washout (second)
+      //             after all layers washout
+      //             the concentration of hno3 is reduced
+      //             then the lifetime xtt is calculated by
+      //
+      //                  xtt = (xhno3(ini) - xgas1(new))/(dt*xhno3(ini))
+      //                  where dt = passing time (s) in vertical
+      //                             path below the cloud
+      //                        dt = dz(cm)/um(cm/s)
+      //-----------------------------------------------------------------
+      xdtm = delz(kk) / xum;                     // the traveling time in each dz
+
+      xxx2 = (xh2o2(kk) - xgas2(kk));
+      if( xxx2 /= 0.0 ) {                       // if no washout lifetime = 1.e29 
+        yh2o2  = xh2o2(kk)/xxx2 * xdtm; 
+      } else {
+        yh2o2  = large_value_lifetime;
+      }
+      tmp_hetrates[1](kk) = max( 1.0 / yh2o2, 0.0 ) * stay;
+      
+      xxx3 = (xso2(kk) - xgas3(kk));
+      if( xxx3 /= 0.0 ) {                       // if no washout lifetime = 1.e29
+          yso2  = xso2(kk)/xxx3 * xdtm; 
+      } else { 
+          yso2  = large_value_lifetime;
+      }
+      tmp_hetrates[2](kk) = max( 1.0 / yso2, 0.0 ) * stay;
+    }
+
+
+    //-----------------------------------------------------------------
+    //       ... part 2, in-cloud solve for low henry constant
+    //                   hno3 and h2o2 have both in and under cloud
+    //-----------------------------------------------------------------
+    for (int kk = ktop; kk < pver; kk++) {
+      for(int mm = 0 mm < gas_pcnst; mm++) {
+        if (rain(kk) <= 0.0) {
+          het_rates[mm](kk) = 0.0;
+      }
+    }
+    
+    for (int kk = ktop; kk < pver; kk++) {
+
+      work1 = avo2 * xliq(kk);
+      work2 = const0 * tfld(kk);
+
+      if( h2o2_ndx > 0 ) {
+          calc_het_rates(satf_h2o2, rain(kk), xhen_h2o2(kk), // in 
+                              tmp_hetrates[1](kk), work1, work2, // in 
+                              het_rates[h2o2_ndx](kk)); // out 
+      }
+
+      //if ( prog_modal_aero .and. 
+      if(so2_ndx>0 && h2o2_ndx>0 ) {
+          het_rates[so2_ndx](kk) = het_rates[h2o2_ndx](kk);
+      } elseif( so2_ndx > 0 ) {
+          calc_het_rates(satf_so2, rain(kk), xhen_so2(kk),  //in
+                    tmp_hetrates[2](kk), work1, work2, // in
+                    het_rates[so2_ndx](kk)); // out
+      }
+
+      if( h2so4_ndx > 0 ) {
+          calc_het_rates(satf_hno3, rain(kk), xhen_hno3(kk), // in
+                    tmp_hetrates[0](kk), work1, work2, // in
+                    het_rates[h2so4_ndx](kk)); // out
+      }
+
+    } 
+
+    //-----------------------------------------------------------------
+    //	... Set rates above tropopause = 0.
+    //-----------------------------------------------------------------
+    for(int mm = 1; mm < gas_wetdep_cnt; mm++) {
+       mm2 = wetdep_map(mm);
+       for(int kk = 0; kk < ktop; kk++) {
+          het_rates[mm2](kk) = 0.0;
+       }
+
+       for(int kk = 0; kk < pver; kk++) {
+          if(het_rates[mm2](kk) == MISSING) {
+            return; //maybe?
+          }
+       } 
+    
+       //if ( any( het_rates(:ncol,:,mm2) == MISSING) ) then
+       //   write(hetratestrg,'(I3)') mm2
+       //   call endrun('sethet: het_rates (wet dep) not set for het reaction number : '//hetratestrg)
+       //endif
+
+    }
+
+} // end subroutine sethet
+
+
 } // namespace mo_sethet
 } // namespace mam4
 #endif

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -356,6 +356,7 @@ void sethet(
         xgas2(kk) = xh2o2(kk); // different levels wash
         xgas3(kk) = xso2(kk);
       });
+  team.team_barrier();
 
   for (int kk = ktop; kk < pver; kk++) {
     stay = 1.0;

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -16,8 +16,8 @@ constexpr Real avo = haero::Constants::avogadro;
 const Real pi = haero::Constants::pi;
 // constexpr Real rgrav =
 //   mo_chm_diags::rgrav; // reciprocal of acceleration of gravity ~ m/s^2
-//   reciprocal of gravity
-constexpr Real rga = mam4::modal_aer_opt::rga;
+//  reciprocal of gravity
+constexpr Real rga = 1.0 / haero::Constants::gravity;
 constexpr int pcnst = mam4::aero_model::pcnst;
 const Real boltz_cgs = haero::Constants::boltzmann * 1.e7; // erg/K
 // number of vertical levels
@@ -184,42 +184,41 @@ void sethet(
     const ThreadTeam &team,
     const ColumnView
         het_rates[pcnst],  //[pver][pcnst], rainout rates [1/s] //out
-    Real rlat,                 // latitude in radians for columns
-    ColumnView press,          // pressure [pascals] //in
-    ColumnView zmid,           // midpoint geopot [km]  //in
-    Real phis,                 // surf geopotential //in
-    ColumnView tfld,           // temperature [K]  //in
-    ColumnView cmfdqr,         // dq/dt for convection [kg/kg/s] //in
-    ColumnView nrain,          // stratoform precip [kg/kg/s] //in
-    ColumnView nevapr,         // evaporation [kg/kg/s] //in
-    Real delt,                 // time step [s] //in
-    ColumnView xhnm,           // total atms density [cm^-3] //in
-    ColumnView qin[pcnst], // xported species [vmr]  //in
-    int lchnk,                 // chunk index //in
+    const Real rlat,                 // latitude in radians for columns
+    const ColumnView press,          // pressure [pascals] //in
+    const ColumnView zmid,           // midpoint geopot [km]  //in
+    const Real phis,                 // surf geopotential //in
+    const ColumnView tfld,           // temperature [K]  //in
+    const ColumnView cmfdqr,         // dq/dt for convection [kg/kg/s] //in
+    const ColumnView nrain,          // stratoform precip [kg/kg/s] //in
+    const ColumnView nevapr,         // evaporation [kg/kg/s] //in
+    const Real delt,                 // time step [s] //in
+    const ColumnView xhnm,           // total atms density [cm^-3] //in
+    const ColumnView qin[pcnst], // xported species [vmr]  //in
     // working variables
-    ColumnView xeqca, // var for gas_washout
-    ColumnView xca,   // var for gas_washout
-    ColumnView
+    const ColumnView xeqca, // var for gas_washout
+    const ColumnView xca,   // var for gas_washout
+    const ColumnView
         xgas2, // gas phase species for h2o2 (2) and so2 (3) [molecules/cm^3]
-    ColumnView
+    const ColumnView
         xgas3, // gas phase species for h2o2 (2) and so2 (3) [molecules/cm^3]
-    ColumnView delz,      // layer depth about interfaces [cm]
-    ColumnView xh2o2,     // h2o2 concentration [molecules/cm^3]
-    ColumnView xso2,      // so2 concentration [molecules/cm^3]
-    ColumnView xliq,      // liquid rain water content in a grid cell [gm/m^3]
-    ColumnView rain,      // precipitation (rain) rate [molecules/cm^3/s]
-    ColumnView precip,    // precipitation rate [kg/kg/s]
-    ColumnView xhen_h2o2, // henry law constants
-    ColumnView xhen_hno3, // henry law constants
-    ColumnView xhen_so2,  // henry law constants
-    ColumnView tmp_hetrates[8],
-    int spc_h2o2_ndx,
-    int spc_so2_ndx,
-    int h2o2_ndx,
-    int so2_ndx,
-    int h2so4_ndx,
-    int gas_wetdep_cnt,
-    int wetdep_map[3]) {
+    const ColumnView delz,      // layer depth about interfaces [cm]
+    const ColumnView xh2o2,     // h2o2 concentration [molecules/cm^3]
+    const ColumnView xso2,      // so2 concentration [molecules/cm^3]
+    const ColumnView xliq,      // liquid rain water content in a grid cell [gm/m^3]
+    const ColumnView rain,      // precipitation (rain) rate [molecules/cm^3/s]
+    const ColumnView precip,    // precipitation rate [kg/kg/s]
+    const ColumnView xhen_h2o2, // henry law constants
+    const ColumnView xhen_hno3, // henry law constants
+    const ColumnView xhen_so2,  // henry law constants
+    const ColumnView tmp_hetrates[pcnst],
+    const int spc_h2o2_ndx,
+    const int spc_so2_ndx,
+    const int h2o2_ndx,
+    const int so2_ndx,
+    const int h2so4_ndx,
+    const int gas_wetdep_cnt,
+    const int wetdep_map[3]) {
 
 
   //-----------------------------------------------------------------------
@@ -414,7 +413,7 @@ void sethet(
     } else {
       yh2o2 = large_value_lifetime;
     }
-    tmp_hetrates[1](kk) = max(1.0 / yh2o2, 0.0) * stay;
+    tmp_hetrates[1](kk) = haero::max(1.0 / yh2o2, 0.0) * stay;
 
     xxx3 = (xso2(kk) - xgas3(kk));
     if (xxx3 /= 0.0) { // if no washout lifetime = 1.e29
@@ -422,7 +421,7 @@ void sethet(
     } else {
       yso2 = large_value_lifetime;
     }
-    tmp_hetrates[2](kk) = max(1.0 / yso2, 0.0) * stay;
+    tmp_hetrates[2](kk) = haero::max(1.0 / yso2, 0.0) * stay;
   }
 
   //-----------------------------------------------------------------

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -74,7 +74,7 @@ void calc_precip_rescale(
   total_rain = 0.0;
   total_pos = 0.0;
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
+      Kokkos::ThreadVectorRange(team, pver), KOKKOS_LAMBDA(int kk) {
         precip(kk) = cmfdqr(kk) + nrain(kk) - nevapr(kk);
       });
 
@@ -87,12 +87,12 @@ void calc_precip_rescale(
 
   if (total_rain <= 0.0) {
     Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
+        Kokkos::ThreadVectorRange(team, pver), KOKKOS_LAMBDA(int kk) {
           precip(kk) = 0.0; // set all levels to zero
         });
   } else {
     Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
+        Kokkos::ThreadVectorRange(team, pver), KOKKOS_LAMBDA(int kk) {
           precip(kk) = precip(kk) * total_rain / total_pos;
         });
   }
@@ -308,7 +308,7 @@ void sethet(
   calc_precip_rescale(team, cmfdqr, nrain, nevapr, precip); // populate precip
 
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
+      Kokkos::ThreadVectorRange(team, pver), KOKKOS_LAMBDA(int kk) {
         rain(kk) = mass_air * precip(kk) * xhnm(kk) / mass_h2o;
         xliq(kk) = precip(kk) * delt * xhnm(kk) / avo * mass_air * m3_2_cm3;
         xh2o2(kk) = qin[spc_h2o2_ndx](kk) * xhnm(kk);
@@ -318,7 +318,7 @@ void sethet(
   zsurf = m2km * phis * rga;
 
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, ktop, pver - 1), KOKKOS_LAMBDA(int kk) {
+      Kokkos::ThreadVectorRange(team, ktop, pver - 1), KOKKOS_LAMBDA(int kk) {
         delz(kk) = haero::abs((zmid(kk) - zmid(kk + 1)) * km2cm);
       });
   delz(pver - 1) = haero::abs((zmid(pver - 1) - zsurf) * km2cm);
@@ -337,7 +337,7 @@ void sethet(
   //             heff = h * (1 + k/[h+]) (in general)
   //-----------------------------------------------------------------
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, ktop, pver), KOKKOS_LAMBDA(int kk) {
+      Kokkos::ThreadVectorRange(team, ktop, pver), KOKKOS_LAMBDA(int kk) {
         //-----------------------------------------------------------------
         // 	... effective henry''s law constants:
         //	hno3, h2o2  (brasseur et al., 1999)
@@ -358,7 +358,7 @@ void sethet(
   //       ... part 1, solve for high henry constant ( hno3, h2o2)
   //-----------------------------------------------------------------
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, pver), KOKKOS_LAMBDA(int kk) {
+      Kokkos::ThreadVectorRange(team, pver), KOKKOS_LAMBDA(int kk) {
         xgas2(kk) = xh2o2(kk); // different levels wash
         xgas3(kk) = xso2(kk);
       });

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -114,14 +114,15 @@ void gas_washout(
   // calculate gas washout by cloud if not saturated
   //------------------------------------------------------------------------
   // FIXME: BAD CONSTANTS
-  constexpr Real allca = 0.0; // total of ca between level plev and kk [#/cm3]
-  constexpr Real const0 = boltz_cgs * 1.0e-6; // [atmospheres/deg k/cm^3]
+  const Real const0 = boltz_cgs * 1.0e-6; // [atmospheres/deg k/cm^3]
   constexpr Real geo_fac =
       6.0; // geometry factor (surf area/volume = geo_fac/diameter)
   constexpr Real xrm = .189;  // mean diameter of rain drop [cm]
   constexpr Real xum = 748.0; // mean rain drop terminal velocity [cm/s]
-  constexpr Real xeqca = 0.0;
-  constexpr Real xca = 0.0;
+  Real xeqca = 0.0;
+  Real xca = 0.0;
+  Real allca = 0.0; // total of ca between level plev and kk [#/cm3]
+
 
   // -----------------------------------------------------------------
   //       ... calculate the saturation concentration eqca
@@ -232,7 +233,7 @@ void sethet(
   constexpr Real satf_hno3 = .016; // saturation factor for hno3 in clouds
   constexpr Real satf_h2o2 = .016; // saturation factor for h2o2 in clouds
   constexpr Real satf_so2 = .016;  // saturation factor for so2 in clouds
-  constexpr Real const0 = boltz_cgs * 1.0e-6; // [atmospheres/deg k/cm^3]
+  const Real const0 = boltz_cgs * 1.0e-6; // [atmospheres/deg k/cm^3]
   constexpr Real hno3_diss = 15.4;            // hno3 dissociation constant
   constexpr Real mass_air = 29.0;  // mass of background atmosphere [amu]
   constexpr Real km2cm = 1.0e5;    // convert km to cm

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -150,16 +150,13 @@ void gas_washout(
         //-----------------------------------------------------------------
         xca(k) = geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq_ik *
                  cm3_2_m3;
+        // Kokkos::printf("xeqca[%d] : %f", k, xeqca(k));
+        // Kokkos::printf("xca[%d] : %f", k, xca(k));
+        Kokkos::printf("hello\n");
       });
   team.team_barrier();
 
-  Kokkos::parallel_reduce(
-    Kokkos::ThreadVectorRange(team, plev, pver_loc),
-    [&](int kk, Real &allca) {
-      allca += xca(kk);
-    },
-    allca);
-    team.team_barrier();
+  // printf("hello\n");
 
   //-----------------------------------------------------------------
   //       ... if is not saturated (take hno3 as an example)
@@ -167,13 +164,12 @@ void gas_washout(
   //           otherwise
   //               hno3(gas)_new = hno3(gas)_old
   //-----------------------------------------------------------------
-  Kokkos::parallel_for(
-        Kokkos::ThreadVectorRange(team, plev, pver_loc), KOKKOS_LAMBDA(int kk) {
-          if (allca < xeqca(kk)) {
+  for(int kk = plev; kk < pver_loc; kk++) {
+      allca += xca(kk);
+      if (allca < xeqca(kk)) {
             xgas(kk) = haero::max(xgas(kk) - xca(kk), 0.0);
-          }
-    });
-    team.team_barrier();
+      }
+  }
 
 } // end subroutine gas_washout
 

--- a/src/validation/mo_sethet/CMakeLists.txt
+++ b/src/validation/mo_sethet/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(sethet_driver
                calc_precip_rescale.cpp
                find_ktop.cpp
                gas_washout.cpp
+               sethet.cpp
                )
 
 target_link_libraries(sethet_driver skywalker;validation;${HAERO_LIBRARIES})
@@ -34,6 +35,7 @@ set(TEST_LIST
     calc_precip_rescale_ts_355
     find_ktop_ts_355
     gas_washout_ts_355
+    sethet_ts_355
     )
 # # matching the tests and errors, just for convenience
 
@@ -43,6 +45,7 @@ set(ERROR_THRESHOLDS
     ${DEFAULT_TOL}
     ${DEFAULT_TOL} # output is an int
     9e-3
+    ${DEFAULT_TOL}
    )
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.

--- a/src/validation/mo_sethet/CMakeLists.txt
+++ b/src/validation/mo_sethet/CMakeLists.txt
@@ -44,7 +44,7 @@ set(ERROR_THRESHOLDS
     9e-8 # calc_het_rates, this is due to using a more specific value for mass_h2o
     ${DEFAULT_TOL} # calc_precip_rescale
     ${DEFAULT_TOL} # find_ktop, output is an int
-    9e-3 # gas_washout
+    9e-7 # gas_washout
     9e-3 # sethet
    )
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)

--- a/src/validation/mo_sethet/CMakeLists.txt
+++ b/src/validation/mo_sethet/CMakeLists.txt
@@ -45,7 +45,7 @@ set(ERROR_THRESHOLDS
     ${DEFAULT_TOL} # calc_precip_rescale
     ${DEFAULT_TOL} # find_ktop, output is an int
     9e-8 # gas_washout
-    9e-6 # sethet
+    9e-8 # sethet
    )
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.

--- a/src/validation/mo_sethet/CMakeLists.txt
+++ b/src/validation/mo_sethet/CMakeLists.txt
@@ -44,7 +44,7 @@ set(ERROR_THRESHOLDS
     9e-8 # calc_het_rates, this is due to using a more specific value for mass_h2o
     ${DEFAULT_TOL} # calc_precip_rescale
     ${DEFAULT_TOL} # find_ktop, output is an int
-    9e-8 # gas_washout
+    9e-3 # gas_washout
     9e-3 # sethet
    )
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)

--- a/src/validation/mo_sethet/CMakeLists.txt
+++ b/src/validation/mo_sethet/CMakeLists.txt
@@ -44,8 +44,8 @@ set(ERROR_THRESHOLDS
     9e-8 # calc_het_rates, this is due to using a more specific value for mass_h2o
     ${DEFAULT_TOL} # calc_precip_rescale
     ${DEFAULT_TOL} # find_ktop, output is an int
-    9e-7 # gas_washout
-    9e-3 # sethet
+    9e-9 # gas_washout
+    9e-9 # sethet
    )
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.

--- a/src/validation/mo_sethet/CMakeLists.txt
+++ b/src/validation/mo_sethet/CMakeLists.txt
@@ -44,8 +44,8 @@ set(ERROR_THRESHOLDS
     9e-8 # calc_het_rates, this is due to using a more specific value for mass_h2o
     ${DEFAULT_TOL} # calc_precip_rescale
     ${DEFAULT_TOL} # find_ktop, output is an int
-    9e-3 # gas_washout
-    9e-2 # sethet
+    9e-8 # gas_washout
+    9e-8 # sethet
    )
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.

--- a/src/validation/mo_sethet/CMakeLists.txt
+++ b/src/validation/mo_sethet/CMakeLists.txt
@@ -28,7 +28,7 @@ foreach(script
     COPYONLY
   )
 endforeach()
-# stand_calc_sum_wght_ts_355
+
 # Run the driver in several configurations to produce datasets.
 set(TEST_LIST
     calc_het_rates_ts_355
@@ -41,11 +41,11 @@ set(TEST_LIST
 
 set(DEFAULT_TOL 1e-13)
 set(ERROR_THRESHOLDS
-    9e-8 #this is due to using a more specific value for mass_h2o
-    ${DEFAULT_TOL}
-    ${DEFAULT_TOL} # output is an int
-    9e-3
-    9e-2 
+    9e-8 # calc_het_rates, this is due to using a more specific value for mass_h2o
+    ${DEFAULT_TOL} # calc_precip_rescale
+    ${DEFAULT_TOL} # find_ktop, output is an int
+    9e-3 # gas_washout
+    9e-2 # sethet
    )
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.

--- a/src/validation/mo_sethet/CMakeLists.txt
+++ b/src/validation/mo_sethet/CMakeLists.txt
@@ -45,7 +45,7 @@ set(ERROR_THRESHOLDS
     ${DEFAULT_TOL}
     ${DEFAULT_TOL} # output is an int
     9e-3
-    ${DEFAULT_TOL}
+    9e-2 
    )
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.

--- a/src/validation/mo_sethet/CMakeLists.txt
+++ b/src/validation/mo_sethet/CMakeLists.txt
@@ -45,7 +45,7 @@ set(ERROR_THRESHOLDS
     ${DEFAULT_TOL} # calc_precip_rescale
     ${DEFAULT_TOL} # find_ktop, output is an int
     9e-8 # gas_washout
-    9e-8 # sethet
+    9e-6 # sethet
    )
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.

--- a/src/validation/mo_sethet/CMakeLists.txt
+++ b/src/validation/mo_sethet/CMakeLists.txt
@@ -45,7 +45,7 @@ set(ERROR_THRESHOLDS
     ${DEFAULT_TOL} # calc_precip_rescale
     ${DEFAULT_TOL} # find_ktop, output is an int
     9e-8 # gas_washout
-    9e-8 # sethet
+    9e-3 # sethet
    )
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.

--- a/src/validation/mo_sethet/calc_precip_rescale.cpp
+++ b/src/validation/mo_sethet/calc_precip_rescale.cpp
@@ -42,9 +42,10 @@ void calc_precip_rescale(Ensemble *ensemble) {
     Kokkos::deep_copy(precip, precip_host);
     // std::vector<Real> precip(pver, zero);
     DeviceType::view_1d<Real> trp_out_val("Return from Device", 1);
+    auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
-        "calc_precip_rescale", 1, KOKKOS_LAMBDA(int i) {
-          calc_precip_rescale(cmfdqr, nrain, nevapr, precip);
+        team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
+          calc_precip_rescale(team, cmfdqr, nrain, nevapr, precip);
         });
 
     Kokkos::deep_copy(precip_host, precip);

--- a/src/validation/mo_sethet/gas_washout.cpp
+++ b/src/validation/mo_sethet/gas_washout.cpp
@@ -42,21 +42,11 @@ void gas_washout(Ensemble *ensemble) {
     Kokkos::deep_copy(delz_i, delz_i_host);
     Kokkos::deep_copy(xgas, xgas_host);
 
-    // initialize internal veriables
-    ColumnView xeqca, xca;
-    std::vector<Real> vector0(pver, 0);
-    auto xeqca_host = View1DHost(vector0.data(), pver);
-    auto xca_host = View1DHost(vector0.data(), pver);
-    xeqca = haero::testing::create_column_view(pver);
-    xca = haero::testing::create_column_view(pver);
-    Kokkos::deep_copy(xeqca, xeqca_host);
-    Kokkos::deep_copy(xca, xca_host);
-
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
           gas_washout(team, plev - 1, xkgm, xliq_ik, xhen_i, tfld_i, delz_i,
-                      xeqca, xca, xgas);
+                      xgas);
         });
 
     Kokkos::deep_copy(xgas_host, xgas);

--- a/src/validation/mo_sethet/gas_washout.cpp
+++ b/src/validation/mo_sethet/gas_washout.cpp
@@ -43,19 +43,22 @@ void gas_washout(Ensemble *ensemble) {
     Kokkos::deep_copy(xgas, xgas_host);
 
     // initialize internal veriables
-    ColumnView xeqca, xca;
+    ColumnView xeqca, xca, allca;
     std::vector<Real> vector0(pver, 0);
     auto xeqca_host = View1DHost(vector0.data(), pver);
     auto xca_host = View1DHost(vector0.data(), pver);
+    auto allca_host = View1DHost("allca_host", 1);
     xeqca = haero::testing::create_column_view(pver);
     xca = haero::testing::create_column_view(pver);
+    allca = haero::testing::create_column_view(1);
     Kokkos::deep_copy(xeqca, xeqca_host);
     Kokkos::deep_copy(xca, xca_host);
+    Kokkos::deep_copy(allca, allca_host);
 
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          gas_washout(team, plev - 1, xkgm, xliq_ik, xhen_i, tfld_i, delz_i, xeqca, xca,
+          gas_washout(team, plev - 1, xkgm, xliq_ik, xhen_i, tfld_i, delz_i, xeqca, xca, allca,
                       xgas);
         });
 

--- a/src/validation/mo_sethet/gas_washout.cpp
+++ b/src/validation/mo_sethet/gas_washout.cpp
@@ -42,10 +42,20 @@ void gas_washout(Ensemble *ensemble) {
     Kokkos::deep_copy(delz_i, delz_i_host);
     Kokkos::deep_copy(xgas, xgas_host);
 
+    // initialize internal veriables
+    ColumnView xeqca, xca;
+    std::vector<Real> vector0(pver, 0);
+    auto xeqca_host = View1DHost(vector0.data(), pver);
+    auto xca_host = View1DHost(vector0.data(), pver);
+    xeqca = haero::testing::create_column_view(pver);
+    xca = haero::testing::create_column_view(pver);
+    Kokkos::deep_copy(xeqca, xeqca_host);
+    Kokkos::deep_copy(xca, xca_host);
+
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          gas_washout(team, plev - 1, xkgm, xliq_ik, xhen_i, tfld_i, delz_i,
+          gas_washout(team, plev - 1, xkgm, xliq_ik, xhen_i, tfld_i, delz_i, xeqca, xca,
                       xgas);
         });
 

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -21,8 +21,8 @@ void sethet(Ensemble *ensemble) {
     constexpr int pver = mam4::nlev;
     constexpr int gas_pcnst = mam4::gas_chemistry::gas_pcnst;
 
-    //non-ColumnView input values
-    //const Real rlat = input.get_array("rlat")[0]; //need
+    // non-ColumnView input values
+    // const Real rlat = input.get_array("rlat")[0]; //need
     const Real rlat = -.2320924702;
     const Real phis = input.get_array("phis")[0];
     const Real delt = input.get_array("delt")[0];
@@ -49,7 +49,7 @@ void sethet(Ensemble *ensemble) {
     const auto xhnm_in = input.get_array("xhnm");
     const auto qin_in = input.get_array("qin");
 
-    //ColumnView input values
+    // ColumnView input values
     ColumnView press, zmid, tfld, cmfdqr, nrain, nevapr, xhnm;
 
     auto press_host = View1DHost((Real *)press_in.data(), pver);
@@ -60,7 +60,6 @@ void sethet(Ensemble *ensemble) {
     auto nevapr_host = View1DHost((Real *)nevapr_in.data(), pver);
     auto xhnm_host = View1DHost((Real *)xhnm_in.data(), pver);
 
-
     press = haero::testing::create_column_view(pver);
     zmid = haero::testing::create_column_view(pver);
     tfld = haero::testing::create_column_view(pver);
@@ -68,7 +67,6 @@ void sethet(Ensemble *ensemble) {
     nrain = haero::testing::create_column_view(pver);
     nevapr = haero::testing::create_column_view(pver);
     xhnm = haero::testing::create_column_view(pver);
-    
 
     Kokkos::deep_copy(press, press_host);
     Kokkos::deep_copy(zmid, zmid_host);
@@ -77,27 +75,25 @@ void sethet(Ensemble *ensemble) {
     Kokkos::deep_copy(nrain, nrain_host);
     Kokkos::deep_copy(nevapr, nevapr_host);
     Kokkos::deep_copy(xhnm, xhnm_host);
-    
 
-
-/*    const auto xeqca_in = input.get_array("xeqca");
-    const auto xca_in = input.get_array("xca");
-    const auto xgas2_in = input.get_array("xgas2");
-    const auto xgas3_in = input.get_array("xgas3");
-    const auto delz_in = input.get_array("delz");
-    const auto xh2o2_in = input.get_array("xh2o2");
-    const auto xso2_in = input.get_array("xso2");
-    const auto xliq_in = input.get_array("xliq");
-    const auto rain_in = input.get_array("rain");
-    const auto precip_in = input.get_array("precip");
-    const auto xhen_h2o2_in = input.get_array("xhen_h2o2");
-    const auto xhen_hno3_in = input.get_array("xhen_hno3");
-    const auto xhen_no2_in = input.get_array("xhen_no2");
-    const auto tmp_hetrates_in = input.get_array("tmp_hetrates");
-*/
-    //working var inputs
+    /*    const auto xeqca_in = input.get_array("xeqca");
+        const auto xca_in = input.get_array("xca");
+        const auto xgas2_in = input.get_array("xgas2");
+        const auto xgas3_in = input.get_array("xgas3");
+        const auto delz_in = input.get_array("delz");
+        const auto xh2o2_in = input.get_array("xh2o2");
+        const auto xso2_in = input.get_array("xso2");
+        const auto xliq_in = input.get_array("xliq");
+        const auto rain_in = input.get_array("rain");
+        const auto precip_in = input.get_array("precip");
+        const auto xhen_h2o2_in = input.get_array("xhen_h2o2");
+        const auto xhen_hno3_in = input.get_array("xhen_hno3");
+        const auto xhen_no2_in = input.get_array("xhen_no2");
+        const auto tmp_hetrates_in = input.get_array("tmp_hetrates");
+    */
+    // working var inputs
     ColumnView xeqca, xca, xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip,
-               xhen_h2o2, xhen_hno3, xhen_so2;
+        xhen_h2o2, xhen_hno3, xhen_so2;
 
     // initialize internal veriables
     std::vector<Real> vector0(pver, 0);
@@ -177,14 +173,15 @@ void sethet(Ensemble *ensemble) {
       Kokkos::deep_copy(qin[mm], qin_host[mm]);
     }
 
-
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          mo_sethet::sethet(team, het_rates, rlat, press, zmid, phis, tfld, cmfdqr, nrain,
-                 nevapr, delt, xhnm, qin, xeqca, xca, xgas2, xgas3, delz, 
-                 xh2o2, xso2, xliq, rain, precip, xhen_h2o2, xhen_hno3, xhen_so2, tmp_hetrates,
-                 spc_h2o2_ndx, spc_so2_ndx, h2o2_ndx, so2_ndx, h2so4_ndx, gas_wetdep_cnt, wetdep_map);
+          mo_sethet::sethet(team, het_rates, rlat, press, zmid, phis, tfld,
+                            cmfdqr, nrain, nevapr, delt, xhnm, qin, xeqca, xca,
+                            xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip,
+                            xhen_h2o2, xhen_hno3, xhen_so2, tmp_hetrates,
+                            spc_h2o2_ndx, spc_so2_ndx, h2o2_ndx, so2_ndx,
+                            h2so4_ndx, gas_wetdep_cnt, wetdep_map);
         });
 
     // transfer data to GPU.

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -1,0 +1,205 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <mam4xx/mam4.hpp>
+
+#include <mam4xx/aero_config.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+using namespace skywalker;
+using namespace mam4;
+using namespace haero;
+using namespace mo_sethet;
+
+void sethet(Ensemble *ensemble) {
+  ensemble->process([=](const Input &input, Output &output) {
+    using View1DHost = typename HostType::view_1d<Real>;
+    using ColumnView = haero::ColumnView;
+    constexpr int pver = mam4::nlev;
+    constexpr int pcnst = mam4::aero_model::pcnst;
+
+    //non-ColumnView input values
+    //const Real rlat = input.get_array("rlat")[0]; //need
+    const Real rlat = -.2320924702;
+    const Real phis = input.get_array("phis")[0];
+    const Real delt = input.get_array("delt")[0];
+
+    const int spc_h2o2_ndx = input.get_array("spc_h2o2_ndx")[0];
+    const int spc_so2_ndx = input.get_array("spc_so2_ndx")[0];
+    const int h2o2_ndx = input.get_array("h2o2_ndx")[0];
+    const int so2_ndx = input.get_array("so2_ndx")[0];
+    const int h2so4_ndx = input.get_array("h2so4_ndx")[0];
+    const int gas_wetdep_cnt = input.get_array("gas_wetdep_cnt")[0];
+
+    int wetdep_map[3];
+    const auto wetdep_map_in = input.get_array("wetdep_map");
+    wetdep_map[0] = wetdep_map_in[0];
+    wetdep_map[1] = wetdep_map_in[1];
+    wetdep_map[2] = wetdep_map_in[2];
+
+    const auto press_in = input.get_array("press");
+    const auto zmid_in = input.get_array("zmid");
+    const auto tfld_in = input.get_array("tfld");
+    const auto cmfdqr_in = input.get_array("cmfdqr");
+    const auto nrain_in = input.get_array("nrain");
+    const auto nevapr_in = input.get_array("nevapr");
+    const auto xhnm_in = input.get_array("xhnm");
+    const auto qin_in = input.get_array("qin");
+
+    //ColumnView input values
+    ColumnView press, zmid, tfld, cmfdqr, nrain, nevapr, xhnm;
+
+    auto press_host = View1DHost((Real *)press_in.data(), pver);
+    auto zmid_host = View1DHost((Real *)zmid_in.data(), pver);
+    auto tfld_host = View1DHost((Real *)tfld_in.data(), pver);
+    auto cmfdqr_host = View1DHost((Real *)cmfdqr_in.data(), pver);
+    auto nrain_host = View1DHost((Real *)nrain_in.data(), pver);
+    auto nevapr_host = View1DHost((Real *)nevapr_in.data(), pver);
+    auto xhnm_host = View1DHost((Real *)xhnm_in.data(), pver);
+
+
+    press = haero::testing::create_column_view(pver);
+    zmid = haero::testing::create_column_view(pver);
+    tfld = haero::testing::create_column_view(pver);
+    cmfdqr = haero::testing::create_column_view(pver);
+    nrain = haero::testing::create_column_view(pver);
+    nevapr = haero::testing::create_column_view(pver);
+    xhnm = haero::testing::create_column_view(pver);
+    
+
+    Kokkos::deep_copy(press, press_host);
+    Kokkos::deep_copy(zmid, zmid_host);
+    Kokkos::deep_copy(tfld, tfld_host);
+    Kokkos::deep_copy(cmfdqr, cmfdqr_host);
+    Kokkos::deep_copy(nrain, nrain_host);
+    Kokkos::deep_copy(nevapr, nevapr_host);
+    Kokkos::deep_copy(xhnm, xhnm_host);
+    
+
+
+/*    const auto xeqca_in = input.get_array("xeqca");
+    const auto xca_in = input.get_array("xca");
+    const auto xgas2_in = input.get_array("xgas2");
+    const auto xgas3_in = input.get_array("xgas3");
+    const auto delz_in = input.get_array("delz");
+    const auto xh2o2_in = input.get_array("xh2o2");
+    const auto xso2_in = input.get_array("xso2");
+    const auto xliq_in = input.get_array("xliq");
+    const auto rain_in = input.get_array("rain");
+    const auto precip_in = input.get_array("precip");
+    const auto xhen_h2o2_in = input.get_array("xhen_h2o2");
+    const auto xhen_hno3_in = input.get_array("xhen_hno3");
+    const auto xhen_no2_in = input.get_array("xhen_no2");
+    const auto tmp_hetrates_in = input.get_array("tmp_hetrates");
+*/
+    //working var inputs
+    ColumnView xeqca, xca, xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip,
+               xhen_h2o2, xhen_hno3, xhen_so2;
+
+    // initialize internal veriables
+    std::vector<Real> vector0(pver, 0);
+    auto xeqca_host = View1DHost(vector0.data(), pver);
+    auto xca_host = View1DHost(vector0.data(), pver);
+    auto xgas2_host = View1DHost(vector0.data(), pver);
+    auto xgas3_host = View1DHost(vector0.data(), pver);
+    auto delz_host = View1DHost(vector0.data(), pver);
+    auto xh2o2_host = View1DHost(vector0.data(), pver);
+    auto xso2_host = View1DHost(vector0.data(), pver);
+    auto xliq_host = View1DHost(vector0.data(), pver);
+    auto rain_host = View1DHost(vector0.data(), pver);
+    auto precip_host = View1DHost(vector0.data(), pver);
+    auto xhen_h2o2_host = View1DHost(vector0.data(), pver);
+    auto xhen_hno3_host = View1DHost(vector0.data(), pver);
+    auto xhen_so2_host = View1DHost(vector0.data(), pver);
+
+    xeqca = haero::testing::create_column_view(pver);
+    xca = haero::testing::create_column_view(pver);
+    xgas2 = haero::testing::create_column_view(pver);
+    xgas3 = haero::testing::create_column_view(pver);
+    delz = haero::testing::create_column_view(pver);
+    xh2o2 = haero::testing::create_column_view(pver);
+    xso2 = haero::testing::create_column_view(pver);
+    xliq = haero::testing::create_column_view(pver);
+    rain = haero::testing::create_column_view(pver);
+    precip = haero::testing::create_column_view(pver);
+    xhen_h2o2 = haero::testing::create_column_view(pver);
+    xhen_hno3 = haero::testing::create_column_view(pver);
+    xhen_so2 = haero::testing::create_column_view(pver);
+
+    Kokkos::deep_copy(xeqca, xeqca_host);
+    Kokkos::deep_copy(xca, xca_host);
+    Kokkos::deep_copy(xgas2, xgas2_host);
+    Kokkos::deep_copy(xgas3, xgas3_host);
+    Kokkos::deep_copy(delz, delz_host);
+    Kokkos::deep_copy(xh2o2, xh2o2_host);
+    Kokkos::deep_copy(xso2, xso2_host);
+    Kokkos::deep_copy(xliq, xliq_host);
+    Kokkos::deep_copy(rain, rain_host);
+    Kokkos::deep_copy(precip, precip_host);
+    Kokkos::deep_copy(xhen_h2o2, xhen_h2o2_host);
+    Kokkos::deep_copy(xhen_hno3, xhen_hno3_host);
+    Kokkos::deep_copy(xhen_so2, xhen_so2_host);
+
+    ColumnView het_rates[pcnst];
+    ColumnView tmp_hetrates[pcnst];
+    ColumnView qin[pcnst];
+    View1DHost het_rates_host[pcnst];
+    View1DHost tmp_hetrates_host[pcnst];
+    View1DHost qin_host[pcnst];
+
+    for (int mm = 0; mm < pcnst; ++mm) {
+      het_rates[mm] = haero::testing::create_column_view(pver);
+      tmp_hetrates[mm] = haero::testing::create_column_view(pver);
+      qin[mm] = haero::testing::create_column_view(pver);
+
+      het_rates_host[mm] = View1DHost("het_rates_host", pver);
+      tmp_hetrates_host[mm] = View1DHost("tmp_hetrates_host", pver);
+      qin_host[mm] = View1DHost("qin_host", pver);
+    }
+
+    int count = 0;
+    for (int mm = 0; mm < pcnst; ++mm) {
+      for (int kk = 0; kk < pver; ++kk) {
+        het_rates_host[mm](kk) = 0.0;
+        tmp_hetrates_host[mm](kk) = 0.0;
+        qin_host[mm](kk) = qin_in[count];
+        count++;
+      }
+    }
+
+    // transfer data to GPU.
+    for (int mm = 0; mm < pcnst; ++mm) {
+      Kokkos::deep_copy(het_rates[mm], het_rates_host[mm]);
+      Kokkos::deep_copy(tmp_hetrates[mm], tmp_hetrates_host[mm]);
+      Kokkos::deep_copy(qin[mm], qin_host[mm]);
+    }
+
+
+    auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
+    Kokkos::parallel_for(
+        team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
+          mo_sethet::sethet(team, het_rates, rlat, press, zmid, phis, tfld, cmfdqr, nrain,
+                 nevapr, delt, xhnm, qin, xeqca, xca, xgas2, xgas3, delz, 
+                 xh2o2, xso2, xliq, rain, precip, xhen_h2o2, xhen_hno3, xhen_so2, tmp_hetrates,
+                 spc_h2o2_ndx, spc_so2_ndx, h2o2_ndx, so2_ndx, h2so4_ndx, gas_wetdep_cnt, wetdep_map);
+        });
+
+    // transfer data to GPU.
+    for (int mm = 0; mm < pcnst; ++mm) {
+      Kokkos::deep_copy(het_rates_host[mm], het_rates[mm]);
+    }
+    std::vector<Real> het_rates_out(pver * pcnst);
+    count = 0;
+    for (int mm = 0; mm < pcnst; ++mm) {
+      for (int kk = 0; kk < pver; ++kk) {
+        het_rates_out[count] = het_rates_host[mm](kk);
+        count++;
+      }
+    }
+
+    output.set("het_rates", het_rates_out);
+  });
+}

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -80,24 +80,6 @@ void sethet(Ensemble *ensemble) {
     ColumnView xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip, xhen_h2o2,
         xhen_hno3, xhen_so2, t_factor, xk0_hno3, xk0_so2, so2_diss;
 
-    // initialize internal veriables
-    std::vector<Real> vector0(pver, 0);
-    auto xgas2_host = View1DHost(vector0.data(), pver);
-    auto xgas3_host = View1DHost(vector0.data(), pver);
-    auto delz_host = View1DHost(vector0.data(), pver);
-    auto xh2o2_host = View1DHost(vector0.data(), pver);
-    auto xso2_host = View1DHost(vector0.data(), pver);
-    auto xliq_host = View1DHost(vector0.data(), pver);
-    auto rain_host = View1DHost(vector0.data(), pver);
-    auto precip_host = View1DHost(vector0.data(), pver);
-    auto xhen_h2o2_host = View1DHost(vector0.data(), pver);
-    auto xhen_hno3_host = View1DHost(vector0.data(), pver);
-    auto xhen_so2_host = View1DHost(vector0.data(), pver);
-    auto t_factor_host = View1DHost(vector0.data(), pver);
-    auto xk0_hno3_host = View1DHost(vector0.data(), pver);
-    auto xk0_so2_host = View1DHost(vector0.data(), pver);
-    auto so2_diss_host = View1DHost(vector0.data(), pver);
-
     xgas2 = haero::testing::create_column_view(pver);
     xgas3 = haero::testing::create_column_view(pver);
     delz = haero::testing::create_column_view(pver);
@@ -114,27 +96,26 @@ void sethet(Ensemble *ensemble) {
     xk0_so2 = haero::testing::create_column_view(pver);
     so2_diss = haero::testing::create_column_view(pver);
 
-    Kokkos::deep_copy(xgas2, xgas2_host);
-    Kokkos::deep_copy(xgas3, xgas3_host);
-    Kokkos::deep_copy(delz, delz_host);
-    Kokkos::deep_copy(xh2o2, xh2o2_host);
-    Kokkos::deep_copy(xso2, xso2_host);
-    Kokkos::deep_copy(xliq, xliq_host);
-    Kokkos::deep_copy(rain, rain_host);
-    Kokkos::deep_copy(precip, precip_host);
-    Kokkos::deep_copy(xhen_h2o2, xhen_h2o2_host);
-    Kokkos::deep_copy(xhen_hno3, xhen_hno3_host);
-    Kokkos::deep_copy(xhen_so2, xhen_so2_host);
-    Kokkos::deep_copy(t_factor, t_factor_host);
-    Kokkos::deep_copy(xk0_hno3, xk0_hno3_host);
-    Kokkos::deep_copy(xk0_so2, xk0_so2_host);
-    Kokkos::deep_copy(so2_diss, so2_diss_host);
+    Kokkos::deep_copy(xgas2, 0.0);
+    Kokkos::deep_copy(xgas3, 0.0);
+    Kokkos::deep_copy(delz, 0.0);
+    Kokkos::deep_copy(xh2o2, 0.0);
+    Kokkos::deep_copy(xso2, 0.0);
+    Kokkos::deep_copy(xliq, 0.0);
+    Kokkos::deep_copy(rain, 0.0);
+    Kokkos::deep_copy(precip, 0.0);
+    Kokkos::deep_copy(xhen_h2o2, 0.0);
+    Kokkos::deep_copy(xhen_hno3, 0.0);
+    Kokkos::deep_copy(xhen_so2, 0.0);
+    Kokkos::deep_copy(t_factor, 0.0);
+    Kokkos::deep_copy(xk0_hno3, 0.0);
+    Kokkos::deep_copy(xk0_so2, 0.0);
+    Kokkos::deep_copy(so2_diss, 0.0);
 
     ColumnView het_rates[gas_pcnst];
     ColumnView tmp_hetrates[gas_pcnst];
     ColumnView qin[gas_pcnst];
     View1DHost het_rates_host[gas_pcnst];
-    View1DHost tmp_hetrates_host[gas_pcnst];
     View1DHost qin_host[gas_pcnst];
 
     for (int mm = 0; mm < gas_pcnst; ++mm) {
@@ -143,15 +124,12 @@ void sethet(Ensemble *ensemble) {
       qin[mm] = haero::testing::create_column_view(pver);
 
       het_rates_host[mm] = View1DHost("het_rates_host", pver);
-      tmp_hetrates_host[mm] = View1DHost("tmp_hetrates_host", pver);
       qin_host[mm] = View1DHost("qin_host", pver);
     }
 
     int count = 0;
     for (int mm = 0; mm < gas_pcnst; ++mm) {
       for (int kk = 0; kk < pver; ++kk) {
-        het_rates_host[mm](kk) = 0.0;
-        tmp_hetrates_host[mm](kk) = 0.0;
         qin_host[mm](kk) = qin_in[count];
         count++;
       }
@@ -159,29 +137,25 @@ void sethet(Ensemble *ensemble) {
 
     // transfer data to GPU.
     for (int mm = 0; mm < gas_pcnst; ++mm) {
-      Kokkos::deep_copy(het_rates[mm], het_rates_host[mm]);
-      Kokkos::deep_copy(tmp_hetrates[mm], tmp_hetrates_host[mm]);
+      Kokkos::deep_copy(het_rates[mm], 0.0);
+      Kokkos::deep_copy(tmp_hetrates[mm], 0.0);
       Kokkos::deep_copy(qin[mm], qin_host[mm]);
     }
 
     // initialize internal veriables
-    ColumnView xeqca, xca, allca;
-    auto xeqca_host = View1DHost(vector0.data(), pver);
-    auto xca_host = View1DHost(vector0.data(), pver);
-    auto allca_host = View1DHost("allca_host", 1);
+    ColumnView xeqca, xca;
+    View1D allca("allca", 1);
     xeqca = haero::testing::create_column_view(pver);
     xca = haero::testing::create_column_view(pver);
-    allca = haero::testing::create_column_view(1);
-    Kokkos::deep_copy(xeqca, xeqca_host);
-    Kokkos::deep_copy(xca, xca_host);
-    Kokkos::deep_copy(allca, allca_host);
+    Kokkos::deep_copy(xeqca, 0.0);
+    Kokkos::deep_copy(xca, 0.0);
 
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
           mo_sethet::sethet(
               team, het_rates, rlat, press, zmid, phis, tfld, cmfdqr, nrain,
-              nevapr, delt, xhnm, qin, xeqca, xca, allca, t_factor, xk0_hno3, 
+              nevapr, delt, xhnm, qin, xeqca, xca, allca, t_factor, xk0_hno3,
               xk0_so2, so2_diss,
               xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip, xhen_h2o2,
               xhen_hno3, xhen_so2, tmp_hetrates, spc_h2o2_ndx, spc_so2_ndx,

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -164,12 +164,25 @@ void sethet(Ensemble *ensemble) {
       Kokkos::deep_copy(qin[mm], qin_host[mm]);
     }
 
+    // initialize internal veriables
+    ColumnView xeqca, xca, allca;
+    auto xeqca_host = View1DHost(vector0.data(), pver);
+    auto xca_host = View1DHost(vector0.data(), pver);
+    auto allca_host = View1DHost("allca_host", 1);
+    xeqca = haero::testing::create_column_view(pver);
+    xca = haero::testing::create_column_view(pver);
+    allca = haero::testing::create_column_view(1);
+    Kokkos::deep_copy(xeqca, xeqca_host);
+    Kokkos::deep_copy(xca, xca_host);
+    Kokkos::deep_copy(allca, allca_host);
+
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
           mo_sethet::sethet(
               team, het_rates, rlat, press, zmid, phis, tfld, cmfdqr, nrain,
-              nevapr, delt, xhnm, qin, t_factor, xk0_hno3, xk0_so2, so2_diss,
+              nevapr, delt, xhnm, qin, xeqca, xca, allca, t_factor, xk0_hno3, 
+              xk0_so2, so2_diss,
               xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip, xhen_h2o2,
               xhen_hno3, xhen_so2, tmp_hetrates, spc_h2o2_ndx, spc_so2_ndx,
               h2o2_ndx, so2_ndx, h2so4_ndx, gas_wetdep_cnt, wetdep_map);

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -67,6 +67,7 @@ void sethet(Ensemble *ensemble) {
     nrain = haero::testing::create_column_view(pver);
     nevapr = haero::testing::create_column_view(pver);
     xhnm = haero::testing::create_column_view(pver);
+    
 
     Kokkos::deep_copy(press, press_host);
     Kokkos::deep_copy(zmid, zmid_host);
@@ -76,9 +77,10 @@ void sethet(Ensemble *ensemble) {
     Kokkos::deep_copy(nevapr, nevapr_host);
     Kokkos::deep_copy(xhnm, xhnm_host);
 
+
     // working var inputs
     ColumnView xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip, xhen_h2o2,
-        xhen_hno3, xhen_so2;
+        xhen_hno3, xhen_so2, t_factor, xk0_hno3, xk0_so2, so2_diss;
 
     // initialize internal veriables
     std::vector<Real> vector0(pver, 0);
@@ -93,6 +95,11 @@ void sethet(Ensemble *ensemble) {
     auto xhen_h2o2_host = View1DHost(vector0.data(), pver);
     auto xhen_hno3_host = View1DHost(vector0.data(), pver);
     auto xhen_so2_host = View1DHost(vector0.data(), pver);
+    auto t_factor_host = View1DHost(vector0.data(), pver);
+    auto xk0_hno3_host = View1DHost(vector0.data(), pver);
+    auto xk0_so2_host = View1DHost(vector0.data(), pver);
+    auto so2_diss_host = View1DHost(vector0.data(), pver);
+    
 
     xgas2 = haero::testing::create_column_view(pver);
     xgas3 = haero::testing::create_column_view(pver);
@@ -105,6 +112,10 @@ void sethet(Ensemble *ensemble) {
     xhen_h2o2 = haero::testing::create_column_view(pver);
     xhen_hno3 = haero::testing::create_column_view(pver);
     xhen_so2 = haero::testing::create_column_view(pver);
+    t_factor = haero::testing::create_column_view(pver);
+    xk0_hno3 = haero::testing::create_column_view(pver);
+    xk0_so2 = haero::testing::create_column_view(pver);
+    so2_diss = haero::testing::create_column_view(pver);
 
     Kokkos::deep_copy(xgas2, xgas2_host);
     Kokkos::deep_copy(xgas3, xgas3_host);
@@ -117,6 +128,10 @@ void sethet(Ensemble *ensemble) {
     Kokkos::deep_copy(xhen_h2o2, xhen_h2o2_host);
     Kokkos::deep_copy(xhen_hno3, xhen_hno3_host);
     Kokkos::deep_copy(xhen_so2, xhen_so2_host);
+    Kokkos::deep_copy(t_factor, t_factor_host);
+    Kokkos::deep_copy(xk0_hno3, xk0_hno3_host);
+    Kokkos::deep_copy(xk0_so2, xk0_so2_host);
+    Kokkos::deep_copy(so2_diss, so2_diss_host);
 
     ColumnView het_rates[gas_pcnst];
     ColumnView tmp_hetrates[gas_pcnst];
@@ -156,7 +171,8 @@ void sethet(Ensemble *ensemble) {
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
           mo_sethet::sethet(team, het_rates, rlat, press, zmid, phis, tfld,
-                            cmfdqr, nrain, nevapr, delt, xhnm, qin, xgas2,
+                            cmfdqr, nrain, nevapr, delt, xhnm, qin, t_factor,
+                            xk0_hno3, xk0_so2, so2_diss, xgas2,
                             xgas3, delz, xh2o2, xso2, xliq, rain, precip,
                             xhen_h2o2, xhen_hno3, xhen_so2, tmp_hetrates,
                             spc_h2o2_ndx, spc_so2_ndx, h2o2_ndx, so2_ndx,

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -67,7 +67,6 @@ void sethet(Ensemble *ensemble) {
     nrain = haero::testing::create_column_view(pver);
     nevapr = haero::testing::create_column_view(pver);
     xhnm = haero::testing::create_column_view(pver);
-    
 
     Kokkos::deep_copy(press, press_host);
     Kokkos::deep_copy(zmid, zmid_host);
@@ -76,7 +75,6 @@ void sethet(Ensemble *ensemble) {
     Kokkos::deep_copy(nrain, nrain_host);
     Kokkos::deep_copy(nevapr, nevapr_host);
     Kokkos::deep_copy(xhnm, xhnm_host);
-
 
     // working var inputs
     ColumnView xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip, xhen_h2o2,
@@ -99,7 +97,6 @@ void sethet(Ensemble *ensemble) {
     auto xk0_hno3_host = View1DHost(vector0.data(), pver);
     auto xk0_so2_host = View1DHost(vector0.data(), pver);
     auto so2_diss_host = View1DHost(vector0.data(), pver);
-    
 
     xgas2 = haero::testing::create_column_view(pver);
     xgas3 = haero::testing::create_column_view(pver);
@@ -170,13 +167,12 @@ void sethet(Ensemble *ensemble) {
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          mo_sethet::sethet(team, het_rates, rlat, press, zmid, phis, tfld,
-                            cmfdqr, nrain, nevapr, delt, xhnm, qin, t_factor,
-                            xk0_hno3, xk0_so2, so2_diss, xgas2,
-                            xgas3, delz, xh2o2, xso2, xliq, rain, precip,
-                            xhen_h2o2, xhen_hno3, xhen_so2, tmp_hetrates,
-                            spc_h2o2_ndx, spc_so2_ndx, h2o2_ndx, so2_ndx,
-                            h2so4_ndx, gas_wetdep_cnt, wetdep_map);
+          mo_sethet::sethet(
+              team, het_rates, rlat, press, zmid, phis, tfld, cmfdqr, nrain,
+              nevapr, delt, xhnm, qin, t_factor, xk0_hno3, xk0_so2, so2_diss,
+              xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip, xhen_h2o2,
+              xhen_hno3, xhen_so2, tmp_hetrates, spc_h2o2_ndx, spc_so2_ndx,
+              h2o2_ndx, so2_ndx, h2so4_ndx, gas_wetdep_cnt, wetdep_map);
         });
 
     // transfer data to GPU.

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -22,8 +22,8 @@ void sethet(Ensemble *ensemble) {
     constexpr int gas_pcnst = mam4::gas_chemistry::gas_pcnst;
 
     // non-ColumnView input values
-    const Real rlat = input.get_array("rlat")[0]; //need
-    //const Real rlat = -.2320924702;
+    const Real rlat = input.get_array("rlat")[0]; // need
+    // const Real rlat = -.2320924702;
     const Real phis = input.get_array("phis")[0];
     const Real delt = input.get_array("delt")[0];
 

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -22,23 +22,23 @@ void sethet(Ensemble *ensemble) {
     constexpr int gas_pcnst = mam4::gas_chemistry::gas_pcnst;
 
     // non-ColumnView input values
-    // const Real rlat = input.get_array("rlat")[0]; //need
-    const Real rlat = -.2320924702;
+    const Real rlat = input.get_array("rlat")[0]; //need
+    //const Real rlat = -.2320924702;
     const Real phis = input.get_array("phis")[0];
     const Real delt = input.get_array("delt")[0];
 
-    const int spc_h2o2_ndx = input.get_array("spc_h2o2_ndx")[0];
-    const int spc_so2_ndx = input.get_array("spc_so2_ndx")[0];
-    const int h2o2_ndx = input.get_array("h2o2_ndx")[0];
-    const int so2_ndx = input.get_array("so2_ndx")[0];
-    const int h2so4_ndx = input.get_array("h2so4_ndx")[0];
+    const int spc_h2o2_ndx = input.get_array("spc_h2o2_ndx")[0] - 1;
+    const int spc_so2_ndx = input.get_array("spc_so2_ndx")[0] - 1;
+    const int h2o2_ndx = input.get_array("h2o2_ndx")[0] - 1;
+    const int so2_ndx = input.get_array("so2_ndx")[0] - 1;
+    const int h2so4_ndx = input.get_array("h2so4_ndx")[0] - 1;
     const int gas_wetdep_cnt = input.get_array("gas_wetdep_cnt")[0];
 
     int wetdep_map[3];
     const auto wetdep_map_in = input.get_array("wetdep_map");
-    wetdep_map[0] = wetdep_map_in[0];
-    wetdep_map[1] = wetdep_map_in[1];
-    wetdep_map[2] = wetdep_map_in[2];
+    wetdep_map[0] = wetdep_map_in[0] - 1;
+    wetdep_map[1] = wetdep_map_in[1] - 1;
+    wetdep_map[2] = wetdep_map_in[2] - 1;
 
     const auto press_in = input.get_array("press");
     const auto zmid_in = input.get_array("zmid");

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -19,7 +19,7 @@ void sethet(Ensemble *ensemble) {
     using View1DHost = typename HostType::view_1d<Real>;
     using ColumnView = haero::ColumnView;
     constexpr int pver = mam4::nlev;
-    constexpr int pcnst = mam4::aero_model::pcnst;
+    constexpr int gas_pcnst = mam4::gas_chemistry::gas_pcnst;
 
     //non-ColumnView input values
     //const Real rlat = input.get_array("rlat")[0]; //need
@@ -143,14 +143,14 @@ void sethet(Ensemble *ensemble) {
     Kokkos::deep_copy(xhen_hno3, xhen_hno3_host);
     Kokkos::deep_copy(xhen_so2, xhen_so2_host);
 
-    ColumnView het_rates[pcnst];
-    ColumnView tmp_hetrates[pcnst];
-    ColumnView qin[pcnst];
-    View1DHost het_rates_host[pcnst];
-    View1DHost tmp_hetrates_host[pcnst];
-    View1DHost qin_host[pcnst];
+    ColumnView het_rates[gas_pcnst];
+    ColumnView tmp_hetrates[gas_pcnst];
+    ColumnView qin[gas_pcnst];
+    View1DHost het_rates_host[gas_pcnst];
+    View1DHost tmp_hetrates_host[gas_pcnst];
+    View1DHost qin_host[gas_pcnst];
 
-    for (int mm = 0; mm < pcnst; ++mm) {
+    for (int mm = 0; mm < gas_pcnst; ++mm) {
       het_rates[mm] = haero::testing::create_column_view(pver);
       tmp_hetrates[mm] = haero::testing::create_column_view(pver);
       qin[mm] = haero::testing::create_column_view(pver);
@@ -161,7 +161,7 @@ void sethet(Ensemble *ensemble) {
     }
 
     int count = 0;
-    for (int mm = 0; mm < pcnst; ++mm) {
+    for (int mm = 0; mm < gas_pcnst; ++mm) {
       for (int kk = 0; kk < pver; ++kk) {
         het_rates_host[mm](kk) = 0.0;
         tmp_hetrates_host[mm](kk) = 0.0;
@@ -171,7 +171,7 @@ void sethet(Ensemble *ensemble) {
     }
 
     // transfer data to GPU.
-    for (int mm = 0; mm < pcnst; ++mm) {
+    for (int mm = 0; mm < gas_pcnst; ++mm) {
       Kokkos::deep_copy(het_rates[mm], het_rates_host[mm]);
       Kokkos::deep_copy(tmp_hetrates[mm], tmp_hetrates_host[mm]);
       Kokkos::deep_copy(qin[mm], qin_host[mm]);
@@ -188,12 +188,12 @@ void sethet(Ensemble *ensemble) {
         });
 
     // transfer data to GPU.
-    for (int mm = 0; mm < pcnst; ++mm) {
+    for (int mm = 0; mm < gas_pcnst; ++mm) {
       Kokkos::deep_copy(het_rates_host[mm], het_rates[mm]);
     }
-    std::vector<Real> het_rates_out(pver * pcnst);
+    std::vector<Real> het_rates_out(pver * gas_pcnst);
     count = 0;
-    for (int mm = 0; mm < pcnst; ++mm) {
+    for (int mm = 0; mm < gas_pcnst; ++mm) {
       for (int kk = 0; kk < pver; ++kk) {
         het_rates_out[count] = het_rates_host[mm](kk);
         count++;

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -76,29 +76,12 @@ void sethet(Ensemble *ensemble) {
     Kokkos::deep_copy(nevapr, nevapr_host);
     Kokkos::deep_copy(xhnm, xhnm_host);
 
-    /*    const auto xeqca_in = input.get_array("xeqca");
-        const auto xca_in = input.get_array("xca");
-        const auto xgas2_in = input.get_array("xgas2");
-        const auto xgas3_in = input.get_array("xgas3");
-        const auto delz_in = input.get_array("delz");
-        const auto xh2o2_in = input.get_array("xh2o2");
-        const auto xso2_in = input.get_array("xso2");
-        const auto xliq_in = input.get_array("xliq");
-        const auto rain_in = input.get_array("rain");
-        const auto precip_in = input.get_array("precip");
-        const auto xhen_h2o2_in = input.get_array("xhen_h2o2");
-        const auto xhen_hno3_in = input.get_array("xhen_hno3");
-        const auto xhen_no2_in = input.get_array("xhen_no2");
-        const auto tmp_hetrates_in = input.get_array("tmp_hetrates");
-    */
     // working var inputs
-    ColumnView xeqca, xca, xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip,
-        xhen_h2o2, xhen_hno3, xhen_so2;
+    ColumnView xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip, xhen_h2o2,
+        xhen_hno3, xhen_so2;
 
     // initialize internal veriables
     std::vector<Real> vector0(pver, 0);
-    auto xeqca_host = View1DHost(vector0.data(), pver);
-    auto xca_host = View1DHost(vector0.data(), pver);
     auto xgas2_host = View1DHost(vector0.data(), pver);
     auto xgas3_host = View1DHost(vector0.data(), pver);
     auto delz_host = View1DHost(vector0.data(), pver);
@@ -111,8 +94,6 @@ void sethet(Ensemble *ensemble) {
     auto xhen_hno3_host = View1DHost(vector0.data(), pver);
     auto xhen_so2_host = View1DHost(vector0.data(), pver);
 
-    xeqca = haero::testing::create_column_view(pver);
-    xca = haero::testing::create_column_view(pver);
     xgas2 = haero::testing::create_column_view(pver);
     xgas3 = haero::testing::create_column_view(pver);
     delz = haero::testing::create_column_view(pver);
@@ -125,8 +106,6 @@ void sethet(Ensemble *ensemble) {
     xhen_hno3 = haero::testing::create_column_view(pver);
     xhen_so2 = haero::testing::create_column_view(pver);
 
-    Kokkos::deep_copy(xeqca, xeqca_host);
-    Kokkos::deep_copy(xca, xca_host);
     Kokkos::deep_copy(xgas2, xgas2_host);
     Kokkos::deep_copy(xgas3, xgas3_host);
     Kokkos::deep_copy(delz, delz_host);
@@ -177,8 +156,8 @@ void sethet(Ensemble *ensemble) {
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
           mo_sethet::sethet(team, het_rates, rlat, press, zmid, phis, tfld,
-                            cmfdqr, nrain, nevapr, delt, xhnm, qin, xeqca, xca,
-                            xgas2, xgas3, delz, xh2o2, xso2, xliq, rain, precip,
+                            cmfdqr, nrain, nevapr, delt, xhnm, qin, xgas2,
+                            xgas3, delz, xh2o2, xso2, xliq, rain, precip,
                             xhen_h2o2, xhen_hno3, xhen_so2, tmp_hetrates,
                             spc_h2o2_ndx, spc_so2_ndx, h2o2_ndx, so2_ndx,
                             h2so4_ndx, gas_wetdep_cnt, wetdep_map);

--- a/src/validation/mo_sethet/sethet_driver.cpp
+++ b/src/validation/mo_sethet/sethet_driver.cpp
@@ -26,6 +26,7 @@ void calc_het_rates(Ensemble *ensemble);
 void calc_precip_rescale(Ensemble *ensemble);
 void find_ktop(Ensemble *ensemble);
 void gas_washout(Ensemble *ensemble);
+void sethet(Ensemble *ensemble);
 
 int main(int argc, char **argv) {
   if (argc == 1) {
@@ -57,6 +58,8 @@ int main(int argc, char **argv) {
       find_ktop(ensemble);
     } else if (func_name == "gas_washout") {
       gas_washout(ensemble);
+    } else if (func_name == "sethet") {
+      sethet(ensemble);
     } else {
       std::cerr << "Error: Function name '" << func_name
                 << "' does not have an implemented test!" << std::endl;


### PR DESCRIPTION
The bulk of the port is there - some resulting questions though:
- what is `wetdep_map`?
- indexes from [`get_spc_ndx` and `get_het_ndx`](https://github.com/eagles-project/e3sm_mam4_refactor/blob/refactor-maint-2.0/components/eam/src/chemistry/mozart/mo_chem_utls.F90) - does that just correlate to [GasId](https://github.com/eagles-project/mam4xx/blob/main/src/mam4xx/aero_modes.hpp#L266)?
- what is necessary in the [last for loop](https://github.com/eagles-project/mam4xx/blob/jaelynlitz/mo_sethet_dev/src/mam4xx/mo_sethet.hpp#L469)? Obviously need to set `het_rates`. Also check for Missing values? Don't need to do the write so don't need `hetratestrg`?
- I see #293 - does `gas_pcnst` == `pcnst` == `gas_wetdep_cnt`? 