### PR TITLE
Trivial change to use aero_model::gas_pcnst.

### DIFF
--- a/src/mam4xx/aero_model.hpp
+++ b/src/mam4xx/aero_model.hpp
@@ -716,10 +716,10 @@ int lptr_nacl_a_amode(const int imode) {
   return lptr_nacl_a_amode[imode];
 }
 
-static constexpr int gas_pcnst = 40;
+static constexpr int pcnst = 40;
 KOKKOS_INLINE_FUNCTION
 int mmtoo_prevap_resusp(const int i) {
-  const int mmtoo_prevap_resusp[gas_pcnst] = {
+  const int mmtoo_prevap_resusp[pcnst] = {
       -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
       -1, 30, 32, 33, 31, 28, 29, 34, -3, 30, 33, 29, 34, -3,
       28, 29, 30, 31, 32, 33, 34, -3, 32, 31, 34, -3};

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -357,13 +357,13 @@ public:
   // This should come from the chemistry model being used and will
   // probably need to be dynamic.  This forces lmassptr_amode to
   // also be dynamic.
-  static constexpr int gas_pcnst = aero_model::gas_pcnst;
+  // static constexpr int gas_pcnst = aero_model::gas_pcnst;
 
   // ====================================================================================
-  // The diagnostic arrays are twice the lengths of ConvProc::gas_pcnst because
-  // cloudborne aerosols are appended after interstitial aerosols both of which
-  // are of length gas_pcnst.
-  static constexpr int pcnst_extd = 2 * gas_pcnst;
+  // The diagnostic arrays are twice the lengths of aero_model::gas_pcnst
+  // because cloudborne aerosols are appended after interstitial aerosols both
+  // of which are of length gas_pcnst.
+  static constexpr int pcnst_extd = 2 * aero_model::gas_pcnst;
 
   // nucleation-specific configuration
   struct Config {
@@ -381,10 +381,10 @@ public:
     int ktop = 47; // BAD_CONSTANT: only true for nlev == 72
     int kbot = mam4::nlev - 1;
     // Flags are defined in "enum ConvProc::species_class".
-    int species_class[ConvProc::gas_pcnst] = {
+    int species_class[aero_model::gas_pcnst] = {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2,
         2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
-    int mmtoo_prevap_resusp[ConvProc::gas_pcnst] = {
+    int mmtoo_prevap_resusp[aero_model::gas_pcnst] = {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, 30, 32, 33, 31, 28, 29, 34, -3, 30, 33, 29, 34, -3,
         28, 29, 30, 31, 32, 33, 34, -3, 32, 31, 34, -3};
@@ -566,7 +566,7 @@ public:
             const Config &convproc_config = Config()) {
     // Set nucleation-specific config parameters.
     config_ = convproc_config;
-    Kokkos::resize(scratch1Dviews[q], config_.nlev * gas_pcnst);
+    Kokkos::resize(scratch1Dviews[q], config_.nlev * aero_model::gas_pcnst);
     Kokkos::resize(scratch1Dviews[mu], config_.nlev);
     Kokkos::resize(scratch1Dviews[md], config_.nlev);
     Kokkos::resize(scratch1Dviews[eudp], config_.nlev);
@@ -598,8 +598,8 @@ public:
     Kokkos::resize(scratch1Dviews[sumprevap_hist], pcnst_extd);
     Kokkos::resize(scratch1Dviews[sumresusp], pcnst_extd);
     Kokkos::resize(scratch1Dviews[sumwetdep], pcnst_extd);
-    Kokkos::resize(scratch1Dviews[dqdt], config_.nlev * ConvProc::gas_pcnst);
-    Kokkos::resize(scratch1Dviews[qnew], config_.nlev * ConvProc::gas_pcnst);
+    Kokkos::resize(scratch1Dviews[dqdt], config_.nlev * aero_model::gas_pcnst);
+    Kokkos::resize(scratch1Dviews[qnew], config_.nlev * aero_model::gas_pcnst);
     Kokkos::resize(scratch1Dviews[dlfdp], config_.nlev);
   } // end(init)
 
@@ -623,7 +623,8 @@ void assign_la_lc(const int imode, const int ispec, int &la, int &lc) {
   // get the index of interstital (la) and cloudborne (lc) aerosols
   // from mode index and species index
   // Cloudborne aerosols are appended after interstitial aerosol array
-  // so lc (cloudborne) is offset from ic (interstitial) by gas_pcnst.
+  // so lc (cloudborne) is offset from ic (interstitial) by
+  // aero_model::gas_pcnst.
   //-----------------------------------------------------------------------
   if (ispec == -1) {
     la = ConvProc::numptr_amode(imode);
@@ -632,7 +633,7 @@ void assign_la_lc(const int imode, const int ispec, int &la, int &lc) {
     la = ConvProc::lmassptr_amode(ispec, imode);
     lc = ConvProc::lmassptrcw_amode(ispec, imode);
   }
-  lc += ConvProc::gas_pcnst;
+  lc += aero_model::gas_pcnst;
 }
 
 // nsrflx is the number of process-specific column tracer tendencies:
@@ -650,7 +651,7 @@ void update_tendency_diagnostics(
     Real sumresusp[ConvProc::pcnst_extd], // INOUT sum (over layers) of dp*dcondt_resusp [kg/kg/s * mb]
     Real sumprevap[ConvProc::pcnst_extd], // INOUT sum (over layers) of dp*dcondt_prevap [kg/kg/s * mb]
     Real sumprevap_hist[ConvProc::pcnst_extd],// INOUT sum (over layers) of dp*dcondt_prevap_hist [kg/kg/s * mb]
-    Real qsrflx[/* ConvProc::gas_pcnst */][nsrflx]) // INOUT process-specific column tracer tendencies [kg/m2/s]
+    Real qsrflx[/* aero_model::gas_pcnst */][nsrflx]) // INOUT process-specific column tracer tendencies [kg/m2/s]
 {
 
   // -----------------------------------------------------------------------
@@ -670,7 +671,7 @@ void update_tendency_diagnostics(
 
   // clang-format on
 
-  EKAT_KERNEL_REQUIRE(ConvProc::gas_pcnst == ncnst);
+  EKAT_KERNEL_REQUIRE(aero_model::gas_pcnst == ncnst);
   const int ntot_amode = AeroConfig::num_modes();
   int la = 0, lc = 0;
   // update diagnostic variables
@@ -976,11 +977,11 @@ template <typename SubView, typename ConstSubView>
 KOKKOS_INLINE_FUNCTION void
 ma_precpprod(const Real rprd, const Real dpdry,
              const bool doconvproc_extd[ConvProc::pcnst_extd],
-             const Real x_ratio, const int species_class[ConvProc::gas_pcnst],
-             const int mmtoo_prevap_resusp[ConvProc::gas_pcnst], Real &pr_flux,
-             Real &pr_flux_tmp, Real &pr_flux_base, ColumnView wd_flux,
-             ConstSubView dcondt_wetdep, SubView dcondt, SubView dcondt_prevap,
-             SubView dcondt_prevap_hist) {
+             const Real x_ratio, const int species_class[aero_model::gas_pcnst],
+             const int mmtoo_prevap_resusp[aero_model::gas_pcnst],
+             Real &pr_flux, Real &pr_flux_tmp, Real &pr_flux_base,
+             ColumnView wd_flux, ConstSubView dcondt_wetdep, SubView dcondt,
+             SubView dcondt_prevap, SubView dcondt_prevap_hist) {
   // clang-format off
   // ------------------------------------------
   //  step 2 in ma_precpevap_convproc: aerosol scavenging from precipitation production
@@ -998,7 +999,7 @@ ma_precpprod(const Real rprd, const Real dpdry,
           spec_class::aerosol    = 2
           spec_class::gas        = 3
           spec_class::other      = 4
-  in  mmtoo_prevap_resusp[ConvProc::gas_pcnst]
+  in  mmtoo_prevap_resusp[aero_model::gas_pcnst]
         pointers for resuspension mmtoo_prevap_resusp values are
            >=0 for aerosol mass species with    coarse mode counterpart
            -2 for aerosol mass species WITHOUT coarse mode counterpart
@@ -1045,7 +1046,7 @@ ma_precpprod(const Real rprd, const Real dpdry,
       const Real dcondt_wdflux = del_wd_flux_evap / dpdry;
 
       // for interstitial icnst2=icnst;  for activated icnst2=icnst-pcnst
-      const int icnst2 = icnst % ConvProc::gas_pcnst;
+      const int icnst2 = icnst % aero_model::gas_pcnst;
 
       // not sure what this mean exactly. Only do it for aerosol mass species
       // (mmtoo>0).  mmtoo<=0 represents aerosol number species
@@ -1078,8 +1079,8 @@ void ma_precpevap_convproc(const int ktop, const int nlev,
                            const Real evapc[/* nlev */],
                            const Real dpdry[/* nlev */],
                            const bool doconvproc_extd[ConvProc::pcnst_extd],
-                           const int species_class[ConvProc::gas_pcnst],
-                           const int mmtoo_prevap_resusp[ConvProc::gas_pcnst],
+                           const int species_class[aero_model::gas_pcnst],
+                           const int mmtoo_prevap_resusp[aero_model::gas_pcnst],
                            ColumnView wd_flux, Kokkos_2D_View dcondt_prevap,
                            Kokkos_2D_View dcondt_prevap_hist,
                            Kokkos_2D_View dcondt) {
@@ -1131,7 +1132,7 @@ void ma_precpevap_convproc(const int ktop, const int nlev,
                                    aerosol    = 2
                                    gas        = 3
                                    other      = 4
-    in  mmtoo_prevap_resusp[ConvProc::gas_pcnst]
+    in  mmtoo_prevap_resusp[aero_model::gas_pcnst]
          pointers for resuspension mmtoo_prevap_resusp values are
             >=0 for aerosol mass species with    coarse mode counterpart
             -2 for aerosol mass species WITHOUT coarse mode counterpart
@@ -1684,7 +1685,7 @@ KOKKOS_INLINE_FUNCTION
 void initialize_tmr_array(
     const int nlev, const int iconvtype,
     const bool doconvproc_extd[ConvProc::pcnst_extd],
-    Kokkos::View<Real * [ConvProc::gas_pcnst], Kokkos::MemoryUnmanaged> q,
+    Kokkos::View<Real * [aero_model::gas_pcnst], Kokkos::MemoryUnmanaged> q,
     Kokkos_2D_View gath, Kokkos_2D_View chat, Kokkos_2D_View conu,
     Kokkos_2D_View cond) {
   // -----------------------------------------------------------------------
@@ -1713,7 +1714,7 @@ void initialize_tmr_array(
   // BAD_CONSTANT - is there a reference for this value?
   const Real small_rel = 1.0e-6;
 
-  const int ncnst = ConvProc::gas_pcnst;
+  const int ncnst = aero_model::gas_pcnst;
   const int pcnst_extd = ConvProc::pcnst_extd;
 
   // initiate variables
@@ -1791,7 +1792,7 @@ void initialize_tmr_array(
 
 // ======================================================================================
 KOKKOS_INLINE_FUNCTION
-void set_cloudborne_vars(const bool doconvproc[ConvProc::gas_pcnst],
+void set_cloudborne_vars(const bool doconvproc[aero_model::gas_pcnst],
                          Real aqfrac[ConvProc::pcnst_extd],
                          bool doconvproc_extd[ConvProc::pcnst_extd]) {
   // -----------------------------------------------------------------------
@@ -1807,7 +1808,7 @@ void set_cloudborne_vars(const bool doconvproc[ConvProc::gas_pcnst],
   [fraction]
   */
   const int pcnst_extd = ConvProc::pcnst_extd;
-  const int gas_pcnst = ConvProc::gas_pcnst;
+  const int gas_pcnst = aero_model::gas_pcnst;
   const int num_modes = AeroConfig::num_modes();
   int la, lc;
 
@@ -1835,9 +1836,9 @@ void set_cloudborne_vars(const bool doconvproc[ConvProc::gas_pcnst],
 // ======================================================================================
 template <typename SubView, typename ConstSubView>
 KOKKOS_INLINE_FUNCTION void
-update_qnew_ptend(const bool dotend[ConvProc::gas_pcnst],
+update_qnew_ptend(const bool dotend[aero_model::gas_pcnst],
                   const bool is_update_ptend, ConstSubView dqdt, const Real dt,
-                  bool ptend_lq[ConvProc::gas_pcnst], SubView ptend_q,
+                  bool ptend_lq[aero_model::gas_pcnst], SubView ptend_q,
                   SubView qnew) {
   // ---------------------------------------------------------------------------------------
   // update qnew, ptend_q and ptend_lq
@@ -1855,11 +1856,11 @@ update_qnew_ptend(const bool dotend[ConvProc::gas_pcnst],
    inout :: qnew[pcnst]    ! Tracer array including moisture [kg/kg]
   */
   // clang-format on 
-  for (int ll = 0; ll < ConvProc::gas_pcnst; ++ll) {
+  for (int ll = 0; ll < aero_model::gas_pcnst; ++ll) {
     // calc new q (after ma_convproc_sh_intr)
     if (dotend[ll]) qnew[ll] = haero::max(0.0, qnew[ll] + dt*dqdt[ll]);
   }
-  for (int ll = 0; ll < ConvProc::gas_pcnst; ++ll) {
+  for (int ll = 0; ll < aero_model::gas_pcnst; ++ll) {
     if (dotend[ll] && is_update_ptend) {
       // add dqdt onto ptend_q and set ptend_lq
       ptend_lq[ll] = true;
@@ -1951,21 +1952,21 @@ void compute_wetdep_tend(
 }
 // ======================================================================================
 KOKKOS_INLINE_FUNCTION
-void assign_dotend(const int species_class[ConvProc::gas_pcnst],
+void assign_dotend(const int species_class[aero_model::gas_pcnst],
                    const bool convproc_do_aer, // true by default
                    const bool convproc_do_gas, // false by default
-                   bool dotend[ConvProc::gas_pcnst]) {
+                   bool dotend[aero_model::gas_pcnst]) {
   // ---------------------------------------------------------------------
   //  assign do-tendency flag from species_class, convproc_do_aer and
   //  convproc_do_gas. convproc_do_aer and convproc_do_gas are assigned in the
   //  beginning of the  module
   // ---------------------------------------------------------------------
   /*
-  in    :: species_class[ConvProc::gas_pcnst]
-  out   :: dotend[ConvProc::gas_pcnst]
+  in    :: species_class[aero_model::gas_pcnst]
+  out   :: dotend[aero_model::gas_pcnst]
   */
   //  turn on/off calculations for aerosols and trace gases
-  for (int ll = 0; ll < ConvProc::gas_pcnst; ++ll) {
+  for (int ll = 0; ll < aero_model::gas_pcnst; ++ll) {
     if (species_class[ll] == ConvProc::species_class::aerosol &&
         convproc_do_aer) {
       dotend[ll] = true;
@@ -2363,22 +2364,21 @@ void compute_updraft_mixing_ratio(
 }
 // ======================================================================================
 template <typename SubView, typename ConstSubView>
-KOKKOS_INLINE_FUNCTION void
-ma_convproc_tend(const Kokkos::View<Real *>
-                     scratch1Dviews[ConvProc::Col1DViewInd::NumScratch],
-                 const int nlev, const ConvProc::convtype convtype,
-                 const Real dt, const Real temperature[/* nlev */],
-                 const Real pmid[/* nlev */], ConstSubView qnew,
-                 const Real du[/* nlev */], const Real eu[/* nlev */],
-                 const Real ed[/* nlev */], const Real dp[/* nlev */],
-                 const Real dpdry[/* nlev */], const int ktop, const int kbot,
-                 const int mmtoo_prevap_resusp[/* ConvProc::gas_pcnst */],
-                 const Real cldfrac[/* nlev */], const Real icwmr[/* nlev */],
-                 const Real rprd[/* nlev */], const Real evapc[/* nlev */],
-                 SubView dqdt, const bool doconvproc[/* ConvProc::gas_pcnst */],
-                 Real qsrflx[/* ConvProc::gas_pcnst */][nsrflx],
-                 const int species_class[/* ConvProc::gas_pcnst */],
-                 Real &xx_mfup_max, Real &xx_wcldbase, int &xx_kcldbase) {
+KOKKOS_INLINE_FUNCTION void ma_convproc_tend(
+    const Kokkos::View<Real *>
+        scratch1Dviews[ConvProc::Col1DViewInd::NumScratch],
+    const int nlev, const ConvProc::convtype convtype, const Real dt,
+    const Real temperature[/* nlev */], const Real pmid[/* nlev */],
+    ConstSubView qnew, const Real du[/* nlev */], const Real eu[/* nlev */],
+    const Real ed[/* nlev */], const Real dp[/* nlev */],
+    const Real dpdry[/* nlev */], const int ktop, const int kbot,
+    const int mmtoo_prevap_resusp[/* aero_model::gas_pcnst */],
+    const Real cldfrac[/* nlev */], const Real icwmr[/* nlev */],
+    const Real rprd[/* nlev */], const Real evapc[/* nlev */], SubView dqdt,
+    const bool doconvproc[/* aero_model::gas_pcnst */],
+    Real qsrflx[/* aero_model::gas_pcnst */][nsrflx],
+    const int species_class[/* aero_model::gas_pcnst */], Real &xx_mfup_max,
+    Real &xx_wcldbase, int &xx_kcldbase) {
   // clang-format off
   /*
   // ----------------------------------------------------------------------- 
@@ -2427,7 +2427,7 @@ ma_convproc_tend(const Kokkos::View<Real *>
    in :: gas_pcnst         ! number of tracers to transport
    in :: dt                ! Model timestep [s]
    in :: temperature[nlev]     ! Temperature [K]
-   in :: qnew[nlev][ConvProc::gas_pcnst]      ! Tracer array including moisture [kg/kg]
+   in :: qnew[nlev][aero_model::gas_pcnst]      ! Tracer array including moisture [kg/kg]
 
    in :: du[nlev]    ! Mass detrain rate from updraft [1/s]
    in :: eu[nlev]    ! Mass entrain rate into updraft [1/s]
@@ -2452,8 +2452,8 @@ ma_convproc_tend(const Kokkos::View<Real *>
    in :: rprd[nlev]     ! Convective precipitation formation rate [kg/kg/s]
    in :: evapc[nlev]    ! Convective precipitation evaporation rate [kg/kg/s]
 
-   out:: dqdt[nlev][ConvProc::gas_pcnst]  ! Tracer tendency array [kg/kg/s]
-   in :: doconvproc[ConvProc::gas_pcnst] ! flag for doing convective transport
+   out:: dqdt[nlev][aero_model::gas_pcnst]  ! Tracer tendency array [kg/kg/s]
+   in :: doconvproc[aero_model::gas_pcnst] ! flag for doing convective transport
    out:: qsrflx[pcnst][nsrflx]
          ! process-specific column tracer tendencies [kg/m2/s]
          !  1 = activation   of interstial to conv-cloudborne
@@ -2475,7 +2475,7 @@ ma_convproc_tend(const Kokkos::View<Real *>
   */
   // clang-format on
   const int pcnst_extd = ConvProc::pcnst_extd;
-  const int pcnst = ConvProc::gas_pcnst;
+  const int pcnst = aero_model::gas_pcnst;
   EKAT_KERNEL_REQUIRE(convtype == ConvProc::Deep || convtype == ConvProc::Uwsh);
   // iconvtype       ! 1=deep, 2=uw shallow
   const int iconvtype = convtype == ConvProc::Deep ? 1 : 2;
@@ -2758,10 +2758,10 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_dp_intr(
     const Real du[/* nlev */], const Real eu[/* nlev */],
     const Real ed[/* nlev */], const Real dp[/* nlev */], const int ktop,
     const int kbot, ConstSubView qnew,
-    const int species_class[/* ConvProc::gas_pcnst */],
-    const int mmtoo_prevap_resusp[/* ConvProc::gas_pcnst */], SubView dqdt,
-    Real qsrflx[/* ConvProc::gas_pcnst */][nsrflx],
-    bool dotend[ConvProc::gas_pcnst]) {
+    const int species_class[/* aero_model::gas_pcnst */],
+    const int mmtoo_prevap_resusp[/* aero_model::gas_pcnst */], SubView dqdt,
+    Real qsrflx[/* aero_model::gas_pcnst */][nsrflx],
+    bool dotend[aero_model::gas_pcnst]) {
 
   // clang-format off
   // ----------------------------------------------------------------------- 
@@ -2862,9 +2862,9 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_sh_intr(
     const Real pdel[/* nlev */], const Real dt, const Real cldfrac[/* nlev */],
     const Real icwmr[/* nlev */], const Real rprddp[/* nlev */],
     const Real evapcdp[/* nlev */], ConstSubView qnew,
-    const int species_class[/* ConvProc::gas_pcnst */], SubView dqdt,
-    Real qsrflx[/* ConvProc::gas_pcnst */][nsrflx],
-    bool dotend[ConvProc::gas_pcnst]) {
+    const int species_class[/* aero_model::gas_pcnst */], SubView dqdt,
+    Real qsrflx[/* aero_model::gas_pcnst */][nsrflx],
+    bool dotend[aero_model::gas_pcnst]) {
   // clang-format off
   // ----------------------------------------------------------------------- 
   //  
@@ -2912,13 +2912,13 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_sh_intr(
   // set them in default values for C++ porting.   - Shuaiqi Tang 2023.2.25
   // =========================================================================================
   for (int i = 0; i < nlev; ++i)
-    for (int j = 0; j < ConvProc::gas_pcnst; ++j)
+    for (int j = 0; j < aero_model::gas_pcnst; ++j)
       dqdt(i, j) = 0;
 
-  for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+  for (int i = 0; i < aero_model::gas_pcnst; ++i)
     for (int j = 0; j < nsrflx; ++j)
       qsrflx[i][j] = 0;
-  for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+  for (int i = 0; i < aero_model::gas_pcnst; ++i)
     dotend[i] = false;
 }
 
@@ -2939,11 +2939,11 @@ void ma_convproc_intr(
     const Real sh_e_ed_ratio[/* nlev */], const Real du[/* nlev */],
     const Real eu[/* nlev */], const Real ed[/* nlev */],
     const Real dp[/* nlev */], const int ktop, const int kbot,
-    const int species_class[ConvProc::gas_pcnst],
-    const int mmtoo_prevap_resusp[ConvProc::gas_pcnst],
+    const int species_class[aero_model::gas_pcnst],
+    const int mmtoo_prevap_resusp[aero_model::gas_pcnst],
     const Diagnostics::ColumnTracerView state_q,
-    Diagnostics::ColumnTracerView ptend_q, bool ptend_lq[ConvProc::gas_pcnst],
-    Real aerdepwetis[ConvProc::gas_pcnst]) {
+    Diagnostics::ColumnTracerView ptend_q, bool ptend_lq[aero_model::gas_pcnst],
+    Real aerdepwetis[aero_model::gas_pcnst]) {
 
   //-----------------------------------------------------------------------
   //
@@ -2992,14 +2992,14 @@ void ma_convproc_intr(
   in    :: dp[nlev]    ! Delta pressure between interfaces [mb]
   in    :: ktop           ! Index of cloud top (updraft top) for each column in w grid
   in    :: kbot         ! Index of cloud base (level of maximum moist static energy) for each column in w grid
-  in    :: species_class[ConvProc::gas_pcnst]  ! species index defined as
+  in    :: species_class[aero_model::gas_pcnst]  ! species index defined as
           spec_class::undefined  = 0
           spec_class::cldphysics = 1
           spec_class::aerosol    = 2
           spec_class::gas        = 3
           spec_class::other      = 4
   
-  in  mmtoo_prevap_resConvProc::gas_pcnstusp[ConvProc::gas_pcnst]
+  in  mmtoo_prevap_resaero_model::gas_pcnstusp[aero_model::gas_pcnst]
         pointers for resuspension mmtoo_prevap_resusp values are
            >=0 for aerosol mass species with    coarse mode counterpart
            -2 for aerosol mass species WITHOUT coarse mode counterpart
@@ -3010,28 +3010,28 @@ void ma_convproc_intr(
 
   auto dqdt = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(
       scratch1Dviews[ConvProc::Col1DViewInd::dqdt].data(), nlev,
-      ConvProc::gas_pcnst);
+      aero_model::gas_pcnst);
 
   auto dlfdp = Kokkos::View<Real *, Kokkos::MemoryUnmanaged>(
       scratch1Dviews[ConvProc::Col1DViewInd::dlfdp].data(), nlev);
 
   for (int j = 0; j < nlev; ++j)
-    for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+    for (int i = 0; i < aero_model::gas_pcnst; ++i)
       dqdt(j, i) = ptend_q(j, i);
 
   // qnew will update in the subroutines but not update back to state%q
   auto qnew = Diagnostics::ColumnTracerView(
       scratch1Dviews[ConvProc::Col1DViewInd::qnew].data(), nlev,
-      ConvProc::gas_pcnst);
+      aero_model::gas_pcnst);
   EKAT_KERNEL_ASSERT(state_q.extent(0) == nlev);
-  EKAT_KERNEL_ASSERT(state_q.extent(1) <= ConvProc::gas_pcnst);
+  EKAT_KERNEL_ASSERT(state_q.extent(1) <= aero_model::gas_pcnst);
   for (int i = 0; i < nlev; ++i)
-    for (int j = 0; j < ConvProc::gas_pcnst; ++j)
+    for (int j = 0; j < aero_model::gas_pcnst; ++j)
       qnew(i, j) = state_q(i, j);
 
   // if do tendency
-  bool dotend[ConvProc::gas_pcnst];
-  for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+  bool dotend[aero_model::gas_pcnst];
+  for (int i = 0; i < aero_model::gas_pcnst; ++i)
     dotend[i] = ptend_lq[i];
 
   //
@@ -3050,9 +3050,9 @@ void ma_convproc_intr(
     //
     // do deep conv processing
     //
-    Real qsrflx[ConvProc::gas_pcnst][nsrflx] = {};
+    Real qsrflx[aero_model::gas_pcnst][nsrflx] = {};
     for (int j = 0; j < nlev; ++j)
-      for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+      for (int i = 0; i < aero_model::gas_pcnst; ++i)
         dqdt(j, i) = 0;
     for (int j = 0; j < nlev; ++j)
       dlfdp[j] = haero::max((dlf[j] - dlfsh[j]), 0.0);
@@ -3068,7 +3068,7 @@ void ma_convproc_intr(
                         Kokkos::subview(ptend_q, kk, Kokkos::ALL()),
                         Kokkos::subview(qnew, kk, Kokkos::ALL()));
     // update variables for output
-    for (int icnst = 0; icnst < ConvProc::gas_pcnst; ++icnst) {
+    for (int icnst = 0; icnst < aero_model::gas_pcnst; ++icnst) {
       // this used for surface coupling:
       //  4 = wet removal
       //  5 = actual precip-evap resuspension (what actually is applied to a
@@ -3081,10 +3081,10 @@ void ma_convproc_intr(
     // do shallow conv processing
     //
     for (int j = 0; j < nlev; ++j)
-      for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+      for (int i = 0; i < aero_model::gas_pcnst; ++i)
         dqdt(j, i) = 0;
     for (int j = 0; j < nsrflx; ++j)
-      for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+      for (int i = 0; i < aero_model::gas_pcnst; ++i)
         qsrflx[i][j] = 0;
     ma_convproc_sh_intr(nlev, temperature, pmid, dpdry, pdel, dt, sh_frac,
                         icwmrsh, rprdsh, evapcsh, qnew, species_class, dqdt,
@@ -3097,7 +3097,7 @@ void ma_convproc_intr(
                         Kokkos::subview(ptend_q, kk, Kokkos::ALL()),
                         Kokkos::subview(qnew, kk, Kokkos::ALL()));
     // update variables for output
-    for (int icnst = 0; icnst < ConvProc::gas_pcnst; ++icnst) {
+    for (int icnst = 0; icnst < aero_model::gas_pcnst; ++icnst) {
       // this used for surface coupling
       //  4 = wet removal
       //  5 = actual precip-evap resuspension (what actually is applied to a
@@ -3127,12 +3127,12 @@ void ConvProc::compute_tendencies(const AeroConfig &config,
   const bool convproc_do_gas = config_.convproc_do_gas;
   const int ktop = config_.ktop;
   const int kbot = config_.kbot;
-  int species_class[ConvProc::gas_pcnst];
-  for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+  int species_class[aero_model::gas_pcnst];
+  for (int i = 0; i < aero_model::gas_pcnst; ++i)
     species_class[i] = config_.species_class[i];
-  int mmtoo_prevap_resusp[ConvProc::gas_pcnst];
+  int mmtoo_prevap_resusp[aero_model::gas_pcnst];
   ;
-  for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+  for (int i = 0; i < aero_model::gas_pcnst; ++i)
     mmtoo_prevap_resusp[i] = config_.mmtoo_prevap_resusp[i];
 
   const int nlev = atmosphere.num_levels();
@@ -3185,9 +3185,9 @@ void ConvProc::compute_tendencies(const AeroConfig &config,
 
   // Diagnostic values that might be of use but not sure.
   // ptend_lq is just a flag that signifies if the gas was updated.
-  bool ptend_lq[ConvProc::gas_pcnst] = {};
+  bool ptend_lq[aero_model::gas_pcnst] = {};
   // Aerosol wet deposition (interstitial) [kg/m2/s]
-  Real aerdepwetis[ConvProc::gas_pcnst] = {};
+  Real aerdepwetis[aero_model::gas_pcnst] = {};
   convproc::ma_convproc_intr(
       team, scratch1Dviews, convproc_do_aer, convproc_do_gas, nlev, temperature,
       pmid, dpdry, pdel, dt, dp_frac, icwmrdp, rprddp, evapcdp, sh_frac,

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -978,10 +978,10 @@ KOKKOS_INLINE_FUNCTION void
 ma_precpprod(const Real rprd, const Real dpdry,
              const bool doconvproc_extd[ConvProc::pcnst_extd],
              const Real x_ratio, const int species_class[aero_model::pcnst],
-             const int mmtoo_prevap_resusp[aero_model::pcnst],
-             Real &pr_flux, Real &pr_flux_tmp, Real &pr_flux_base,
-             ColumnView wd_flux, ConstSubView dcondt_wetdep, SubView dcondt,
-             SubView dcondt_prevap, SubView dcondt_prevap_hist) {
+             const int mmtoo_prevap_resusp[aero_model::pcnst], Real &pr_flux,
+             Real &pr_flux_tmp, Real &pr_flux_base, ColumnView wd_flux,
+             ConstSubView dcondt_wetdep, SubView dcondt, SubView dcondt_prevap,
+             SubView dcondt_prevap_hist) {
   // clang-format off
   // ------------------------------------------
   //  step 2 in ma_precpevap_convproc: aerosol scavenging from precipitation production
@@ -2364,21 +2364,22 @@ void compute_updraft_mixing_ratio(
 }
 // ======================================================================================
 template <typename SubView, typename ConstSubView>
-KOKKOS_INLINE_FUNCTION void ma_convproc_tend(
-    const Kokkos::View<Real *>
-        scratch1Dviews[ConvProc::Col1DViewInd::NumScratch],
-    const int nlev, const ConvProc::convtype convtype, const Real dt,
-    const Real temperature[/* nlev */], const Real pmid[/* nlev */],
-    ConstSubView qnew, const Real du[/* nlev */], const Real eu[/* nlev */],
-    const Real ed[/* nlev */], const Real dp[/* nlev */],
-    const Real dpdry[/* nlev */], const int ktop, const int kbot,
-    const int mmtoo_prevap_resusp[/* aero_model::pcnst */],
-    const Real cldfrac[/* nlev */], const Real icwmr[/* nlev */],
-    const Real rprd[/* nlev */], const Real evapc[/* nlev */], SubView dqdt,
-    const bool doconvproc[/* aero_model::pcnst */],
-    Real qsrflx[/* aero_model::pcnst */][nsrflx],
-    const int species_class[/* aero_model::pcnst */], Real &xx_mfup_max,
-    Real &xx_wcldbase, int &xx_kcldbase) {
+KOKKOS_INLINE_FUNCTION void
+ma_convproc_tend(const Kokkos::View<Real *>
+                     scratch1Dviews[ConvProc::Col1DViewInd::NumScratch],
+                 const int nlev, const ConvProc::convtype convtype,
+                 const Real dt, const Real temperature[/* nlev */],
+                 const Real pmid[/* nlev */], ConstSubView qnew,
+                 const Real du[/* nlev */], const Real eu[/* nlev */],
+                 const Real ed[/* nlev */], const Real dp[/* nlev */],
+                 const Real dpdry[/* nlev */], const int ktop, const int kbot,
+                 const int mmtoo_prevap_resusp[/* aero_model::pcnst */],
+                 const Real cldfrac[/* nlev */], const Real icwmr[/* nlev */],
+                 const Real rprd[/* nlev */], const Real evapc[/* nlev */],
+                 SubView dqdt, const bool doconvproc[/* aero_model::pcnst */],
+                 Real qsrflx[/* aero_model::pcnst */][nsrflx],
+                 const int species_class[/* aero_model::pcnst */],
+                 Real &xx_mfup_max, Real &xx_wcldbase, int &xx_kcldbase) {
   // clang-format off
   /*
   // ----------------------------------------------------------------------- 
@@ -2748,20 +2749,21 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_tend(
 
 // =========================================================================================
 template <typename SubView, typename ConstSubView>
-KOKKOS_INLINE_FUNCTION void ma_convproc_dp_intr(
-    const Kokkos::View<Real *>
-        scratch1Dviews[ConvProc::Col1DViewInd::NumScratch],
-    const int nlev, const Real temperature[/* nlev */],
-    const Real pmid[/* nlev */], const Real dpdry[/* nlev */], const Real dt,
-    const Real cldfrac[/* nlev */], const Real icwmr[/* nlev */],
-    const Real rprddp[/* nlev */], const Real evapcdp[/* nlev */],
-    const Real du[/* nlev */], const Real eu[/* nlev */],
-    const Real ed[/* nlev */], const Real dp[/* nlev */], const int ktop,
-    const int kbot, ConstSubView qnew,
-    const int species_class[/* aero_model::pcnst */],
-    const int mmtoo_prevap_resusp[/* aero_model::pcnst */], SubView dqdt,
-    Real qsrflx[/* aero_model::pcnst */][nsrflx],
-    bool dotend[aero_model::pcnst]) {
+KOKKOS_INLINE_FUNCTION void
+ma_convproc_dp_intr(const Kokkos::View<Real *>
+                        scratch1Dviews[ConvProc::Col1DViewInd::NumScratch],
+                    const int nlev, const Real temperature[/* nlev */],
+                    const Real pmid[/* nlev */], const Real dpdry[/* nlev */],
+                    const Real dt, const Real cldfrac[/* nlev */],
+                    const Real icwmr[/* nlev */], const Real rprddp[/* nlev */],
+                    const Real evapcdp[/* nlev */], const Real du[/* nlev */],
+                    const Real eu[/* nlev */], const Real ed[/* nlev */],
+                    const Real dp[/* nlev */], const int ktop, const int kbot,
+                    ConstSubView qnew,
+                    const int species_class[/* aero_model::pcnst */],
+                    const int mmtoo_prevap_resusp[/* aero_model::pcnst */],
+                    SubView dqdt, Real qsrflx[/* aero_model::pcnst */][nsrflx],
+                    bool dotend[aero_model::pcnst]) {
 
   // clang-format off
   // ----------------------------------------------------------------------- 
@@ -2856,15 +2858,16 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_dp_intr(
 
 // =========================================================================================
 template <typename SubView, typename ConstSubView>
-KOKKOS_INLINE_FUNCTION void ma_convproc_sh_intr(
-    const int nlev, const Real temperature[/* nlev */],
-    const Real pmid[/* nlev */], const Real dpdry[/* nlev */],
-    const Real pdel[/* nlev */], const Real dt, const Real cldfrac[/* nlev */],
-    const Real icwmr[/* nlev */], const Real rprddp[/* nlev */],
-    const Real evapcdp[/* nlev */], ConstSubView qnew,
-    const int species_class[/* aero_model::pcnst */], SubView dqdt,
-    Real qsrflx[/* aero_model::pcnst */][nsrflx],
-    bool dotend[aero_model::pcnst]) {
+KOKKOS_INLINE_FUNCTION void
+ma_convproc_sh_intr(const int nlev, const Real temperature[/* nlev */],
+                    const Real pmid[/* nlev */], const Real dpdry[/* nlev */],
+                    const Real pdel[/* nlev */], const Real dt,
+                    const Real cldfrac[/* nlev */],
+                    const Real icwmr[/* nlev */], const Real rprddp[/* nlev */],
+                    const Real evapcdp[/* nlev */], ConstSubView qnew,
+                    const int species_class[/* aero_model::pcnst */],
+                    SubView dqdt, Real qsrflx[/* aero_model::pcnst */][nsrflx],
+                    bool dotend[aero_model::pcnst]) {
   // clang-format off
   // ----------------------------------------------------------------------- 
   //  

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -357,13 +357,13 @@ public:
   // This should come from the chemistry model being used and will
   // probably need to be dynamic.  This forces lmassptr_amode to
   // also be dynamic.
-  // static constexpr int gas_pcnst = aero_model::gas_pcnst;
+  // static constexpr int gas_pcnst = aero_model::pcnst;
 
   // ====================================================================================
-  // The diagnostic arrays are twice the lengths of aero_model::gas_pcnst
+  // The diagnostic arrays are twice the lengths of aero_model::pcnst
   // because cloudborne aerosols are appended after interstitial aerosols both
   // of which are of length gas_pcnst.
-  static constexpr int pcnst_extd = 2 * aero_model::gas_pcnst;
+  static constexpr int pcnst_extd = 2 * aero_model::pcnst;
 
   // nucleation-specific configuration
   struct Config {
@@ -381,10 +381,10 @@ public:
     int ktop = 47; // BAD_CONSTANT: only true for nlev == 72
     int kbot = mam4::nlev - 1;
     // Flags are defined in "enum ConvProc::species_class".
-    int species_class[aero_model::gas_pcnst] = {
+    int species_class[aero_model::pcnst] = {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2,
         2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
-    int mmtoo_prevap_resusp[aero_model::gas_pcnst] = {
+    int mmtoo_prevap_resusp[aero_model::pcnst] = {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, 30, 32, 33, 31, 28, 29, 34, -3, 30, 33, 29, 34, -3,
         28, 29, 30, 31, 32, 33, 34, -3, 32, 31, 34, -3};
@@ -566,7 +566,7 @@ public:
             const Config &convproc_config = Config()) {
     // Set nucleation-specific config parameters.
     config_ = convproc_config;
-    Kokkos::resize(scratch1Dviews[q], config_.nlev * aero_model::gas_pcnst);
+    Kokkos::resize(scratch1Dviews[q], config_.nlev * aero_model::pcnst);
     Kokkos::resize(scratch1Dviews[mu], config_.nlev);
     Kokkos::resize(scratch1Dviews[md], config_.nlev);
     Kokkos::resize(scratch1Dviews[eudp], config_.nlev);
@@ -598,8 +598,8 @@ public:
     Kokkos::resize(scratch1Dviews[sumprevap_hist], pcnst_extd);
     Kokkos::resize(scratch1Dviews[sumresusp], pcnst_extd);
     Kokkos::resize(scratch1Dviews[sumwetdep], pcnst_extd);
-    Kokkos::resize(scratch1Dviews[dqdt], config_.nlev * aero_model::gas_pcnst);
-    Kokkos::resize(scratch1Dviews[qnew], config_.nlev * aero_model::gas_pcnst);
+    Kokkos::resize(scratch1Dviews[dqdt], config_.nlev * aero_model::pcnst);
+    Kokkos::resize(scratch1Dviews[qnew], config_.nlev * aero_model::pcnst);
     Kokkos::resize(scratch1Dviews[dlfdp], config_.nlev);
   } // end(init)
 
@@ -624,7 +624,7 @@ void assign_la_lc(const int imode, const int ispec, int &la, int &lc) {
   // from mode index and species index
   // Cloudborne aerosols are appended after interstitial aerosol array
   // so lc (cloudborne) is offset from ic (interstitial) by
-  // aero_model::gas_pcnst.
+  // aero_model::pcnst.
   //-----------------------------------------------------------------------
   if (ispec == -1) {
     la = ConvProc::numptr_amode(imode);
@@ -633,7 +633,7 @@ void assign_la_lc(const int imode, const int ispec, int &la, int &lc) {
     la = ConvProc::lmassptr_amode(ispec, imode);
     lc = ConvProc::lmassptrcw_amode(ispec, imode);
   }
-  lc += aero_model::gas_pcnst;
+  lc += aero_model::pcnst;
 }
 
 // nsrflx is the number of process-specific column tracer tendencies:
@@ -651,7 +651,7 @@ void update_tendency_diagnostics(
     Real sumresusp[ConvProc::pcnst_extd], // INOUT sum (over layers) of dp*dcondt_resusp [kg/kg/s * mb]
     Real sumprevap[ConvProc::pcnst_extd], // INOUT sum (over layers) of dp*dcondt_prevap [kg/kg/s * mb]
     Real sumprevap_hist[ConvProc::pcnst_extd],// INOUT sum (over layers) of dp*dcondt_prevap_hist [kg/kg/s * mb]
-    Real qsrflx[/* aero_model::gas_pcnst */][nsrflx]) // INOUT process-specific column tracer tendencies [kg/m2/s]
+    Real qsrflx[/* aero_model::pcnst */][nsrflx]) // INOUT process-specific column tracer tendencies [kg/m2/s]
 {
 
   // -----------------------------------------------------------------------
@@ -671,7 +671,7 @@ void update_tendency_diagnostics(
 
   // clang-format on
 
-  EKAT_KERNEL_REQUIRE(aero_model::gas_pcnst == ncnst);
+  EKAT_KERNEL_REQUIRE(aero_model::pcnst == ncnst);
   const int ntot_amode = AeroConfig::num_modes();
   int la = 0, lc = 0;
   // update diagnostic variables
@@ -977,8 +977,8 @@ template <typename SubView, typename ConstSubView>
 KOKKOS_INLINE_FUNCTION void
 ma_precpprod(const Real rprd, const Real dpdry,
              const bool doconvproc_extd[ConvProc::pcnst_extd],
-             const Real x_ratio, const int species_class[aero_model::gas_pcnst],
-             const int mmtoo_prevap_resusp[aero_model::gas_pcnst],
+             const Real x_ratio, const int species_class[aero_model::pcnst],
+             const int mmtoo_prevap_resusp[aero_model::pcnst],
              Real &pr_flux, Real &pr_flux_tmp, Real &pr_flux_base,
              ColumnView wd_flux, ConstSubView dcondt_wetdep, SubView dcondt,
              SubView dcondt_prevap, SubView dcondt_prevap_hist) {
@@ -999,7 +999,7 @@ ma_precpprod(const Real rprd, const Real dpdry,
           spec_class::aerosol    = 2
           spec_class::gas        = 3
           spec_class::other      = 4
-  in  mmtoo_prevap_resusp[aero_model::gas_pcnst]
+  in  mmtoo_prevap_resusp[aero_model::pcnst]
         pointers for resuspension mmtoo_prevap_resusp values are
            >=0 for aerosol mass species with    coarse mode counterpart
            -2 for aerosol mass species WITHOUT coarse mode counterpart
@@ -1046,7 +1046,7 @@ ma_precpprod(const Real rprd, const Real dpdry,
       const Real dcondt_wdflux = del_wd_flux_evap / dpdry;
 
       // for interstitial icnst2=icnst;  for activated icnst2=icnst-pcnst
-      const int icnst2 = icnst % aero_model::gas_pcnst;
+      const int icnst2 = icnst % aero_model::pcnst;
 
       // not sure what this mean exactly. Only do it for aerosol mass species
       // (mmtoo>0).  mmtoo<=0 represents aerosol number species
@@ -1079,8 +1079,8 @@ void ma_precpevap_convproc(const int ktop, const int nlev,
                            const Real evapc[/* nlev */],
                            const Real dpdry[/* nlev */],
                            const bool doconvproc_extd[ConvProc::pcnst_extd],
-                           const int species_class[aero_model::gas_pcnst],
-                           const int mmtoo_prevap_resusp[aero_model::gas_pcnst],
+                           const int species_class[aero_model::pcnst],
+                           const int mmtoo_prevap_resusp[aero_model::pcnst],
                            ColumnView wd_flux, Kokkos_2D_View dcondt_prevap,
                            Kokkos_2D_View dcondt_prevap_hist,
                            Kokkos_2D_View dcondt) {
@@ -1132,7 +1132,7 @@ void ma_precpevap_convproc(const int ktop, const int nlev,
                                    aerosol    = 2
                                    gas        = 3
                                    other      = 4
-    in  mmtoo_prevap_resusp[aero_model::gas_pcnst]
+    in  mmtoo_prevap_resusp[aero_model::pcnst]
          pointers for resuspension mmtoo_prevap_resusp values are
             >=0 for aerosol mass species with    coarse mode counterpart
             -2 for aerosol mass species WITHOUT coarse mode counterpart
@@ -1685,7 +1685,7 @@ KOKKOS_INLINE_FUNCTION
 void initialize_tmr_array(
     const int nlev, const int iconvtype,
     const bool doconvproc_extd[ConvProc::pcnst_extd],
-    Kokkos::View<Real * [aero_model::gas_pcnst], Kokkos::MemoryUnmanaged> q,
+    Kokkos::View<Real * [aero_model::pcnst], Kokkos::MemoryUnmanaged> q,
     Kokkos_2D_View gath, Kokkos_2D_View chat, Kokkos_2D_View conu,
     Kokkos_2D_View cond) {
   // -----------------------------------------------------------------------
@@ -1714,7 +1714,7 @@ void initialize_tmr_array(
   // BAD_CONSTANT - is there a reference for this value?
   const Real small_rel = 1.0e-6;
 
-  const int ncnst = aero_model::gas_pcnst;
+  const int ncnst = aero_model::pcnst;
   const int pcnst_extd = ConvProc::pcnst_extd;
 
   // initiate variables
@@ -1792,7 +1792,7 @@ void initialize_tmr_array(
 
 // ======================================================================================
 KOKKOS_INLINE_FUNCTION
-void set_cloudborne_vars(const bool doconvproc[aero_model::gas_pcnst],
+void set_cloudborne_vars(const bool doconvproc[aero_model::pcnst],
                          Real aqfrac[ConvProc::pcnst_extd],
                          bool doconvproc_extd[ConvProc::pcnst_extd]) {
   // -----------------------------------------------------------------------
@@ -1808,7 +1808,7 @@ void set_cloudborne_vars(const bool doconvproc[aero_model::gas_pcnst],
   [fraction]
   */
   const int pcnst_extd = ConvProc::pcnst_extd;
-  const int gas_pcnst = aero_model::gas_pcnst;
+  const int gas_pcnst = aero_model::pcnst;
   const int num_modes = AeroConfig::num_modes();
   int la, lc;
 
@@ -1836,9 +1836,9 @@ void set_cloudborne_vars(const bool doconvproc[aero_model::gas_pcnst],
 // ======================================================================================
 template <typename SubView, typename ConstSubView>
 KOKKOS_INLINE_FUNCTION void
-update_qnew_ptend(const bool dotend[aero_model::gas_pcnst],
+update_qnew_ptend(const bool dotend[aero_model::pcnst],
                   const bool is_update_ptend, ConstSubView dqdt, const Real dt,
-                  bool ptend_lq[aero_model::gas_pcnst], SubView ptend_q,
+                  bool ptend_lq[aero_model::pcnst], SubView ptend_q,
                   SubView qnew) {
   // ---------------------------------------------------------------------------------------
   // update qnew, ptend_q and ptend_lq
@@ -1856,11 +1856,11 @@ update_qnew_ptend(const bool dotend[aero_model::gas_pcnst],
    inout :: qnew[pcnst]    ! Tracer array including moisture [kg/kg]
   */
   // clang-format on 
-  for (int ll = 0; ll < aero_model::gas_pcnst; ++ll) {
+  for (int ll = 0; ll < aero_model::pcnst; ++ll) {
     // calc new q (after ma_convproc_sh_intr)
     if (dotend[ll]) qnew[ll] = haero::max(0.0, qnew[ll] + dt*dqdt[ll]);
   }
-  for (int ll = 0; ll < aero_model::gas_pcnst; ++ll) {
+  for (int ll = 0; ll < aero_model::pcnst; ++ll) {
     if (dotend[ll] && is_update_ptend) {
       // add dqdt onto ptend_q and set ptend_lq
       ptend_lq[ll] = true;
@@ -1952,21 +1952,21 @@ void compute_wetdep_tend(
 }
 // ======================================================================================
 KOKKOS_INLINE_FUNCTION
-void assign_dotend(const int species_class[aero_model::gas_pcnst],
+void assign_dotend(const int species_class[aero_model::pcnst],
                    const bool convproc_do_aer, // true by default
                    const bool convproc_do_gas, // false by default
-                   bool dotend[aero_model::gas_pcnst]) {
+                   bool dotend[aero_model::pcnst]) {
   // ---------------------------------------------------------------------
   //  assign do-tendency flag from species_class, convproc_do_aer and
   //  convproc_do_gas. convproc_do_aer and convproc_do_gas are assigned in the
   //  beginning of the  module
   // ---------------------------------------------------------------------
   /*
-  in    :: species_class[aero_model::gas_pcnst]
-  out   :: dotend[aero_model::gas_pcnst]
+  in    :: species_class[aero_model::pcnst]
+  out   :: dotend[aero_model::pcnst]
   */
   //  turn on/off calculations for aerosols and trace gases
-  for (int ll = 0; ll < aero_model::gas_pcnst; ++ll) {
+  for (int ll = 0; ll < aero_model::pcnst; ++ll) {
     if (species_class[ll] == ConvProc::species_class::aerosol &&
         convproc_do_aer) {
       dotend[ll] = true;
@@ -2372,12 +2372,12 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_tend(
     ConstSubView qnew, const Real du[/* nlev */], const Real eu[/* nlev */],
     const Real ed[/* nlev */], const Real dp[/* nlev */],
     const Real dpdry[/* nlev */], const int ktop, const int kbot,
-    const int mmtoo_prevap_resusp[/* aero_model::gas_pcnst */],
+    const int mmtoo_prevap_resusp[/* aero_model::pcnst */],
     const Real cldfrac[/* nlev */], const Real icwmr[/* nlev */],
     const Real rprd[/* nlev */], const Real evapc[/* nlev */], SubView dqdt,
-    const bool doconvproc[/* aero_model::gas_pcnst */],
-    Real qsrflx[/* aero_model::gas_pcnst */][nsrflx],
-    const int species_class[/* aero_model::gas_pcnst */], Real &xx_mfup_max,
+    const bool doconvproc[/* aero_model::pcnst */],
+    Real qsrflx[/* aero_model::pcnst */][nsrflx],
+    const int species_class[/* aero_model::pcnst */], Real &xx_mfup_max,
     Real &xx_wcldbase, int &xx_kcldbase) {
   // clang-format off
   /*
@@ -2427,7 +2427,7 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_tend(
    in :: gas_pcnst         ! number of tracers to transport
    in :: dt                ! Model timestep [s]
    in :: temperature[nlev]     ! Temperature [K]
-   in :: qnew[nlev][aero_model::gas_pcnst]      ! Tracer array including moisture [kg/kg]
+   in :: qnew[nlev][aero_model::pcnst]      ! Tracer array including moisture [kg/kg]
 
    in :: du[nlev]    ! Mass detrain rate from updraft [1/s]
    in :: eu[nlev]    ! Mass entrain rate into updraft [1/s]
@@ -2452,8 +2452,8 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_tend(
    in :: rprd[nlev]     ! Convective precipitation formation rate [kg/kg/s]
    in :: evapc[nlev]    ! Convective precipitation evaporation rate [kg/kg/s]
 
-   out:: dqdt[nlev][aero_model::gas_pcnst]  ! Tracer tendency array [kg/kg/s]
-   in :: doconvproc[aero_model::gas_pcnst] ! flag for doing convective transport
+   out:: dqdt[nlev][aero_model::pcnst]  ! Tracer tendency array [kg/kg/s]
+   in :: doconvproc[aero_model::pcnst] ! flag for doing convective transport
    out:: qsrflx[pcnst][nsrflx]
          ! process-specific column tracer tendencies [kg/m2/s]
          !  1 = activation   of interstial to conv-cloudborne
@@ -2475,7 +2475,7 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_tend(
   */
   // clang-format on
   const int pcnst_extd = ConvProc::pcnst_extd;
-  const int pcnst = aero_model::gas_pcnst;
+  const int pcnst = aero_model::pcnst;
   EKAT_KERNEL_REQUIRE(convtype == ConvProc::Deep || convtype == ConvProc::Uwsh);
   // iconvtype       ! 1=deep, 2=uw shallow
   const int iconvtype = convtype == ConvProc::Deep ? 1 : 2;
@@ -2758,10 +2758,10 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_dp_intr(
     const Real du[/* nlev */], const Real eu[/* nlev */],
     const Real ed[/* nlev */], const Real dp[/* nlev */], const int ktop,
     const int kbot, ConstSubView qnew,
-    const int species_class[/* aero_model::gas_pcnst */],
-    const int mmtoo_prevap_resusp[/* aero_model::gas_pcnst */], SubView dqdt,
-    Real qsrflx[/* aero_model::gas_pcnst */][nsrflx],
-    bool dotend[aero_model::gas_pcnst]) {
+    const int species_class[/* aero_model::pcnst */],
+    const int mmtoo_prevap_resusp[/* aero_model::pcnst */], SubView dqdt,
+    Real qsrflx[/* aero_model::pcnst */][nsrflx],
+    bool dotend[aero_model::pcnst]) {
 
   // clang-format off
   // ----------------------------------------------------------------------- 
@@ -2862,9 +2862,9 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_sh_intr(
     const Real pdel[/* nlev */], const Real dt, const Real cldfrac[/* nlev */],
     const Real icwmr[/* nlev */], const Real rprddp[/* nlev */],
     const Real evapcdp[/* nlev */], ConstSubView qnew,
-    const int species_class[/* aero_model::gas_pcnst */], SubView dqdt,
-    Real qsrflx[/* aero_model::gas_pcnst */][nsrflx],
-    bool dotend[aero_model::gas_pcnst]) {
+    const int species_class[/* aero_model::pcnst */], SubView dqdt,
+    Real qsrflx[/* aero_model::pcnst */][nsrflx],
+    bool dotend[aero_model::pcnst]) {
   // clang-format off
   // ----------------------------------------------------------------------- 
   //  
@@ -2912,13 +2912,13 @@ KOKKOS_INLINE_FUNCTION void ma_convproc_sh_intr(
   // set them in default values for C++ porting.   - Shuaiqi Tang 2023.2.25
   // =========================================================================================
   for (int i = 0; i < nlev; ++i)
-    for (int j = 0; j < aero_model::gas_pcnst; ++j)
+    for (int j = 0; j < aero_model::pcnst; ++j)
       dqdt(i, j) = 0;
 
-  for (int i = 0; i < aero_model::gas_pcnst; ++i)
+  for (int i = 0; i < aero_model::pcnst; ++i)
     for (int j = 0; j < nsrflx; ++j)
       qsrflx[i][j] = 0;
-  for (int i = 0; i < aero_model::gas_pcnst; ++i)
+  for (int i = 0; i < aero_model::pcnst; ++i)
     dotend[i] = false;
 }
 
@@ -2939,11 +2939,11 @@ void ma_convproc_intr(
     const Real sh_e_ed_ratio[/* nlev */], const Real du[/* nlev */],
     const Real eu[/* nlev */], const Real ed[/* nlev */],
     const Real dp[/* nlev */], const int ktop, const int kbot,
-    const int species_class[aero_model::gas_pcnst],
-    const int mmtoo_prevap_resusp[aero_model::gas_pcnst],
+    const int species_class[aero_model::pcnst],
+    const int mmtoo_prevap_resusp[aero_model::pcnst],
     const Diagnostics::ColumnTracerView state_q,
-    Diagnostics::ColumnTracerView ptend_q, bool ptend_lq[aero_model::gas_pcnst],
-    Real aerdepwetis[aero_model::gas_pcnst]) {
+    Diagnostics::ColumnTracerView ptend_q, bool ptend_lq[aero_model::pcnst],
+    Real aerdepwetis[aero_model::pcnst]) {
 
   //-----------------------------------------------------------------------
   //
@@ -2992,14 +2992,14 @@ void ma_convproc_intr(
   in    :: dp[nlev]    ! Delta pressure between interfaces [mb]
   in    :: ktop           ! Index of cloud top (updraft top) for each column in w grid
   in    :: kbot         ! Index of cloud base (level of maximum moist static energy) for each column in w grid
-  in    :: species_class[aero_model::gas_pcnst]  ! species index defined as
+  in    :: species_class[aero_model::pcnst]  ! species index defined as
           spec_class::undefined  = 0
           spec_class::cldphysics = 1
           spec_class::aerosol    = 2
           spec_class::gas        = 3
           spec_class::other      = 4
   
-  in  mmtoo_prevap_resaero_model::gas_pcnstusp[aero_model::gas_pcnst]
+  in  mmtoo_prevap_resaero_model::pcnst[aero_model::pcnst]
         pointers for resuspension mmtoo_prevap_resusp values are
            >=0 for aerosol mass species with    coarse mode counterpart
            -2 for aerosol mass species WITHOUT coarse mode counterpart
@@ -3010,28 +3010,28 @@ void ma_convproc_intr(
 
   auto dqdt = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(
       scratch1Dviews[ConvProc::Col1DViewInd::dqdt].data(), nlev,
-      aero_model::gas_pcnst);
+      aero_model::pcnst);
 
   auto dlfdp = Kokkos::View<Real *, Kokkos::MemoryUnmanaged>(
       scratch1Dviews[ConvProc::Col1DViewInd::dlfdp].data(), nlev);
 
   for (int j = 0; j < nlev; ++j)
-    for (int i = 0; i < aero_model::gas_pcnst; ++i)
+    for (int i = 0; i < aero_model::pcnst; ++i)
       dqdt(j, i) = ptend_q(j, i);
 
   // qnew will update in the subroutines but not update back to state%q
   auto qnew = Diagnostics::ColumnTracerView(
       scratch1Dviews[ConvProc::Col1DViewInd::qnew].data(), nlev,
-      aero_model::gas_pcnst);
+      aero_model::pcnst);
   EKAT_KERNEL_ASSERT(state_q.extent(0) == nlev);
-  EKAT_KERNEL_ASSERT(state_q.extent(1) <= aero_model::gas_pcnst);
+  EKAT_KERNEL_ASSERT(state_q.extent(1) <= aero_model::pcnst);
   for (int i = 0; i < nlev; ++i)
-    for (int j = 0; j < aero_model::gas_pcnst; ++j)
+    for (int j = 0; j < aero_model::pcnst; ++j)
       qnew(i, j) = state_q(i, j);
 
   // if do tendency
-  bool dotend[aero_model::gas_pcnst];
-  for (int i = 0; i < aero_model::gas_pcnst; ++i)
+  bool dotend[aero_model::pcnst];
+  for (int i = 0; i < aero_model::pcnst; ++i)
     dotend[i] = ptend_lq[i];
 
   //
@@ -3050,9 +3050,9 @@ void ma_convproc_intr(
     //
     // do deep conv processing
     //
-    Real qsrflx[aero_model::gas_pcnst][nsrflx] = {};
+    Real qsrflx[aero_model::pcnst][nsrflx] = {};
     for (int j = 0; j < nlev; ++j)
-      for (int i = 0; i < aero_model::gas_pcnst; ++i)
+      for (int i = 0; i < aero_model::pcnst; ++i)
         dqdt(j, i) = 0;
     for (int j = 0; j < nlev; ++j)
       dlfdp[j] = haero::max((dlf[j] - dlfsh[j]), 0.0);
@@ -3068,7 +3068,7 @@ void ma_convproc_intr(
                         Kokkos::subview(ptend_q, kk, Kokkos::ALL()),
                         Kokkos::subview(qnew, kk, Kokkos::ALL()));
     // update variables for output
-    for (int icnst = 0; icnst < aero_model::gas_pcnst; ++icnst) {
+    for (int icnst = 0; icnst < aero_model::pcnst; ++icnst) {
       // this used for surface coupling:
       //  4 = wet removal
       //  5 = actual precip-evap resuspension (what actually is applied to a
@@ -3081,10 +3081,10 @@ void ma_convproc_intr(
     // do shallow conv processing
     //
     for (int j = 0; j < nlev; ++j)
-      for (int i = 0; i < aero_model::gas_pcnst; ++i)
+      for (int i = 0; i < aero_model::pcnst; ++i)
         dqdt(j, i) = 0;
     for (int j = 0; j < nsrflx; ++j)
-      for (int i = 0; i < aero_model::gas_pcnst; ++i)
+      for (int i = 0; i < aero_model::pcnst; ++i)
         qsrflx[i][j] = 0;
     ma_convproc_sh_intr(nlev, temperature, pmid, dpdry, pdel, dt, sh_frac,
                         icwmrsh, rprdsh, evapcsh, qnew, species_class, dqdt,
@@ -3097,7 +3097,7 @@ void ma_convproc_intr(
                         Kokkos::subview(ptend_q, kk, Kokkos::ALL()),
                         Kokkos::subview(qnew, kk, Kokkos::ALL()));
     // update variables for output
-    for (int icnst = 0; icnst < aero_model::gas_pcnst; ++icnst) {
+    for (int icnst = 0; icnst < aero_model::pcnst; ++icnst) {
       // this used for surface coupling
       //  4 = wet removal
       //  5 = actual precip-evap resuspension (what actually is applied to a
@@ -3127,12 +3127,12 @@ void ConvProc::compute_tendencies(const AeroConfig &config,
   const bool convproc_do_gas = config_.convproc_do_gas;
   const int ktop = config_.ktop;
   const int kbot = config_.kbot;
-  int species_class[aero_model::gas_pcnst];
-  for (int i = 0; i < aero_model::gas_pcnst; ++i)
+  int species_class[aero_model::pcnst];
+  for (int i = 0; i < aero_model::pcnst; ++i)
     species_class[i] = config_.species_class[i];
-  int mmtoo_prevap_resusp[aero_model::gas_pcnst];
+  int mmtoo_prevap_resusp[aero_model::pcnst];
   ;
-  for (int i = 0; i < aero_model::gas_pcnst; ++i)
+  for (int i = 0; i < aero_model::pcnst; ++i)
     mmtoo_prevap_resusp[i] = config_.mmtoo_prevap_resusp[i];
 
   const int nlev = atmosphere.num_levels();
@@ -3185,9 +3185,9 @@ void ConvProc::compute_tendencies(const AeroConfig &config,
 
   // Diagnostic values that might be of use but not sure.
   // ptend_lq is just a flag that signifies if the gas was updated.
-  bool ptend_lq[aero_model::gas_pcnst] = {};
+  bool ptend_lq[aero_model::pcnst] = {};
   // Aerosol wet deposition (interstitial) [kg/m2/s]
-  Real aerdepwetis[aero_model::gas_pcnst] = {};
+  Real aerdepwetis[aero_model::pcnst] = {};
   convproc::ma_convproc_intr(
       team, scratch1Dviews, convproc_do_aer, convproc_do_gas, nlev, temperature,
       pmid, dpdry, pdel, dt, dp_frac, icwmrdp, rprddp, evapcdp, sh_frac,

--- a/src/mam4xx/drydep.hpp
+++ b/src/mam4xx/drydep.hpp
@@ -56,12 +56,12 @@ private:
   Kokkos::View<Real *> vlc_dry[AeroConfig::num_modes()][aerosol_categories];
   Kokkos::View<Real *> vlc_trb[AeroConfig::num_modes()][aerosol_categories];
   Kokkos::View<Real *> vlc_grv[AeroConfig::num_modes()][aerosol_categories];
-  Kokkos::View<Real *> dqdt_tmp[aero_model::gas_pcnst];
+  Kokkos::View<Real *> dqdt_tmp[aero_model::pcnst];
 
   // Computed tendenciesColumnView for
   // modal cloudborne aerosol number mixing ratios and
   // cloudborne aerosol mass mixing ratios within each mode.
-  Kokkos::View<Real *> qqcw_tends[aero_model::gas_pcnst] = {};
+  Kokkos::View<Real *> qqcw_tends[aero_model::pcnst] = {};
 
 public:
   // name -- unique name of the process implemented by this class
@@ -84,7 +84,7 @@ public:
         Kokkos::deep_copy(vlc_grv[j][i], 0);
       }
     }
-    for (int j = 0; j < aero_model::gas_pcnst; ++j) {
+    for (int j = 0; j < aero_model::pcnst; ++j) {
       Kokkos::resize(dqdt_tmp[j], nlev);
       Kokkos::deep_copy(dqdt_tmp[j], 0);
       Kokkos::resize(qqcw_tends[j], nlev);
@@ -869,11 +869,11 @@ void aero_model_drydep(
     const Diagnostics::ColumnTracerView state_q,
     const ColumnView dgncur_awet[AeroConfig::num_modes()],
     const ColumnView wetdens[AeroConfig::num_modes()],
-    const Kokkos::View<Real *> qqcw[aero_model::gas_pcnst], const Real obklen,
+    const Kokkos::View<Real *> qqcw[aero_model::pcnst], const Real obklen,
     const Real ustar, const Real landfrac, const Real icefrac,
     const Real ocnfrac, const Real fricvelin, const Real ram1in,
     const Diagnostics::ColumnTracerView ptend_q,
-    bool ptend_lq[aero_model::gas_pcnst], const Real dt,
+    bool ptend_lq[aero_model::pcnst], const Real dt,
     const ColumnView aerdepdrycw, const ColumnView aerdepdryis,
 
     const ColumnView rho,
@@ -883,7 +883,7 @@ void aero_model_drydep(
                                       [DryDeposition::aerosol_categories],
     const Kokkos::View<Real *> vlc_grv[AeroConfig::num_modes()]
                                       [DryDeposition::aerosol_categories],
-    const Kokkos::View<Real *> dqdt_tmp[aero_model::gas_pcnst]) {
+    const Kokkos::View<Real *> dqdt_tmp[aero_model::pcnst]) {
   // clang-format off
   /*   
     // Arguments
@@ -903,7 +903,7 @@ void aero_model_drydep(
     in :: ram1in            : aerodynamical resistance from land model [s/m]
     in :: dt                : time step [s]
     inout  :: qqcw(nlev)    : Cloud borne aerosols mixing ratios [kg/kg or 1/kg]
-    out    :: ptend_q (nlev, aero_model::gas_pcnst) : diagnostics.d_tracer_mixing_ratio_dt
+    out    :: ptend_q (nlev, aero_model::pcnst) : diagnostics.d_tracer_mixing_ratio_dt
 
     // Scratch Space
     rho(nlev)               : air density [kg/m3]
@@ -1157,7 +1157,7 @@ void DryDeposition::compute_tendencies(const AeroConfig &config, const ThreadTea
   const Real fricvelin = diags.friction_velocity;
   const Real ram1in = diags.aerodynamical_resistance;
   auto ptend_q = diags.d_tracer_mixing_ratio_dt;
-  bool ptend_lq[aero_model::gas_pcnst];
+  bool ptend_lq[aero_model::pcnst];
   auto aerdepdrycw = diags.deposition_flux_of_cloud_borne_aerosols;
   auto aerdepdryis = diags.deposition_flux_of_interstitial_aerosols;
   auto rho     = this->rho;

--- a/src/mam4xx/modal_aer_opt.hpp
+++ b/src/mam4xx/modal_aer_opt.hpp
@@ -918,7 +918,7 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt,
   const auto fa_work = View3D(work_ptr, pver, ntot_amode, nswbands);
   work_ptr += pver * ntot_amode * nswbands;
 
-  constexpr int pcnst = mam4::ndrop::nvars;
+  constexpr int pcnst = aero_model::pcnst;
 
   constexpr Real zero = 0;
 
@@ -1201,7 +1201,7 @@ void modal_aero_lw(const ThreadTeam &team, const Real dt,
   // cldn(:,:)         layer cloud fraction [fraction]
   // qqcw(:)                Cloud borne aerosols mixing ratios [kg/kg or 1/kg]
   // tauxar(pcols,pver,nlwbands)  layer absorption optical depth
-  constexpr int pcnst = mam4::ndrop::nvars;
+  constexpr int pcnst = aero_model::pcnst;
 
   constexpr Real zero = 0.0;
   // dry mass in each cell

--- a/src/mam4xx/modal_aer_opt.hpp
+++ b/src/mam4xx/modal_aer_opt.hpp
@@ -26,7 +26,7 @@ constexpr int ntot_amode = mam4::AeroConfig::num_modes();
 // FIXME:  is top_lev equal to 1 in aerosol optics ?
 constexpr int top_lev = 0;
 //
-constexpr int pcnst = 40;
+constexpr int pcnst = aero_model::pcnst;
 //  min, max aerosol surface mode radius treated [m]
 constexpr Real rmmin = 0.01e-6; // BAD CONSTANT
 constexpr Real rmmax = 25.e-6;  // BAD CONSTANT
@@ -798,7 +798,7 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt, const View2D &state_q,
                    const ConstColumnView &temperature,
                    const ConstColumnView &pmid, const ConstColumnView &pdel,
                    const ConstColumnView &pdeldry, const ConstColumnView &cldn,
-                   // const ColumnView qqcw_fld[pcnst],
+                   // const ColumnView qqcw_fld[aero_model::pcnst],
                    const View2D &tauxar, const View2D &wa, const View2D &ga,
                    const View2D &fa,
                    const AerosolOpticsDeviceData &aersol_optics_data,
@@ -895,7 +895,7 @@ KOKKOS_INLINE_FUNCTION
 void modal_aero_sw(const ThreadTeam &team, const Real dt,
                    mam4::Prognostics &progs, const haero::Atmosphere &atm,
                    const ConstColumnView &pdel, const ConstColumnView &pdeldry,
-                   // const ColumnView qqcw_fld[pcnst],
+                   // const ColumnView qqcw_fld[aero_model::pcnst],
                    const View2D &tauxar, const View2D &wa, const View2D &ga,
                    const View2D &fa,
                    const AerosolOpticsDeviceData &aersol_optics_data,

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -7,6 +7,7 @@
 #include <haero/math.hpp>
 
 #include <mam4xx/aero_config.hpp>
+#include <mam4xx/aero_model.hpp>
 #include <mam4xx/conversions.hpp>
 #include <mam4xx/mam4_types.hpp>
 #include <mam4xx/utils.hpp>
@@ -25,8 +26,6 @@ constexpr int pver = mam4::nlev;
 // Top level for troposphere cloud physics
 constexpr int top_lev = 7;
 constexpr int psat = 6; //  number of supersaturations to calc ccn concentration
-//  number of variables in state_q
-constexpr int nvars = 40;
 constexpr int maxd_aspectype = 14;
 // BAD CONSTANT
 // reference temperature [K] (from mam4)
@@ -35,7 +34,6 @@ constexpr Real t0 = 273.0;
 // reference pressure [Pa] (from mam4)
 // pressure at sea level [Pa] (1 atm)
 constexpr Real p0 = 1013.25e2;
-constexpr int nvar_ptend_q = 40;
 // BAD CONSTANT
 // surface tension of water w/respect to air (N/m)
 constexpr Real surften = 0.076;
@@ -118,7 +116,7 @@ void get_e3sm_parameters(
 
 KOKKOS_INLINE_FUNCTION
 void get_aer_mmr_sum(
-    const int imode, const int nspec, const Real state_q[nvars],
+    const int imode, const int nspec, const Real state_q[aero_model::pcnst],
     const Real qcldbrn1d[maxd_aspectype],
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
     const Real specdens_amode[maxd_aspectype],
@@ -159,7 +157,7 @@ void get_aer_mmr_sum(
 
 KOKKOS_INLINE_FUNCTION
 void get_aer_num(const Real voltonumbhi_amode, const Real voltonumblo_amode,
-                 const int num_idx, const Real state_q[nvars],
+                 const int num_idx, const Real state_q[aero_model::pcnst],
                  const Real air_density, const Real vaerosol,
                  const Real qcldbrn1d_num, Real &naerosol) {
 
@@ -246,7 +244,7 @@ void maxsat(
 } // end maxsat
 
 KOKKOS_INLINE_FUNCTION
-void loadaer(const Real state_q[nvars],
+void loadaer(const Real state_q[aero_model::pcnst],
              const int nspec_amode[AeroConfig::num_modes()], Real air_density,
              const int phase,
              const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
@@ -335,7 +333,7 @@ void loadaer(const Real state_q[nvars],
 } // loadaer
 
 KOKKOS_INLINE_FUNCTION
-void ccncalc(const Real state_q[nvars], const Real tair,
+void ccncalc(const Real state_q[aero_model::pcnst], const Real tair,
              const Real qcldbrn[maxd_aspectype][AeroConfig::num_modes()],
              const Real qcldbrn_num[AeroConfig::num_modes()],
              const Real air_density,
@@ -702,7 +700,7 @@ void activate_modal(const Real w_in, const Real wmaxf, const Real tair,
 
 KOKKOS_INLINE_FUNCTION
 void get_activate_frac(
-    const Real state_q_kload[nvars], const Real air_density_kload,
+    const Real state_q_kload[aero_model::pcnst], const Real air_density_kload,
     const Real air_density_kk, const Real wtke,
     const Real tair, // in
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
@@ -775,7 +773,7 @@ void update_from_cldn_profile(
     const Real dz, // in
     const Real temp_col_in, const Real air_density, const Real air_density_kp1,
     const Real csbot_cscen,
-    const Real state_q_col_in_kp1[nvars], // in
+    const Real state_q_col_in_kp1[aero_model::pcnst], // in
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
     const Real specdens_amode[maxd_aspectype],
     const Real spechygro[maxd_aspectype],
@@ -963,7 +961,7 @@ void update_from_newcld(
     const Real cldn_col_in, const Real cldo_col_in,
     const Real dtinv, // in
     const Real wtke_col_in, const Real temp_col_in, const Real air_density,
-    const Real state_q_col_in[nvars], // in
+    const Real state_q_col_in[aero_model::pcnst], // in
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
     const Real specdens_amode[maxd_aspectype],
     const Real spechygro[maxd_aspectype],
@@ -1472,7 +1470,7 @@ void dropmixnuc(
     const ColumnView &qcld, const ColumnView &wsub,
     const ColumnView &cldo,               // in
     const ColumnView qqcw_fld[ncnst_tot], // inout
-    const ColumnView ptend_q[nvar_ptend_q], const ColumnView &tendnd,
+    const ColumnView ptend_q[aero_model::pcnst], const ColumnView &tendnd,
     const View2D &factnum, const ColumnView &ndropcol,
     const ColumnView &ndropmix, const ColumnView &nsource,
     const ColumnView &wtke, const View2D &ccn,
@@ -1513,7 +1511,7 @@ void dropmixnuc(
   //  qqcw(:)     cloud-borne aerosol mass, number mixing ratios [#/kg or kg/kg]
 
   // output arguments
-  // ptend_q[nvar_ptend_q]
+  // ptend_q[aero_model::pcnst]
   // tendnd(pcols,pver) tendency in droplet number mixing ratio [#/kg/s]
   // factnum(:,:,:)     activation fraction for aerosol number [fraction]
   // nsource            droplet number mixing ratio source tendency [#/kg/s]

--- a/src/mam4xx/water_uptake.hpp
+++ b/src/mam4xx/water_uptake.hpp
@@ -59,8 +59,6 @@ public:
 };
 
 namespace water_uptake {
-//  number of variables in state_q
-constexpr int nvars = 40;
 constexpr int maxd_aspectype = 14;
 constexpr Real small_value_30 = 1e-30; // (Bad Constant)
 constexpr Real small_value_31 = 1e-31; // (Bad Constant)
@@ -356,7 +354,7 @@ void modal_aero_water_uptake_dryaer(
     int nspec_amode[AeroConfig::num_modes()],
     Real specdens_amode[maxd_aspectype], Real spechygro[maxd_aspectype],
     int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    Real state_q[nvars], Real dgncur_a[AeroConfig::num_modes()],
+    Real state_q[aero_model::pcnst], Real dgncur_a[AeroConfig::num_modes()],
     Real hygro[AeroConfig::num_modes()], Real naer[AeroConfig::num_modes()],
     Real dryrad[AeroConfig::num_modes()], Real dryvol[AeroConfig::num_modes()],
     Real drymass[AeroConfig::num_modes()],
@@ -434,7 +432,7 @@ void modal_aero_water_uptake_dr_b4_wetdens(
     int nspec_amode[AeroConfig::num_modes()],
     Real specdens_amode[maxd_aspectype], Real spechygro[maxd_aspectype],
     int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    Real state_q[nvars], Real temperature, Real pmid, Real cldn,
+    Real state_q[aero_model::pcnst], Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
     Real qaerwat[AeroConfig::num_modes()], Real wetvol[AeroConfig::num_modes()],
@@ -476,7 +474,7 @@ void modal_aero_water_uptake_dr(
     int nspec_amode[AeroConfig::num_modes()],
     Real specdens_amode[maxd_aspectype], Real spechygro[maxd_aspectype],
     int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    Real state_q[nvars], Real temperature, Real pmid, Real cldn,
+    Real state_q[aero_model::pcnst], Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
     Real qaerwat[AeroConfig::num_modes()],
@@ -504,7 +502,7 @@ void modal_aero_water_uptake_dr(
     int nspec_amode[AeroConfig::num_modes()],
     Real specdens_amode[maxd_aspectype], Real spechygro[maxd_aspectype],
     int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    Real state_q[nvars], Real temperature, Real pmid, Real cldn,
+    Real state_q[aero_model::pcnst], Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
     Real qaerwat[AeroConfig::num_modes()]) {

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1323,13 +1323,13 @@ void compute_q_tendencies_phase_2(
     const Real pdel, const Real dt, const int mam_prevap_resusp_optcc,
     const int jnv, const int mm, const int k) {
 
-  static constexpr int gas_pcnst = aero_model::gas_pcnst;
+  static constexpr int pcnst = aero_model::pcnst;
   // There is no cloud-borne aerosol water in the model, so this
   // code block should NEVER execute for lspec =
   // nspec_amode(m)+1 (i.e., jnummaswtr = 2). The code only
   // worked because the "do lspec" loop cycles when lspec =
   // nspec_amode(m)+1, but that does not make the code correct.
-  Real qqcw_all[gas_pcnst] = {};
+  Real qqcw_all[pcnst] = {};
   utils::extract_qqcw_from_prognostics(progs, qqcw_all, k);
   const Real tracer = qqcw_all[mm];
   qqcw_sav = tracer;
@@ -1384,7 +1384,7 @@ void compute_q_tendencies(
     Kokkos::View<Real *> bcscavt, Kokkos::View<Real *> rcscavt,
     Kokkos::View<Real *> rtscavt_sv, Diagnostics::ColumnTracerView state_q,
     Diagnostics::ColumnTracerView ptend_q,
-    Kokkos::View<Real * [aero_model::maxd_aspectype + 2][aero_model::gas_pcnst]>
+    Kokkos::View<Real * [aero_model::maxd_aspectype + 2][aero_model::pcnst]>
         qqcw_sav,
     haero::ConstColumnView pdel, const Real dt, const int jnummaswtr,
     const int jnv, const int mm, const int lphase, const int imode,
@@ -1557,7 +1557,7 @@ private:
 
   Kokkos::View<Real *> rtscavt_sv;
 
-  Kokkos::View<Real * [aero_model::maxd_aspectype + 2][aero_model::gas_pcnst]>
+  Kokkos::View<Real * [aero_model::maxd_aspectype + 2][aero_model::pcnst]>
       qqcw_sav;
 
   Real scavimptblnum[aero_model::nimptblgrow_total][AeroConfig::num_modes()];
@@ -1589,15 +1589,15 @@ inline void WetDeposition::init(const AeroConfig &aero_config,
   Kokkos::resize(sol_factic, nlev);
   Kokkos::resize(sol_factb, nlev);
   Kokkos::resize(f_act_conv, nlev);
-  Kokkos::resize(qsrflx_mzaer2cnvpr, aero_model::gas_pcnst, 2);
+  Kokkos::resize(qsrflx_mzaer2cnvpr, aero_model::pcnst, 2);
   Kokkos::resize(qqcw_sav, nlev, aero_model::maxd_aspectype + 2,
-                 aero_model::gas_pcnst);
+                 aero_model::pcnst);
 
   Kokkos::resize(scavt, nlev);
   Kokkos::resize(bcscavt, nlev);
   Kokkos::resize(rcscavt, nlev);
 
-  Kokkos::resize(rtscavt_sv, aero_model::gas_pcnst);
+  Kokkos::resize(rtscavt_sv, aero_model::pcnst);
   Kokkos::deep_copy(rtscavt_sv, 0.0);
 
   const int num_modes = AeroConfig::num_modes();
@@ -1628,7 +1628,7 @@ void WetDeposition::compute_tendencies(
     const Atmosphere &atm, const Surface &sfc, const Prognostics &progs,
     const Diagnostics &diags, const Tendencies &tends) const {
   const int nlev = config_.nlev;
-  static constexpr int gas_pcnst = aero_model::gas_pcnst;
+  static constexpr int pcnst = aero_model::pcnst;
 
   // change mode order as mmode_loop_aa loops in a different order
   static constexpr int mode_order_change[4] = {0, 1, 3, 2};
@@ -1697,8 +1697,8 @@ void WetDeposition::compute_tendencies(
   team.team_barrier();
   ColumnView dlf = diags.total_convective_detrainment;
 
-  wetdep::zero_values(team, aerdepwetis, gas_pcnst);
-  wetdep::zero_values(team, aerdepwetcw, gas_pcnst);
+  wetdep::zero_values(team, aerdepwetis, pcnst);
+  wetdep::zero_values(team, aerdepwetcw, pcnst);
 
   // set the mass-weighted sol_factic for coarse mode species.
   wetdep::set_f_act(team, isprx, f_act_conv_coarse, f_act_conv_coarse_dust,

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1309,7 +1309,6 @@ void compute_q_tendencies_phase_1(
                                     rtscavt_sv);
 }
 
-static constexpr int gas_pcnst = aero_model::gas_pcnst;
 KOKKOS_INLINE_FUNCTION
 void compute_q_tendencies_phase_2(
     Real &scavt, Real &bcscavt, Real &rcscavt, Real rtscavt_sv[],
@@ -1324,6 +1323,7 @@ void compute_q_tendencies_phase_2(
     const Real pdel, const Real dt, const int mam_prevap_resusp_optcc,
     const int jnv, const int mm, const int k) {
 
+  static constexpr int gas_pcnst = aero_model::gas_pcnst;
   // There is no cloud-borne aerosol water in the model, so this
   // code block should NEVER execute for lspec =
   // nspec_amode(m)+1 (i.e., jnummaswtr = 2). The code only
@@ -1384,7 +1384,8 @@ void compute_q_tendencies(
     Kokkos::View<Real *> bcscavt, Kokkos::View<Real *> rcscavt,
     Kokkos::View<Real *> rtscavt_sv, Diagnostics::ColumnTracerView state_q,
     Diagnostics::ColumnTracerView ptend_q,
-    Kokkos::View<Real * [aero_model::maxd_aspectype + 2][gas_pcnst]> qqcw_sav,
+    Kokkos::View<Real * [aero_model::maxd_aspectype + 2][aero_model::gas_pcnst]>
+        qqcw_sav,
     haero::ConstColumnView pdel, const Real dt, const int jnummaswtr,
     const int jnv, const int mm, const int lphase, const int imode,
     const int lspec) {
@@ -1489,7 +1490,6 @@ void update_q_tendencies(const ThreadTeam &team,
 /// Wet Deposition process for MAM4 aerosol model.
 class WetDeposition {
 public:
-  static constexpr int gas_pcnst = aero_model::gas_pcnst;
   struct Config {
     Config(){};
     Config(const Config &) = default;
@@ -1557,7 +1557,8 @@ private:
 
   Kokkos::View<Real *> rtscavt_sv;
 
-  Kokkos::View<Real * [aero_model::maxd_aspectype + 2][gas_pcnst]> qqcw_sav;
+  Kokkos::View<Real * [aero_model::maxd_aspectype + 2][aero_model::gas_pcnst]>
+      qqcw_sav;
 
   Real scavimptblnum[aero_model::nimptblgrow_total][AeroConfig::num_modes()];
   Real scavimptblvol[aero_model::nimptblgrow_total][AeroConfig::num_modes()];
@@ -1588,14 +1589,15 @@ inline void WetDeposition::init(const AeroConfig &aero_config,
   Kokkos::resize(sol_factic, nlev);
   Kokkos::resize(sol_factb, nlev);
   Kokkos::resize(f_act_conv, nlev);
-  Kokkos::resize(qsrflx_mzaer2cnvpr, gas_pcnst, 2);
-  Kokkos::resize(qqcw_sav, nlev, aero_model::maxd_aspectype + 2, gas_pcnst);
+  Kokkos::resize(qsrflx_mzaer2cnvpr, aero_model::gas_pcnst, 2);
+  Kokkos::resize(qqcw_sav, nlev, aero_model::maxd_aspectype + 2,
+                 aero_model::gas_pcnst);
 
   Kokkos::resize(scavt, nlev);
   Kokkos::resize(bcscavt, nlev);
   Kokkos::resize(rcscavt, nlev);
 
-  Kokkos::resize(rtscavt_sv, gas_pcnst);
+  Kokkos::resize(rtscavt_sv, aero_model::gas_pcnst);
   Kokkos::deep_copy(rtscavt_sv, 0.0);
 
   const int num_modes = AeroConfig::num_modes();
@@ -1626,7 +1628,7 @@ void WetDeposition::compute_tendencies(
     const Atmosphere &atm, const Surface &sfc, const Prognostics &progs,
     const Diagnostics &diags, const Tendencies &tends) const {
   const int nlev = config_.nlev;
-  static constexpr int gas_pcnst = WetDeposition::gas_pcnst;
+  static constexpr int gas_pcnst = aero_model::gas_pcnst;
 
   // change mode order as mmode_loop_aa loops in a different order
   static constexpr int mode_order_change[4] = {0, 1, 3, 2};

--- a/src/tests/mam4_convproc_unit_tests.cpp
+++ b/src/tests/mam4_convproc_unit_tests.cpp
@@ -79,7 +79,7 @@ TEST_CASE("update_conu_from_act_frac", "mam4_convproc_process") {
   REQUIRE(dconudt[lc] == 3.0 / 8.0);
 }
 TEST_CASE("set_cloudborne_vars", "mam4_convproc_process") {
-  const int gas_pcnst = mam4::aero_model::gas_pcnst;
+  const int pcnst = mam4::aero_model::pcnst;
   const int num_modes = mam4::ConvProc::num_modes;
   const int pcnst_extd = mam4::ConvProc::pcnst_extd;
   const int maxd_aspectype = mam4::ConvProc::maxd_aspectype;
@@ -90,8 +90,8 @@ TEST_CASE("set_cloudborne_vars", "mam4_convproc_process") {
         Real aqfrac[pcnst_extd];
         bool doconvproc_extd[pcnst_extd];
         {
-          bool doconvproc[gas_pcnst];
-          for (int i = 0; i < gas_pcnst; ++i)
+          bool doconvproc[pcnst];
+          for (int i = 0; i < pcnst; ++i)
             // Set every other values to true as a test.
             doconvproc[i] = i % 2;
           mam4::convproc::set_cloudborne_vars(doconvproc, aqfrac,
@@ -121,12 +121,12 @@ TEST_CASE("set_cloudborne_vars", "mam4_convproc_process") {
     const int k = mam4::ConvProc::numptr_amode(j);
     // k%2 because that is what is set in doconvproc above.
     if (0 <= k && k % 2)
-      check.insert(gas_pcnst + k);
+      check.insert(pcnst + k);
     for (int i = 0; i < maxd_aspectype; ++i) {
       const int k = mam4::ConvProc::lmassptr_amode(i, j);
       // k%2 because that is what is set in doconvproc above.
       if (0 <= k && k % 2)
-        check.insert(gas_pcnst + k);
+        check.insert(pcnst + k);
     }
   }
   for (int i = 0; i < pcnst_extd; ++i) {
@@ -136,7 +136,7 @@ TEST_CASE("set_cloudborne_vars", "mam4_convproc_process") {
       REQUIRE(aqfrac[i] == 0.0);
   }
   for (int i = 0; i < pcnst_extd; ++i) {
-    if (i < gas_pcnst) {
+    if (i < pcnst) {
       // Fist values are set as in doconvproc:
       REQUIRE(doconvproc_extd[i] == i % 2);
     } else {
@@ -150,13 +150,13 @@ TEST_CASE("set_cloudborne_vars", "mam4_convproc_process") {
   }
 }
 TEST_CASE("assign_dotend", "mam4_convproc_process") {
-  const int gas_pcnst = mam4::aero_model::gas_pcnst;
-  ColumnView dotend_dev = testing::create_column_view(gas_pcnst);
+  const int pcnst = mam4::aero_model::pcnst;
+  ColumnView dotend_dev = testing::create_column_view(pcnst);
   Kokkos::parallel_for(
       1, KOKKOS_LAMBDA(const int) {
-        bool dotend[gas_pcnst];
+        bool dotend[pcnst];
         {
-          const int species_class[gas_pcnst] = {
+          const int species_class[pcnst] = {
               0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2,
               2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
           const bool convproc_do_aer = true;
@@ -164,17 +164,17 @@ TEST_CASE("assign_dotend", "mam4_convproc_process") {
           mam4::convproc::assign_dotend(species_class, convproc_do_aer,
                                         convproc_do_gas, dotend);
         }
-        for (int i = 0; i < gas_pcnst; ++i)
+        for (int i = 0; i < pcnst; ++i)
           dotend_dev[i] = dotend[i];
       });
-  bool dotend[gas_pcnst];
+  bool dotend[pcnst];
   {
     auto host_view = Kokkos::create_mirror_view(dotend_dev);
     Kokkos::deep_copy(host_view, dotend_dev);
-    for (int i = 0; i < gas_pcnst; ++i)
+    for (int i = 0; i < pcnst; ++i)
       dotend[i] = host_view[i];
   }
-  for (int i = 0; i < gas_pcnst; ++i) {
+  for (int i = 0; i < pcnst; ++i) {
     if (i < 15) {
       // First values are set to species_class != 2
       REQUIRE(dotend[i] == false);
@@ -185,9 +185,9 @@ TEST_CASE("assign_dotend", "mam4_convproc_process") {
   }
   Kokkos::parallel_for(
       1, KOKKOS_LAMBDA(const int) {
-        bool dotend[gas_pcnst];
+        bool dotend[pcnst];
         {
-          const int species_class[gas_pcnst] = {
+          const int species_class[pcnst] = {
               0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2,
               2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
           const bool convproc_do_aer = false;
@@ -195,16 +195,16 @@ TEST_CASE("assign_dotend", "mam4_convproc_process") {
           mam4::convproc::assign_dotend(species_class, convproc_do_aer,
                                         convproc_do_gas, dotend);
         }
-        for (int i = 0; i < gas_pcnst; ++i)
+        for (int i = 0; i < pcnst; ++i)
           dotend_dev[i] = dotend[i];
       });
   {
     auto host_view = Kokkos::create_mirror_view(dotend_dev);
     Kokkos::deep_copy(host_view, dotend_dev);
-    for (int i = 0; i < gas_pcnst; ++i)
+    for (int i = 0; i < pcnst; ++i)
       dotend[i] = host_view[i];
   }
-  for (int i = 0; i < gas_pcnst; ++i) {
+  for (int i = 0; i < pcnst; ++i) {
     if (i < 9 || 14 < i) {
       // First values are set to species_class != 3
       REQUIRE(dotend[i] == false);

--- a/src/tests/mam4_convproc_unit_tests.cpp
+++ b/src/tests/mam4_convproc_unit_tests.cpp
@@ -79,7 +79,7 @@ TEST_CASE("update_conu_from_act_frac", "mam4_convproc_process") {
   REQUIRE(dconudt[lc] == 3.0 / 8.0);
 }
 TEST_CASE("set_cloudborne_vars", "mam4_convproc_process") {
-  const int gas_pcnst = mam4::ConvProc::gas_pcnst;
+  const int gas_pcnst = mam4::aero_model::gas_pcnst;
   const int num_modes = mam4::ConvProc::num_modes;
   const int pcnst_extd = mam4::ConvProc::pcnst_extd;
   const int maxd_aspectype = mam4::ConvProc::maxd_aspectype;
@@ -150,7 +150,7 @@ TEST_CASE("set_cloudborne_vars", "mam4_convproc_process") {
   }
 }
 TEST_CASE("assign_dotend", "mam4_convproc_process") {
-  const int gas_pcnst = mam4::ConvProc::gas_pcnst;
+  const int gas_pcnst = mam4::aero_model::gas_pcnst;
   ColumnView dotend_dev = testing::create_column_view(gas_pcnst);
   Kokkos::parallel_for(
       1, KOKKOS_LAMBDA(const int) {

--- a/src/tests/mam4_ndrop_unit_tests.cpp
+++ b/src/tests/mam4_ndrop_unit_tests.cpp
@@ -126,7 +126,7 @@ TEST_CASE("test_get_aer_num", "mam4_ndrop_unit_tests") {
   // and then work backward to get state_q
   // span the orders of magnitude with the top and bottom outside the interval
   const Real test_num[4] = {1.2e18, 3.4e19, 5.6e20, 7.9e21};
-  Real state_q[mam4::ndrop::nvars];
+  Real state_q[mam4::aero_model::pcnst];
   Real naerosol;
   const Real ans[4] = {voltonumbhi_amode, test_num[1], test_num[2],
                        voltonumblo_amode};

--- a/src/validation/aerosol_optics/aer_rad_props_lw.cpp
+++ b/src/validation/aerosol_optics/aer_rad_props_lw.cpp
@@ -28,7 +28,7 @@ void aer_rad_props_lw(Ensemble *ensemble) {
     const auto state_q_db = input.get_array("state_q");
     auto qqcw_db = input.get_array("qqcw"); // 2d
 
-    View2D state_q("state_q", pver, nvars);
+    View2D state_q("state_q", pver, pcnst);
     mam4::validation::convert_1d_vector_to_2d_view_device(state_q_db, state_q);
 
     View2D qqcw("qqcw", pver, pcnst);

--- a/src/validation/aerosol_optics/aer_rad_props_sw.cpp
+++ b/src/validation/aerosol_optics/aer_rad_props_sw.cpp
@@ -29,7 +29,7 @@ void aer_rad_props_sw(Ensemble *ensemble) {
 
     int count = 0;
 
-    View2D state_q("state_q", pver, nvars);
+    View2D state_q("state_q", pver, pcnst);
     mam4::validation::convert_1d_vector_to_2d_view_device(state_q_db, state_q);
 
     const auto zm_db = input.get_array("zm");

--- a/src/validation/aerosol_optics/modal_aero_lw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_lw.cpp
@@ -28,7 +28,7 @@ void modal_aero_lw(Ensemble *ensemble) {
     const auto state_q_db = input.get_array("state_q");
     auto qqcw_db = input.get_array("qqcw"); // 2d
 
-    View2D state_q("state_q", pver, nvars);
+    View2D state_q("state_q", pver, pcnst);
     mam4::validation::convert_1d_vector_to_2d_view_device(state_q_db, state_q);
 
     View2D qqcw("qqcw", pver, pcnst);

--- a/src/validation/aerosol_optics/modal_aero_sw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_sw.cpp
@@ -29,7 +29,7 @@ void modal_aero_sw(Ensemble *ensemble) {
 
     int count = 0;
 
-    View2D state_q("state_q", pver, nvars);
+    View2D state_q("state_q", pver, pcnst);
     mam4::validation::convert_1d_vector_to_2d_view_device(state_q_db, state_q);
 
     const auto state_zm_db = input.get_array("state_zm");

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -15,10 +15,9 @@ using namespace haero;
 
 void modal_aero_calcsize_sub(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
-    constexpr int nvars = ndrop::nvars;
+    constexpr int pcnst = aero_model::pcnst;
     constexpr int pver = ndrop::pver;
     constexpr int ntot_amode = AeroConfig::num_modes();
-    constexpr int pcnst = modal_aer_opt::pcnst;
     constexpr int nspec_max = ndrop::nspec_max;
     constexpr int maxd_aspectype = ndrop::maxd_aspectype;
 
@@ -28,7 +27,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
     auto qqcw_db = input.get_array("qqcw");
     const auto dt = input.get_array("dt")[0];
 
-    View2D state_q("state_q", pver, nvars);
+    View2D state_q("state_q", pver, pcnst);
     mam4::validation::convert_1d_vector_to_2d_view_device(state_q_db, state_q);
     View2D qqcw("qqcw", pver, pcnst);
     auto qqcw_host = create_mirror_view(qqcw);

--- a/src/validation/convproc/compute_tendencies.cpp
+++ b/src/validation/convproc/compute_tendencies.cpp
@@ -70,7 +70,7 @@ void compute_tendencies(Ensemble *ensemble) {
     const Real dt = 36000;
     const Real pblh = 1000;
     // const int pcnst_extd = ConvProc::pcnst_extd;
-    const int pcnst = ConvProc::gas_pcnst;
+    const int pcnst = aero_model::gas_pcnst;
     // Fetch ensemble parameters
     // Convert to C++ index by subtracting one.
     // ktop is jt(il1g) to jt(il2g) in Fortran
@@ -146,13 +146,13 @@ void compute_tendencies(Ensemble *ensemble) {
         mam4::validation::create_column_view(nlev);
     diagnostics.delta_pressure = mam4::validation::create_column_view(nlev);
     auto mixing_ratio =
-        mam4::validation::create_column_view(nlev * ConvProc::gas_pcnst);
+        mam4::validation::create_column_view(nlev * aero_model::gas_pcnst);
     diagnostics.tracer_mixing_ratio = Diagnostics::ColumnTracerView(
-        mixing_ratio.data(), nlev, ConvProc::gas_pcnst);
+        mixing_ratio.data(), nlev, aero_model::gas_pcnst);
     auto mixing_ratio_dt =
-        mam4::validation::create_column_view(nlev * ConvProc::gas_pcnst);
+        mam4::validation::create_column_view(nlev * aero_model::gas_pcnst);
     diagnostics.d_tracer_mixing_ratio_dt = Diagnostics::ColumnTracerView(
-        mixing_ratio_dt.data(), nlev, ConvProc::gas_pcnst);
+        mixing_ratio_dt.data(), nlev, aero_model::gas_pcnst);
     Kokkos::parallel_for(
         "init_column_views", nlev, KOKKOS_LAMBDA(int i) {
           diagnostics.hydrostatic_dry_dp[i] = 0;
@@ -171,7 +171,7 @@ void compute_tendencies(Ensemble *ensemble) {
           diagnostics.mass_entrain_rate_into_downdraft[i] = 0;
           diagnostics.mass_detrain_rate_from_updraft[i] = 0;
           diagnostics.delta_pressure[i] = 0;
-          for (int j = 0; j < ConvProc::gas_pcnst; ++j) {
+          for (int j = 0; j < aero_model::gas_pcnst; ++j) {
             diagnostics.tracer_mixing_ratio(i, j) = 0;
             diagnostics.d_tracer_mixing_ratio_dt(i, j) = 0;
           }

--- a/src/validation/convproc/compute_tendencies.cpp
+++ b/src/validation/convproc/compute_tendencies.cpp
@@ -70,7 +70,7 @@ void compute_tendencies(Ensemble *ensemble) {
     const Real dt = 36000;
     const Real pblh = 1000;
     // const int pcnst_extd = ConvProc::pcnst_extd;
-    const int pcnst = aero_model::gas_pcnst;
+    const int pcnst = aero_model::pcnst;
     // Fetch ensemble parameters
     // Convert to C++ index by subtracting one.
     // ktop is jt(il1g) to jt(il2g) in Fortran
@@ -146,13 +146,13 @@ void compute_tendencies(Ensemble *ensemble) {
         mam4::validation::create_column_view(nlev);
     diagnostics.delta_pressure = mam4::validation::create_column_view(nlev);
     auto mixing_ratio =
-        mam4::validation::create_column_view(nlev * aero_model::gas_pcnst);
+        mam4::validation::create_column_view(nlev * aero_model::pcnst);
     diagnostics.tracer_mixing_ratio = Diagnostics::ColumnTracerView(
-        mixing_ratio.data(), nlev, aero_model::gas_pcnst);
+        mixing_ratio.data(), nlev, aero_model::pcnst);
     auto mixing_ratio_dt =
-        mam4::validation::create_column_view(nlev * aero_model::gas_pcnst);
+        mam4::validation::create_column_view(nlev * aero_model::pcnst);
     diagnostics.d_tracer_mixing_ratio_dt = Diagnostics::ColumnTracerView(
-        mixing_ratio_dt.data(), nlev, aero_model::gas_pcnst);
+        mixing_ratio_dt.data(), nlev, aero_model::pcnst);
     Kokkos::parallel_for(
         "init_column_views", nlev, KOKKOS_LAMBDA(int i) {
           diagnostics.hydrostatic_dry_dp[i] = 0;
@@ -171,7 +171,7 @@ void compute_tendencies(Ensemble *ensemble) {
           diagnostics.mass_entrain_rate_into_downdraft[i] = 0;
           diagnostics.mass_detrain_rate_from_updraft[i] = 0;
           diagnostics.delta_pressure[i] = 0;
-          for (int j = 0; j < aero_model::gas_pcnst; ++j) {
+          for (int j = 0; j < aero_model::pcnst; ++j) {
             diagnostics.tracer_mixing_ratio(i, j) = 0;
             diagnostics.d_tracer_mixing_ratio_dt(i, j) = 0;
           }

--- a/src/validation/convproc/initialize_tmr_array.cpp
+++ b/src/validation/convproc/initialize_tmr_array.cpp
@@ -26,7 +26,7 @@ void get_input(const Input &input, const std::string &name, const int size,
 }
 void get_input(const Input &input, const std::string &name, const int rows,
                const int cols, std::vector<Real> &host,
-               Kokkos::View<Real * [aero_model::gas_pcnst],
+               Kokkos::View<Real * [aero_model::pcnst],
                             Kokkos::MemoryUnmanaged> &dev) {
   host = input.get_array(name);
   EKAT_ASSERT(host.size() == rows * cols);
@@ -65,7 +65,7 @@ void initialize_tmr_array(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
     const int nlev = 72;
     const int pcnst_extd = ConvProc::pcnst_extd;
-    const int pcnst = aero_model::gas_pcnst;
+    const int pcnst = aero_model::pcnst;
     using Kokko2DView =
         Kokkos::View<Real *[pcnst_extd], Kokkos::MemoryUnmanaged>;
     // Fetch ensemble parameters

--- a/src/validation/convproc/initialize_tmr_array.cpp
+++ b/src/validation/convproc/initialize_tmr_array.cpp
@@ -24,10 +24,10 @@ void get_input(const Input &input, const std::string &name, const int size,
     host_view[n] = host[n];
   Kokkos::deep_copy(dev, host_view);
 }
-void get_input(const Input &input, const std::string &name, const int rows,
-               const int cols, std::vector<Real> &host,
-               Kokkos::View<Real * [aero_model::pcnst],
-                            Kokkos::MemoryUnmanaged> &dev) {
+void get_input(
+    const Input &input, const std::string &name, const int rows, const int cols,
+    std::vector<Real> &host,
+    Kokkos::View<Real * [aero_model::pcnst], Kokkos::MemoryUnmanaged> &dev) {
   host = input.get_array(name);
   EKAT_ASSERT(host.size() == rows * cols);
   ColumnView col_view = mam4::validation::create_column_view(rows * cols);

--- a/src/validation/convproc/initialize_tmr_array.cpp
+++ b/src/validation/convproc/initialize_tmr_array.cpp
@@ -24,10 +24,10 @@ void get_input(const Input &input, const std::string &name, const int size,
     host_view[n] = host[n];
   Kokkos::deep_copy(dev, host_view);
 }
-void get_input(
-    const Input &input, const std::string &name, const int rows, const int cols,
-    std::vector<Real> &host,
-    Kokkos::View<Real * [ConvProc::gas_pcnst], Kokkos::MemoryUnmanaged> &dev) {
+void get_input(const Input &input, const std::string &name, const int rows,
+               const int cols, std::vector<Real> &host,
+               Kokkos::View<Real * [aero_model::gas_pcnst],
+                            Kokkos::MemoryUnmanaged> &dev) {
   host = input.get_array(name);
   EKAT_ASSERT(host.size() == rows * cols);
   ColumnView col_view = mam4::validation::create_column_view(rows * cols);
@@ -65,7 +65,7 @@ void initialize_tmr_array(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
     const int nlev = 72;
     const int pcnst_extd = ConvProc::pcnst_extd;
-    const int pcnst = ConvProc::gas_pcnst;
+    const int pcnst = aero_model::gas_pcnst;
     using Kokko2DView =
         Kokkos::View<Real *[pcnst_extd], Kokkos::MemoryUnmanaged>;
     // Fetch ensemble parameters

--- a/src/validation/convproc/ma_convproc_dp_intr.cpp
+++ b/src/validation/convproc/ma_convproc_dp_intr.cpp
@@ -19,7 +19,7 @@ void init_scratch(
     Kokkos::View<Real *> scratch1Dviews[ConvProc::Col1DViewInd::NumScratch]) {
   const ConvProc::Config config_;
   Kokkos::resize(scratch1Dviews[ConvProc::q],
-                 config_.nlev * ConvProc::gas_pcnst);
+                 config_.nlev * aero_model::gas_pcnst);
   Kokkos::resize(scratch1Dviews[ConvProc::mu], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::md], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::eudp], config_.nlev);
@@ -73,10 +73,10 @@ void get_input(const Input &input, const std::string &name, const int size,
     host_view[n] = host[n];
   Kokkos::deep_copy(dev, host_view);
 }
-void get_input(
-    const Input &input, const std::string &name, const int rows, const int cols,
-    std::vector<Real> &host,
-    Kokkos::View<Real * [ConvProc::gas_pcnst], Kokkos::MemoryUnmanaged> &dev) {
+void get_input(const Input &input, const std::string &name, const int rows,
+               const int cols, std::vector<Real> &host,
+               Kokkos::View<Real * [aero_model::gas_pcnst],
+                            Kokkos::MemoryUnmanaged> &dev) {
   host = input.get_array(name);
   ColumnView col_view = mam4::validation::create_column_view(rows * cols);
   dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(col_view.data(), rows,
@@ -118,7 +118,7 @@ void ma_convproc_dp_intr(Ensemble *ensemble) {
     const int kbot = 71;
     const Real dt = 36000;
     // const int pcnst_extd = ConvProc::pcnst_extd;
-    const int pcnst = ConvProc::gas_pcnst;
+    const int pcnst = aero_model::gas_pcnst;
     const int nsrflx = 6;
     // Fetch ensemble parameters
     // Convert to C++ index by subtracting one.

--- a/src/validation/convproc/ma_convproc_dp_intr.cpp
+++ b/src/validation/convproc/ma_convproc_dp_intr.cpp
@@ -18,8 +18,7 @@ namespace {
 void init_scratch(
     Kokkos::View<Real *> scratch1Dviews[ConvProc::Col1DViewInd::NumScratch]) {
   const ConvProc::Config config_;
-  Kokkos::resize(scratch1Dviews[ConvProc::q],
-                 config_.nlev * aero_model::pcnst);
+  Kokkos::resize(scratch1Dviews[ConvProc::q], config_.nlev * aero_model::pcnst);
   Kokkos::resize(scratch1Dviews[ConvProc::mu], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::md], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::eudp], config_.nlev);
@@ -73,10 +72,10 @@ void get_input(const Input &input, const std::string &name, const int size,
     host_view[n] = host[n];
   Kokkos::deep_copy(dev, host_view);
 }
-void get_input(const Input &input, const std::string &name, const int rows,
-               const int cols, std::vector<Real> &host,
-               Kokkos::View<Real * [aero_model::pcnst],
-                            Kokkos::MemoryUnmanaged> &dev) {
+void get_input(
+    const Input &input, const std::string &name, const int rows, const int cols,
+    std::vector<Real> &host,
+    Kokkos::View<Real * [aero_model::pcnst], Kokkos::MemoryUnmanaged> &dev) {
   host = input.get_array(name);
   ColumnView col_view = mam4::validation::create_column_view(rows * cols);
   dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(col_view.data(), rows,

--- a/src/validation/convproc/ma_convproc_dp_intr.cpp
+++ b/src/validation/convproc/ma_convproc_dp_intr.cpp
@@ -19,7 +19,7 @@ void init_scratch(
     Kokkos::View<Real *> scratch1Dviews[ConvProc::Col1DViewInd::NumScratch]) {
   const ConvProc::Config config_;
   Kokkos::resize(scratch1Dviews[ConvProc::q],
-                 config_.nlev * aero_model::gas_pcnst);
+                 config_.nlev * aero_model::pcnst);
   Kokkos::resize(scratch1Dviews[ConvProc::mu], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::md], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::eudp], config_.nlev);
@@ -75,7 +75,7 @@ void get_input(const Input &input, const std::string &name, const int size,
 }
 void get_input(const Input &input, const std::string &name, const int rows,
                const int cols, std::vector<Real> &host,
-               Kokkos::View<Real * [aero_model::gas_pcnst],
+               Kokkos::View<Real * [aero_model::pcnst],
                             Kokkos::MemoryUnmanaged> &dev) {
   host = input.get_array(name);
   ColumnView col_view = mam4::validation::create_column_view(rows * cols);
@@ -118,7 +118,7 @@ void ma_convproc_dp_intr(Ensemble *ensemble) {
     const int kbot = 71;
     const Real dt = 36000;
     // const int pcnst_extd = ConvProc::pcnst_extd;
-    const int pcnst = aero_model::gas_pcnst;
+    const int pcnst = aero_model::pcnst;
     const int nsrflx = 6;
     // Fetch ensemble parameters
     // Convert to C++ index by subtracting one.

--- a/src/validation/convproc/ma_convproc_tend.cpp
+++ b/src/validation/convproc/ma_convproc_tend.cpp
@@ -18,8 +18,7 @@ namespace {
 void init_scratch(
     Kokkos::View<Real *> scratch1Dviews[ConvProc::Col1DViewInd::NumScratch]) {
   const ConvProc::Config config_;
-  Kokkos::resize(scratch1Dviews[ConvProc::q],
-                 config_.nlev * aero_model::pcnst);
+  Kokkos::resize(scratch1Dviews[ConvProc::q], config_.nlev * aero_model::pcnst);
   Kokkos::resize(scratch1Dviews[ConvProc::mu], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::md], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::eudp], config_.nlev);
@@ -73,10 +72,10 @@ void get_input(const Input &input, const std::string &name, const int size,
     host_view[n] = host[n];
   Kokkos::deep_copy(dev, host_view);
 }
-void get_input(const Input &input, const std::string &name, const int rows,
-               const int cols, std::vector<Real> &host,
-               Kokkos::View<Real * [aero_model::pcnst],
-                            Kokkos::MemoryUnmanaged> &dev) {
+void get_input(
+    const Input &input, const std::string &name, const int rows, const int cols,
+    std::vector<Real> &host,
+    Kokkos::View<Real * [aero_model::pcnst], Kokkos::MemoryUnmanaged> &dev) {
   host = input.get_array(name);
   ColumnView col_view = mam4::validation::create_column_view(rows * cols);
   dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(col_view.data(), rows,

--- a/src/validation/convproc/ma_convproc_tend.cpp
+++ b/src/validation/convproc/ma_convproc_tend.cpp
@@ -19,7 +19,7 @@ void init_scratch(
     Kokkos::View<Real *> scratch1Dviews[ConvProc::Col1DViewInd::NumScratch]) {
   const ConvProc::Config config_;
   Kokkos::resize(scratch1Dviews[ConvProc::q],
-                 config_.nlev * aero_model::gas_pcnst);
+                 config_.nlev * aero_model::pcnst);
   Kokkos::resize(scratch1Dviews[ConvProc::mu], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::md], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::eudp], config_.nlev);
@@ -75,7 +75,7 @@ void get_input(const Input &input, const std::string &name, const int size,
 }
 void get_input(const Input &input, const std::string &name, const int rows,
                const int cols, std::vector<Real> &host,
-               Kokkos::View<Real * [aero_model::gas_pcnst],
+               Kokkos::View<Real * [aero_model::pcnst],
                             Kokkos::MemoryUnmanaged> &dev) {
   host = input.get_array(name);
   ColumnView col_view = mam4::validation::create_column_view(rows * cols);
@@ -119,7 +119,7 @@ void ma_convproc_tend(Ensemble *ensemble) {
     const Real dt = 36000;
     const ConvProc::convtype convtype = ConvProc::Deep;
     // const int pcnst_extd = ConvProc::pcnst_extd;
-    const int pcnst = aero_model::gas_pcnst;
+    const int pcnst = aero_model::pcnst;
     const int nsrflx = 6;
     // Fetch ensemble parameters
     // Convert to C++ index by subtracting one.

--- a/src/validation/convproc/ma_convproc_tend.cpp
+++ b/src/validation/convproc/ma_convproc_tend.cpp
@@ -19,7 +19,7 @@ void init_scratch(
     Kokkos::View<Real *> scratch1Dviews[ConvProc::Col1DViewInd::NumScratch]) {
   const ConvProc::Config config_;
   Kokkos::resize(scratch1Dviews[ConvProc::q],
-                 config_.nlev * ConvProc::gas_pcnst);
+                 config_.nlev * aero_model::gas_pcnst);
   Kokkos::resize(scratch1Dviews[ConvProc::mu], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::md], 1 + config_.nlev);
   Kokkos::resize(scratch1Dviews[ConvProc::eudp], config_.nlev);
@@ -73,10 +73,10 @@ void get_input(const Input &input, const std::string &name, const int size,
     host_view[n] = host[n];
   Kokkos::deep_copy(dev, host_view);
 }
-void get_input(
-    const Input &input, const std::string &name, const int rows, const int cols,
-    std::vector<Real> &host,
-    Kokkos::View<Real * [ConvProc::gas_pcnst], Kokkos::MemoryUnmanaged> &dev) {
+void get_input(const Input &input, const std::string &name, const int rows,
+               const int cols, std::vector<Real> &host,
+               Kokkos::View<Real * [aero_model::gas_pcnst],
+                            Kokkos::MemoryUnmanaged> &dev) {
   host = input.get_array(name);
   ColumnView col_view = mam4::validation::create_column_view(rows * cols);
   dev = Kokkos::View<Real **, Kokkos::MemoryUnmanaged>(col_view.data(), rows,
@@ -119,7 +119,7 @@ void ma_convproc_tend(Ensemble *ensemble) {
     const Real dt = 36000;
     const ConvProc::convtype convtype = ConvProc::Deep;
     // const int pcnst_extd = ConvProc::pcnst_extd;
-    const int pcnst = ConvProc::gas_pcnst;
+    const int pcnst = aero_model::gas_pcnst;
     const int nsrflx = 6;
     // Fetch ensemble parameters
     // Convert to C++ index by subtracting one.

--- a/src/validation/convproc/ma_precpevap_convproc.cpp
+++ b/src/validation/convproc/ma_precpevap_convproc.cpp
@@ -102,12 +102,12 @@ void ma_precpevap_convproc(Ensemble *ensemble) {
     get_input(nlev, pcnst_extd, dcondt_prevap_hist_host,
               dcondt_prevap_hist_dev);
 
-    get_input(input, "species_class", aero_model::gas_pcnst, species_class_host,
+    get_input(input, "species_class", aero_model::pcnst, species_class_host,
               species_class_dev);
     get_input(input, "doconvproc_extd", pcnst_extd, doconvproc_extd_host,
               doconvproc_extd_dev);
     get_input(input, "dcondt", nlev, pcnst_extd, dcondt_host, dcondt_dev);
-    get_input(input, "mmtoo_prevap_resusp", aero_model::gas_pcnst,
+    get_input(input, "mmtoo_prevap_resusp", aero_model::pcnst,
               mmtoo_prevap_resusp_host, mmtoo_prevap_resusp_dev);
     ColumnView wd_flux =
         mam4::validation::create_column_view(ConvProc::pcnst_extd);
@@ -116,11 +116,11 @@ void ma_precpevap_convproc(Ensemble *ensemble) {
           bool doconvproc_extd[ConvProc::pcnst_extd];
           for (int i = 0; i < ConvProc::pcnst_extd; ++i)
             doconvproc_extd[i] = doconvproc_extd_dev[i];
-          int species_class[aero_model::gas_pcnst];
-          for (int i = 0; i < aero_model::gas_pcnst; ++i)
+          int species_class[aero_model::pcnst];
+          for (int i = 0; i < aero_model::pcnst; ++i)
             species_class[i] = species_class_dev[i];
-          int mmtoo_prevap_resusp[aero_model::gas_pcnst];
-          for (int i = 0; i < aero_model::gas_pcnst; ++i)
+          int mmtoo_prevap_resusp[aero_model::pcnst];
+          for (int i = 0; i < aero_model::pcnst; ++i)
             mmtoo_prevap_resusp[i] = mmtoo_prevap_resusp_dev[i] - 1;
 
           convproc::ma_precpevap_convproc(

--- a/src/validation/convproc/ma_precpevap_convproc.cpp
+++ b/src/validation/convproc/ma_precpevap_convproc.cpp
@@ -102,12 +102,12 @@ void ma_precpevap_convproc(Ensemble *ensemble) {
     get_input(nlev, pcnst_extd, dcondt_prevap_hist_host,
               dcondt_prevap_hist_dev);
 
-    get_input(input, "species_class", ConvProc::gas_pcnst, species_class_host,
+    get_input(input, "species_class", aero_model::gas_pcnst, species_class_host,
               species_class_dev);
     get_input(input, "doconvproc_extd", pcnst_extd, doconvproc_extd_host,
               doconvproc_extd_dev);
     get_input(input, "dcondt", nlev, pcnst_extd, dcondt_host, dcondt_dev);
-    get_input(input, "mmtoo_prevap_resusp", ConvProc::gas_pcnst,
+    get_input(input, "mmtoo_prevap_resusp", aero_model::gas_pcnst,
               mmtoo_prevap_resusp_host, mmtoo_prevap_resusp_dev);
     ColumnView wd_flux =
         mam4::validation::create_column_view(ConvProc::pcnst_extd);
@@ -116,11 +116,11 @@ void ma_precpevap_convproc(Ensemble *ensemble) {
           bool doconvproc_extd[ConvProc::pcnst_extd];
           for (int i = 0; i < ConvProc::pcnst_extd; ++i)
             doconvproc_extd[i] = doconvproc_extd_dev[i];
-          int species_class[ConvProc::gas_pcnst];
-          for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+          int species_class[aero_model::gas_pcnst];
+          for (int i = 0; i < aero_model::gas_pcnst; ++i)
             species_class[i] = species_class_dev[i];
-          int mmtoo_prevap_resusp[ConvProc::gas_pcnst];
-          for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+          int mmtoo_prevap_resusp[aero_model::gas_pcnst];
+          for (int i = 0; i < aero_model::gas_pcnst; ++i)
             mmtoo_prevap_resusp[i] = mmtoo_prevap_resusp_dev[i] - 1;
 
           convproc::ma_precpevap_convproc(

--- a/src/validation/convproc/ma_precpprod.cpp
+++ b/src/validation/convproc/ma_precpprod.cpp
@@ -93,7 +93,7 @@ void ma_precpprod(Ensemble *ensemble) {
         dcondt_dev, dcondt_prevap_dev, dcondt_prevap_hist_dev;
     get_input(input, "dcondt_wetdep", nlev, pcnst_extd, dcondt_wetdep_host,
               dcondt_wetdep_dev);
-    get_input(input, "species_class", ConvProc::gas_pcnst, species_class_host,
+    get_input(input, "species_class", aero_model::gas_pcnst, species_class_host,
               species_class_dev);
     get_input(input, "doconvproc_extd", pcnst_extd, doconvproc_extd_host,
               doconvproc_extd_dev);
@@ -103,7 +103,7 @@ void ma_precpprod(Ensemble *ensemble) {
               dcondt_prevap_dev);
     get_input(input, "dcondt_prevap_hist", nlev, pcnst_extd,
               dcondt_prevap_hist_host, dcondt_prevap_hist_dev);
-    get_input(input, "mmtoo_prevap_resusp", ConvProc::gas_pcnst,
+    get_input(input, "mmtoo_prevap_resusp", aero_model::gas_pcnst,
               mmtoo_prevap_resusp_host, mmtoo_prevap_resusp_dev);
     ColumnView return_vals = mam4::validation::create_column_view(3);
     Kokkos::parallel_for(
@@ -117,11 +117,11 @@ void ma_precpprod(Ensemble *ensemble) {
           bool doconvproc_extd[ConvProc::pcnst_extd];
           for (int i = 0; i < ConvProc::pcnst_extd; ++i)
             doconvproc_extd[i] = doconvproc_extd_dev[i];
-          int species_class[ConvProc::gas_pcnst];
-          for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+          int species_class[aero_model::gas_pcnst];
+          for (int i = 0; i < aero_model::gas_pcnst; ++i)
             species_class[i] = species_class_dev[i];
-          int mmtoo_prevap_resusp[ConvProc::gas_pcnst];
-          for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+          int mmtoo_prevap_resusp[aero_model::gas_pcnst];
+          for (int i = 0; i < aero_model::gas_pcnst; ++i)
             mmtoo_prevap_resusp[i] = mmtoo_prevap_resusp_dev[i] - 1;
 
           auto dcondt_wetdep =
@@ -179,11 +179,11 @@ void ma_precpprod(Ensemble *ensemble) {
         bool doconvproc_extd[ConvProc::pcnst_extd];
         for (int i = 0; i < ConvProc::pcnst_extd; ++i)
           doconvproc_extd[i] = 1;
-        int species_class[ConvProc::gas_pcnst];
-        for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+        int species_class[aero_model::gas_pcnst];
+        for (int i = 0; i < aero_model::gas_pcnst; ++i)
           species_class[i] = 1;
-        int mmtoo_prevap_resusp[ConvProc::gas_pcnst];
-        for (int i = 0; i < ConvProc::gas_pcnst; ++i)
+        int mmtoo_prevap_resusp[aero_model::gas_pcnst];
+        for (int i = 0; i < aero_model::gas_pcnst; ++i)
           mmtoo_prevap_resusp[i] = 1;
 
         for (int i = 0; i < ConvProc::pcnst_extd; ++i)

--- a/src/validation/convproc/ma_precpprod.cpp
+++ b/src/validation/convproc/ma_precpprod.cpp
@@ -93,7 +93,7 @@ void ma_precpprod(Ensemble *ensemble) {
         dcondt_dev, dcondt_prevap_dev, dcondt_prevap_hist_dev;
     get_input(input, "dcondt_wetdep", nlev, pcnst_extd, dcondt_wetdep_host,
               dcondt_wetdep_dev);
-    get_input(input, "species_class", aero_model::gas_pcnst, species_class_host,
+    get_input(input, "species_class", aero_model::pcnst, species_class_host,
               species_class_dev);
     get_input(input, "doconvproc_extd", pcnst_extd, doconvproc_extd_host,
               doconvproc_extd_dev);
@@ -103,7 +103,7 @@ void ma_precpprod(Ensemble *ensemble) {
               dcondt_prevap_dev);
     get_input(input, "dcondt_prevap_hist", nlev, pcnst_extd,
               dcondt_prevap_hist_host, dcondt_prevap_hist_dev);
-    get_input(input, "mmtoo_prevap_resusp", aero_model::gas_pcnst,
+    get_input(input, "mmtoo_prevap_resusp", aero_model::pcnst,
               mmtoo_prevap_resusp_host, mmtoo_prevap_resusp_dev);
     ColumnView return_vals = mam4::validation::create_column_view(3);
     Kokkos::parallel_for(
@@ -117,11 +117,11 @@ void ma_precpprod(Ensemble *ensemble) {
           bool doconvproc_extd[ConvProc::pcnst_extd];
           for (int i = 0; i < ConvProc::pcnst_extd; ++i)
             doconvproc_extd[i] = doconvproc_extd_dev[i];
-          int species_class[aero_model::gas_pcnst];
-          for (int i = 0; i < aero_model::gas_pcnst; ++i)
+          int species_class[aero_model::pcnst];
+          for (int i = 0; i < aero_model::pcnst; ++i)
             species_class[i] = species_class_dev[i];
-          int mmtoo_prevap_resusp[aero_model::gas_pcnst];
-          for (int i = 0; i < aero_model::gas_pcnst; ++i)
+          int mmtoo_prevap_resusp[aero_model::pcnst];
+          for (int i = 0; i < aero_model::pcnst; ++i)
             mmtoo_prevap_resusp[i] = mmtoo_prevap_resusp_dev[i] - 1;
 
           auto dcondt_wetdep =
@@ -179,11 +179,11 @@ void ma_precpprod(Ensemble *ensemble) {
         bool doconvproc_extd[ConvProc::pcnst_extd];
         for (int i = 0; i < ConvProc::pcnst_extd; ++i)
           doconvproc_extd[i] = 1;
-        int species_class[aero_model::gas_pcnst];
-        for (int i = 0; i < aero_model::gas_pcnst; ++i)
+        int species_class[aero_model::pcnst];
+        for (int i = 0; i < aero_model::pcnst; ++i)
           species_class[i] = 1;
-        int mmtoo_prevap_resusp[aero_model::gas_pcnst];
-        for (int i = 0; i < aero_model::gas_pcnst; ++i)
+        int mmtoo_prevap_resusp[aero_model::pcnst];
+        for (int i = 0; i < aero_model::pcnst; ++i)
           mmtoo_prevap_resusp[i] = 1;
 
         for (int i = 0; i < ConvProc::pcnst_extd; ++i)

--- a/src/validation/convproc/ma_resuspend_convproc.cpp
+++ b/src/validation/convproc/ma_resuspend_convproc.cpp
@@ -51,7 +51,7 @@ void ma_resuspend_convproc(Ensemble *ensemble) {
   // Run the ensemble.
   ensemble->process([=](const Input &input, Output &output) {
     const int nlev = 72;
-    const int gas_pcnst = aero_model::gas_pcnst;
+    const int pcnst = aero_model::pcnst;
     // Fetch ensemble parameters
 
     // these variables depend on mode No and k
@@ -60,7 +60,7 @@ void ma_resuspend_convproc(Ensemble *ensemble) {
     EKAT_ASSERT(nlev == kbot_prevap);
     // number of tracers to transport
     const int pcnst_extd = input.get("pcnst_extd");
-    EKAT_ASSERT(pcnst_extd == 2 * gas_pcnst);
+    EKAT_ASSERT(pcnst_extd == 2 * pcnst);
 
     // flag for doing convective transport
     std::vector<Real> dcondt_host, dcondt_resusp_host;
@@ -78,15 +78,15 @@ void ma_resuspend_convproc(Ensemble *ensemble) {
         "ma_resuspend_convproc", kbot_prevap, KOKKOS_LAMBDA(int klev) {
           if (ktop - 1 <= klev) {
 
-            Real dcondt[2 * gas_pcnst];
-            for (int i = 0; i < 2 * gas_pcnst; ++i)
+            Real dcondt[2 * pcnst];
+            for (int i = 0; i < 2 * pcnst; ++i)
               dcondt[i] = dcondt_dev(i, klev);
-            Real dcondt_resusp[2 * gas_pcnst];
+            Real dcondt_resusp[2 * pcnst];
             convproc::ma_resuspend_convproc(dcondt, dcondt_resusp);
 
-            for (int i = 0; i < 2 * gas_pcnst; ++i)
+            for (int i = 0; i < 2 * pcnst; ++i)
               dcondt_dev(i, klev) = dcondt[i];
-            for (int i = 0; i < 2 * gas_pcnst; ++i)
+            for (int i = 0; i < 2 * pcnst; ++i)
               dcondt_resusp_dev(i, klev) = dcondt_resusp[i];
           }
         });

--- a/src/validation/convproc/ma_resuspend_convproc.cpp
+++ b/src/validation/convproc/ma_resuspend_convproc.cpp
@@ -51,7 +51,7 @@ void ma_resuspend_convproc(Ensemble *ensemble) {
   // Run the ensemble.
   ensemble->process([=](const Input &input, Output &output) {
     const int nlev = 72;
-    const int gas_pcnst = ConvProc::gas_pcnst;
+    const int gas_pcnst = aero_model::gas_pcnst;
     // Fetch ensemble parameters
 
     // these variables depend on mode No and k

--- a/src/validation/convproc/update_qnew_ptend.cpp
+++ b/src/validation/convproc/update_qnew_ptend.cpp
@@ -39,7 +39,7 @@ void update_qnew_ptend(Ensemble *ensemble) {
 
   // Run the ensemble.
   ensemble->process([=](const Input &input, Output &output) {
-    const int gas_pcnst = aero_model::gas_pcnst;
+    const int pcnst = aero_model::pcnst;
     // Fetch ensemble parameters
 
     // delta t (model time increment) [s]
@@ -52,43 +52,43 @@ void update_qnew_ptend(Ensemble *ensemble) {
         qnew_host;
     ColumnView dotend_dev, ptend_lq_dev, dqdt_dev, ptend_q_dev, qnew_dev;
 
-    get_input(input, "dotend", gas_pcnst, dotend_host, dotend_dev);
-    get_input(input, "dqdt", gas_pcnst, dqdt_host, dqdt_dev);
-    get_input(input, "ptend_lq", gas_pcnst, ptend_lq_host, ptend_lq_dev);
-    get_input(input, "ptend_q", gas_pcnst, ptend_q_host, ptend_q_dev);
-    get_input(input, "qnew", gas_pcnst, qnew_host, qnew_dev);
+    get_input(input, "dotend", pcnst, dotend_host, dotend_dev);
+    get_input(input, "dqdt", pcnst, dqdt_host, dqdt_dev);
+    get_input(input, "ptend_lq", pcnst, ptend_lq_host, ptend_lq_dev);
+    get_input(input, "ptend_q", pcnst, ptend_q_host, ptend_q_dev);
+    get_input(input, "qnew", pcnst, qnew_host, qnew_dev);
 
     Kokkos::parallel_for(
         "update_qnew_ptend", 1, KOKKOS_LAMBDA(int) {
-          bool dotend[gas_pcnst];
-          for (int n = 0; n < gas_pcnst; ++n)
+          bool dotend[pcnst];
+          for (int n = 0; n < pcnst; ++n)
             dotend[n] = dotend_dev[n];
-          bool ptend_lq[gas_pcnst];
-          for (int n = 0; n < gas_pcnst; ++n)
+          bool ptend_lq[pcnst];
+          for (int n = 0; n < pcnst; ++n)
             ptend_lq[n] = ptend_lq_dev[n];
 
-          Real dqdt[gas_pcnst];
-          for (int j = 0; j < gas_pcnst; ++j)
+          Real dqdt[pcnst];
+          for (int j = 0; j < pcnst; ++j)
             dqdt[j] = dqdt_dev(j);
-          Real ptend_q[gas_pcnst];
-          for (int j = 0; j < gas_pcnst; ++j)
+          Real ptend_q[pcnst];
+          for (int j = 0; j < pcnst; ++j)
             ptend_q[j] = ptend_q_dev(j);
-          Real qnew[gas_pcnst];
-          for (int j = 0; j < gas_pcnst; ++j)
+          Real qnew[pcnst];
+          for (int j = 0; j < pcnst; ++j)
             qnew[j] = qnew_dev(j);
 
           convproc::update_qnew_ptend(dotend, is_update_ptend, dqdt, dt,
                                       ptend_lq, ptend_q, qnew);
-          for (int n = 0; n < gas_pcnst; ++n)
+          for (int n = 0; n < pcnst; ++n)
             ptend_lq_dev[n] = ptend_lq[n];
-          for (int j = 0; j < gas_pcnst; ++j)
+          for (int j = 0; j < pcnst; ++j)
             ptend_q_dev(j) = ptend_q[j];
-          for (int j = 0; j < gas_pcnst; ++j)
+          for (int j = 0; j < pcnst; ++j)
             qnew_dev(j) = qnew[j];
         });
 
-    set_output(output, "ptend_lq", gas_pcnst, ptend_lq_host, ptend_lq_dev);
-    set_output(output, "ptend_q", gas_pcnst, ptend_q_host, ptend_q_dev);
-    set_output(output, "qnew", gas_pcnst, qnew_host, qnew_dev);
+    set_output(output, "ptend_lq", pcnst, ptend_lq_host, ptend_lq_dev);
+    set_output(output, "ptend_q", pcnst, ptend_q_host, ptend_q_dev);
+    set_output(output, "qnew", pcnst, qnew_host, qnew_dev);
   });
 }

--- a/src/validation/convproc/update_qnew_ptend.cpp
+++ b/src/validation/convproc/update_qnew_ptend.cpp
@@ -39,7 +39,7 @@ void update_qnew_ptend(Ensemble *ensemble) {
 
   // Run the ensemble.
   ensemble->process([=](const Input &input, Output &output) {
-    const int gas_pcnst = ConvProc::gas_pcnst;
+    const int gas_pcnst = aero_model::gas_pcnst;
     // Fetch ensemble parameters
 
     // delta t (model time increment) [s]

--- a/src/validation/convproc/update_tendency_final.cpp
+++ b/src/validation/convproc/update_tendency_final.cpp
@@ -194,8 +194,7 @@ void update_tendency_final(Ensemble *ensemble) {
     set_output(output, "q_i", ncnst, kbot_prevap, row_major, q_i_host, q_i_dev);
     set_output(output, "qsrflx", ncnst, nsrflx, col_major, qsrflx_host,
                qsrflx_dev);
-    set_output(output, "doconvproc", pcnst, doconvproc_host,
-               doconvproc_dev);
+    set_output(output, "doconvproc", pcnst, doconvproc_host, doconvproc_dev);
     set_output(output, "sumactiva", 2 * ncnst, sumactiva_host, sumactiva_dev);
     set_output(output, "sumaqchem", 2 * ncnst, sumaqchem_host, sumaqchem_dev);
     set_output(output, "sumwetdep", 2 * ncnst, sumwetdep_host, sumwetdep_dev);

--- a/src/validation/convproc/update_tendency_final.cpp
+++ b/src/validation/convproc/update_tendency_final.cpp
@@ -82,7 +82,7 @@ void update_tendency_final(Ensemble *ensemble) {
   // Run the ensemble.
   ensemble->process([=](const Input &input, Output &output) {
     const int nlev = 72;
-    const int gas_pcnst = ConvProc::gas_pcnst;
+    const int gas_pcnst = aero_model::gas_pcnst;
     // Fetch ensemble parameters
 
     // delta t (model time increment) [s]

--- a/src/validation/drydep/compute_tendencies.cpp
+++ b/src/validation/drydep/compute_tendencies.cpp
@@ -31,7 +31,7 @@ void compute_tendencies(Ensemble *ensemble) {
       EKAT_REQUIRE_MSG(input.has_array(s), "Required name: " + s);
 
     for (std::string s : {"statq_", "qqcw_"}) {
-      for (int i = aerosol_index; i < aero_model::gas_pcnst; ++i) {
+      for (int i = aerosol_index; i < aero_model::pcnst; ++i) {
         const std::string name = s + std::to_string(i + 1);
         EKAT_REQUIRE_MSG(input.has_array(name), "Required name: " + name);
         EKAT_REQUIRE_MSG(nlev == input.get_array(name).size(),
@@ -74,12 +74,12 @@ void compute_tendencies(Ensemble *ensemble) {
     haero::ConstColumnView pdel = to_dev(input.get_array("pdel"));
 
     auto state_q_mem =
-        mam4::validation::create_column_view(nlev * aero_model::gas_pcnst);
+        mam4::validation::create_column_view(nlev * aero_model::pcnst);
     Diagnostics::ColumnTracerView state_q(state_q_mem.data(), nlev,
-                                          aero_model::gas_pcnst);
+                                          aero_model::pcnst);
     {
       auto host_q = Kokkos::create_mirror_view(state_q);
-      for (int i = aerosol_index; i < aero_model::gas_pcnst; ++i) {
+      for (int i = aerosol_index; i < aero_model::pcnst; ++i) {
         const std::string name = "statq_" + std::to_string(i + 1);
         const std::vector<Real> vec = input.get_array(name);
         for (int j = 0; j < vec.size(); ++j)
@@ -88,8 +88,8 @@ void compute_tendencies(Ensemble *ensemble) {
       Kokkos::deep_copy(state_q, host_q);
     }
 
-    Kokkos::View<Real *> qqcw[aero_model::gas_pcnst];
-    for (int i = 0; i < aero_model::gas_pcnst; ++i) {
+    Kokkos::View<Real *> qqcw[aero_model::pcnst];
+    for (int i = 0; i < aero_model::pcnst; ++i) {
       const std::string name = "qqcw_" + std::to_string(i + 1);
       if (i < aerosol_index)
         qqcw[i] = mam4::validation::create_column_view(nlev);
@@ -131,14 +131,14 @@ void compute_tendencies(Ensemble *ensemble) {
     const Real dt = input.get_array("dt").front();
 
     auto ptend_q_mem =
-        mam4::validation::create_column_view(nlev * aero_model::gas_pcnst);
+        mam4::validation::create_column_view(nlev * aero_model::pcnst);
     Diagnostics::ColumnTracerView ptend_q(ptend_q_mem.data(), nlev,
-                                          aero_model::gas_pcnst);
+                                          aero_model::pcnst);
 
     ColumnView aerdepdryis =
-        mam4::validation::create_column_view(aero_model::gas_pcnst);
+        mam4::validation::create_column_view(aero_model::pcnst);
     ColumnView aerdepdrycw =
-        mam4::validation::create_column_view(aero_model::gas_pcnst);
+        mam4::validation::create_column_view(aero_model::pcnst);
 
     const int aerosol_categories = DryDeposition::aerosol_categories;
     ColumnView rho = mam4::validation::create_column_view(nlev);
@@ -152,8 +152,8 @@ void compute_tendencies(Ensemble *ensemble) {
         Kokkos::resize(vlc_grv[j][i], nlev);
       }
     }
-    Kokkos::View<Real *> dqdt_tmp[aero_model::gas_pcnst];
-    for (int i = 0; i < aero_model::gas_pcnst; ++i)
+    Kokkos::View<Real *> dqdt_tmp[aero_model::pcnst];
+    for (int i = 0; i < aero_model::pcnst; ++i)
       Kokkos::resize(dqdt_tmp[i], nlev);
 
     Real pblh = 1000;
@@ -228,7 +228,7 @@ void compute_tendencies(Ensemble *ensemble) {
     std::vector<Real> cw_host = to_host(aerdepdrycw);
     Kokkos::deep_copy(ptend_host, ptend_q);
     std::vector<Real> ptend(nlev);
-    for (int m = aerosol_index; m < aero_model::gas_pcnst; ++m) {
+    for (int m = aerosol_index; m < aero_model::pcnst; ++m) {
       for (int lev = 0; lev < nlev; ++lev)
         ptend[lev] = ptend_host(lev, m);
       output.set("ptendq_" + std::to_string(m + 1), ptend);

--- a/src/validation/ndrop/ccncalc.cpp
+++ b/src/validation/ndrop/ccncalc.cpp
@@ -19,7 +19,7 @@ void ccncalc(Ensemble *ensemble) {
     const Real zero = 0;
     const int maxd_aspectype = ndrop::maxd_aspectype;
     const int ntot_amode = AeroConfig::num_modes();
-    const int nvars = ndrop::nvars;
+    const int pcnst = aero_model::pcnst;
     const int psat = ndrop::psat;
 
     const int pver = ndrop::pver;
@@ -35,11 +35,11 @@ void ccncalc(Ensemble *ensemble) {
     using View2D = ndrop::View2D;
     using View1DHost = typename HostType::view_1d<Real>;
 
-    View2D state_q("state_q", pver, nvars);
+    View2D state_q("state_q", pver, pcnst);
     auto state_host = Kokkos::create_mirror_view(state_q);
 
     int count = 0;
-    for (int i = 0; i < nvars; ++i) {
+    for (int i = 0; i < pcnst; ++i) {
       // input data is store on the cpu.
       for (int kk = 0; kk < pver; ++kk) {
         state_host(kk, i) = state_q_db[count];

--- a/src/validation/ndrop/dropmixnuc.cpp
+++ b/src/validation/ndrop/dropmixnuc.cpp
@@ -17,11 +17,10 @@ void dropmixnuc(Ensemble *ensemble) {
     const Real zero = 0;
     const int maxd_aspectype = ndrop::maxd_aspectype;
     const int ntot_amode = AeroConfig::num_modes();
-    const int nvars = ndrop::nvars;
+    const int pcnst = aero_model::pcnst;
     const int psat = ndrop::psat;
     const int ncnst_tot = ndrop::ncnst_tot;
     const int nspec_max = mam4::ndrop::nspec_max;
-    const int nvar_ptend_q = mam4::ndrop::nvar_ptend_q;
 
     const int pver = ndrop::pver;
     const auto state_q_db = input.get_array("state_q");
@@ -47,10 +46,10 @@ void dropmixnuc(Ensemble *ensemble) {
 
     int count = 0;
 
-    View2D state_q("state_q", pver, nvars);
+    View2D state_q("state_q", pver, pcnst);
     auto state_host = Kokkos::create_mirror_view(state_q);
 
-    for (int i = 0; i < nvars; ++i) {
+    for (int i = 0; i < pcnst; ++i) {
       // input data is store on the cpu.
       for (int kk = 0; kk < pver; ++kk) {
         state_host(kk, i) = state_q_db[count];
@@ -145,10 +144,10 @@ void dropmixnuc(Ensemble *ensemble) {
     nsource = haero::testing::create_column_view(pver);
     wtke = haero::testing::create_column_view(pver);
 
-    ColumnView ptend_q[nvar_ptend_q];
+    ColumnView ptend_q[pcnst];
 
     count = 0;
-    for (int i = 0; i < nvar_ptend_q; ++i) {
+    for (int i = 0; i < pcnst; ++i) {
       ptend_q[i] = haero::testing::create_column_view(pver);
     }
 
@@ -274,7 +273,7 @@ void dropmixnuc(Ensemble *ensemble) {
 
     auto ptend_q_host = Kokkos::create_mirror_view(ptend_q[0]);
     std::vector<Real> output_ptend_q;
-    for (int i = 0; i < nvar_ptend_q; ++i) {
+    for (int i = 0; i < pcnst; ++i) {
       Kokkos::deep_copy(ptend_q_host, ptend_q[i]);
       for (int kk = 0; kk < pver; ++kk) {
         output_ptend_q.push_back(ptend_q_host(kk));

--- a/src/validation/ndrop/get_activate_frac.cpp
+++ b/src/validation/ndrop/get_activate_frac.cpp
@@ -18,7 +18,7 @@ void get_activate_frac(Ensemble *ensemble) {
     const Real zero = 0;
     const int maxd_aspectype = ndrop::maxd_aspectype;
     const int ntot_amode = AeroConfig::num_modes();
-    const int nvars = ndrop::nvars;
+    const int pcnst = aero_model::pcnst;
     const int nspec_max = ndrop::nspec_max;
 
     const int pver = ndrop::pver;
@@ -32,10 +32,10 @@ void get_activate_frac(Ensemble *ensemble) {
     using View1DHost = typename HostType::view_1d<Real>;
 
     int count = 0;
-    View2D state_q("state_q", pver, nvars);
+    View2D state_q("state_q", pver, pcnst);
     auto state_host = Kokkos::create_mirror_view(state_q);
 
-    for (int i = 0; i < nvars; ++i) {
+    for (int i = 0; i < pcnst; ++i) {
       // input data is store on the cpu.
       for (int kk = 0; kk < pver; ++kk) {
         state_host(kk, i) = state_q_db[count];

--- a/src/validation/water_uptake/modal_aero_water_uptake_dr_col.cpp
+++ b/src/validation/water_uptake/modal_aero_water_uptake_dr_col.cpp
@@ -39,11 +39,11 @@ void modal_aero_water_uptake_dr_col(Ensemble *ensemble) {
     using View2D = typename DeviceType::view_2d<Real>;
     using View1DHost = typename HostType::view_1d<Real>;
 
-    constexpr int nvars = ndrop::nvars;
+    constexpr int pcnst = aero_model::pcnst;
     constexpr int pver = ndrop::pver;
     constexpr int ntot_amode = AeroConfig::num_modes();
 
-    View2D state_q("state_q", pver, nvars);
+    View2D state_q("state_q", pver, pcnst);
     mam4::validation::convert_1d_vector_to_2d_view_device(state_q_db, state_q);
 
     ColumnView temperature;

--- a/src/validation/wetdep/compute_tendencies.cpp
+++ b/src/validation/wetdep/compute_tendencies.cpp
@@ -67,7 +67,7 @@ void test_compute_tendencies(std::unique_ptr<Ensemble> &ensemble) {
     const Real t = 0;
     const Real dt = 36000;
     const Real pblh = 1000;
-    const int gas_pcnst = aero_model::gas_pcnst;
+    const int pcnst = aero_model::pcnst;
     EKAT_ASSERT(input.get("dt") == 3600);
 
     Atmosphere atmosphere = validation::create_atmosphere(nlev, pblh);
@@ -106,19 +106,19 @@ void test_compute_tendencies(std::unique_ptr<Ensemble> &ensemble) {
     diagnostics.evaporation_of_falling_precipitation =
         mam4::validation::create_column_view(nlev);
     diagnostics.aerosol_wet_deposition_interstitial =
-        mam4::validation::create_column_view(gas_pcnst);
+        mam4::validation::create_column_view(pcnst);
     diagnostics.aerosol_wet_deposition_cloud_water =
-        mam4::validation::create_column_view(gas_pcnst);
+        mam4::validation::create_column_view(pcnst);
     for (int i = 0; i < AeroConfig::num_modes(); ++i)
       diagnostics.wet_geometric_mean_diameter_i[i] =
           mam4::validation::create_column_view(nlev);
-    auto mixing_ratio = mam4::validation::create_column_view(nlev * gas_pcnst);
+    auto mixing_ratio = mam4::validation::create_column_view(nlev * pcnst);
     diagnostics.tracer_mixing_ratio =
-        Diagnostics::ColumnTracerView(mixing_ratio.data(), nlev, gas_pcnst);
+        Diagnostics::ColumnTracerView(mixing_ratio.data(), nlev, pcnst);
     auto mixing_ratio_dt =
-        mam4::validation::create_column_view(nlev * gas_pcnst);
+        mam4::validation::create_column_view(nlev * pcnst);
     diagnostics.d_tracer_mixing_ratio_dt =
-        Diagnostics::ColumnTracerView(mixing_ratio_dt.data(), nlev, gas_pcnst);
+        Diagnostics::ColumnTracerView(mixing_ratio_dt.data(), nlev, pcnst);
     Kokkos::parallel_for(
         "init_column_views", nlev, KOKKOS_LAMBDA(int i) {
           diagnostics.deep_convective_cloud_fraction[i] = 0;
@@ -133,13 +133,13 @@ void test_compute_tendencies(std::unique_ptr<Ensemble> &ensemble) {
           diagnostics.shallow_convective_detrainment[i] = 0;
           diagnostics.shallow_convective_ratio[i] = 0;
           diagnostics.evaporation_of_falling_precipitation[i] = 0;
-          for (int j = 0; j < gas_pcnst; ++j) {
+          for (int j = 0; j < pcnst; ++j) {
             diagnostics.tracer_mixing_ratio(i, j) = 0;
             diagnostics.d_tracer_mixing_ratio_dt(i, j) = 0;
           }
         });
     Kokkos::parallel_for(
-        "init_column_views", gas_pcnst, KOKKOS_LAMBDA(int i) {
+        "init_column_views", pcnst, KOKKOS_LAMBDA(int i) {
           diagnostics.aerosol_wet_deposition_interstitial[i] = 0;
           diagnostics.aerosol_wet_deposition_cloud_water[i] = 0;
         });
@@ -165,7 +165,7 @@ void test_compute_tendencies(std::unique_ptr<Ensemble> &ensemble) {
               diagnostics.deep_convective_precipitation_production);
     get_input(input, "evapcdp", nlev, evapc_host,
               diagnostics.deep_convective_precipitation_evaporation);
-    get_input(input, "qnew", nlev, gas_pcnst, dp_host,
+    get_input(input, "qnew", nlev, pcnst, dp_host,
               diagnostics.tracer_mixing_ratio);
     get_input(input, "evapr", nlev, evapr_host,
               diagnostics.evaporation_of_falling_precipitation);
@@ -190,7 +190,7 @@ void test_compute_tendencies(std::unique_ptr<Ensemble> &ensemble) {
                                     tendencies);
         });
     Kokkos::fence();
-    set_output(output, "dqdt", nlev, gas_pcnst, dqdt_host,
+    set_output(output, "dqdt", nlev, pcnst, dqdt_host,
                diagnostics.d_tracer_mixing_ratio_dt);
   });
 }

--- a/src/validation/wetdep/compute_tendencies.cpp
+++ b/src/validation/wetdep/compute_tendencies.cpp
@@ -115,8 +115,7 @@ void test_compute_tendencies(std::unique_ptr<Ensemble> &ensemble) {
     auto mixing_ratio = mam4::validation::create_column_view(nlev * pcnst);
     diagnostics.tracer_mixing_ratio =
         Diagnostics::ColumnTracerView(mixing_ratio.data(), nlev, pcnst);
-    auto mixing_ratio_dt =
-        mam4::validation::create_column_view(nlev * pcnst);
+    auto mixing_ratio_dt = mam4::validation::create_column_view(nlev * pcnst);
     diagnostics.d_tracer_mixing_ratio_dt =
         Diagnostics::ColumnTracerView(mixing_ratio_dt.data(), nlev, pcnst);
     Kokkos::parallel_for(


### PR DESCRIPTION
The classes that set a gas_pcnst from aero_model::gas_pcnst in public header data were changed to use the one from aero_model directly. Clean up the code a bit.

Note that there is a gas_pcnst in gas_chemistry that is set to 31. The one in aero_model is set to 40 and it might be a bit confusing.