### PR TITLE
Fixed failing test for `mo_drydep::calculate_resistance_rlux()`

### DIFF
--- a/src/mam4xx/mo_drydep.hpp
+++ b/src/mam4xx/mo_drydep.hpp
@@ -320,6 +320,16 @@ void calculate_resistance_rlux(
   const auto rlu = drydep_data.rlu;
   const auto foxd = drydep_data.foxd;
 
+  // NOTE: as it stands, since rlux gets passed in, and we can't guarantee all
+  // entries are initialized to 0, we do it here
+  for (size_t ispec = 0; ispec  < gas_pcnst; ++ispec)
+  {
+    for (size_t lt = 0; lt < n_land_type; ++lt)
+    {
+      rlux[ispec][lt] = 0.0;
+    }
+  }
+
   Real rlux_o3[n_land_type] = {}; // vegetative resistance (upper canopy) [s/m]
   for (int ispec = 0; ispec < gas_pcnst; ++ispec) {
     if (drydep_data.has_dvel(ispec)) {
@@ -369,6 +379,7 @@ void calculate_resistance_rlux(
             // no effect if sfc_temp < O C
             //-------------------------------------------------------------------------------------
             // BAD_CONSTANTS
+            // NOTE: this is currently not called
             rlux[ispec][lt] = 1.0 / ((1.0 / (3. * rlux[ispec][lt])) +
                                      1e-7 * heff[idx_drydep] +
                                      foxd(idx_drydep) / rlux_o3[lt]);
@@ -543,7 +554,7 @@ void drydep_xactive(
 
   int index_season[n_land_type];
   for (int lt = 0; lt < n_land_type; ++lt) {
-    index_season[lt] = index_season[month];
+    index_season[lt] = col_index_season[month];
   }
 
   //-------------------------------------------------------------------------------------

--- a/src/validation/mo_drydep/CMakeLists.txt
+++ b/src/validation/mo_drydep/CMakeLists.txt
@@ -56,7 +56,7 @@ set(ERROR_THRESHOLDS
     7e-8 # calculate_obukhov_length
     ${DEFAULT_TOL} # calculate_resistance_rclx FIXME: still needs work!
     1.1e-6 # calculate_resistance_rgsx_and_rsmx FIXME: still needs work!
-    ${DEFAULT_TOL} # calculate_resistance_rlux FIXME: still needs work!
+    1e-9# calculate_resistance_rlux FIXME: still needs work!
     ${DEFAULT_TOL} # calculate_ustar_over_water # FIXME: still needs work, esp regarding inout parameters???
     ${DEFAULT_TOL} # calculate_ustar # FIXME: still off by too much
     ${DEFAULT_TOL} # calculate_uustar FIXME: still off by too much

--- a/src/validation/mo_drydep/calculate_resistance_rlux.cpp
+++ b/src/validation/mo_drydep/calculate_resistance_rlux.cpp
@@ -33,7 +33,7 @@ void calculate_resistance_rlux(const seq_drydep::Data &data,
 
     ViewInt1DHost index_season_h("index_season", n_land_type);
     for (int lt = 0; lt < n_land_type; ++lt) {
-      index_season_h(lt) = int(index_season[lt]);
+      index_season_h(lt) = int(index_season[lt]) - 1;
     }
     ViewInt1D index_season_d("index_season", n_land_type);
     Kokkos::deep_copy(index_season_d, index_season_h);


### PR DESCRIPTION
Turned out to be a combined issue of a practically invisible indexing issue and initializing the output variable, `rlux` to zero to avoid pesky `NaN`s.

This is step 1 of addressing the failing `drydep_xactive` test.

Not tested on gpu yet, but will get there shortly.