### PR TITLE
Oscar/water uptake

### DIFF
--- a/src/mam4xx/water_uptake.hpp
+++ b/src/mam4xx/water_uptake.hpp
@@ -136,7 +136,11 @@ void makoh_quartic(Kokkos::complex<Real> cx[4], const Real p3, const Real p2,
   Real rr = -haero::cube(p2 / 6.0) + p2 * (p3 * p1 - 4.0 * p0) / 48.0 +
             (4.0 * p0 * p2 - p0 * p3 * p3 - p1 * p1) / 16.0;
 
-  Kokkos::complex<Real> crad = Kokkos::sqrt(rr * rr + qq * qq * qq);
+  // Note: Kokkos::sqrt<Real value> will return a Real and if input value is negative Kokkos::sqrt will return Nan.
+  Kokkos::complex<Real> sq_crad = rr * rr + qq * qq * qq;
+  // Note: we use Kokkos::complex<Real> Kokkos::sqrt<Real value>
+  // for case where  Kokkos::sqrt<Real value>  is negative.
+  Kokkos::complex<Real> crad = Kokkos::sqrt(sq_crad);
   Kokkos::complex<Real> cb = rr - crad;
 
   if (cb == czero) {

--- a/src/mam4xx/water_uptake.hpp
+++ b/src/mam4xx/water_uptake.hpp
@@ -136,7 +136,8 @@ void makoh_quartic(Kokkos::complex<Real> cx[4], const Real p3, const Real p2,
   Real rr = -haero::cube(p2 / 6.0) + p2 * (p3 * p1 - 4.0 * p0) / 48.0 +
             (4.0 * p0 * p2 - p0 * p3 * p3 - p1 * p1) / 16.0;
 
-  // Note: Kokkos::sqrt<Real value> will return a Real and if input value is negative Kokkos::sqrt will return Nan.
+  // Note: Kokkos::sqrt<Real value> will return a Real and if input value is
+  // negative Kokkos::sqrt will return Nan.
   Kokkos::complex<Real> sq_crad = rr * rr + qq * qq * qq;
   // Note: we use Kokkos::complex<Real> Kokkos::sqrt<Real value>
   // for case where  Kokkos::sqrt<Real value>  is negative.


### PR DESCRIPTION
This PR fixed the EMAxx coupled test ``homme_shoc_mam_optics_cld_p3_rrtmgp``; see [EMAxx PR # 2718]( https://github.com/E3SM-Project/scream/pull/2718).   

This coupled test was failing in GPUs with the following error:

```
block: [70,0,0], thread: [0,69,0] Assertion `Kokkos contract violation:
    Expected precondition `r >= 0` evaluated false.
Error at scream/externals/ekat/extern/kokkos/core/src/Kokkos_Complex.hpp":692 
` failed.
```

Source of the error: if a real negative value is passed to  `Kokkos::sqrt`, this function will return a Nan. To fix this error, we must pass a complex value instead of real value in the `kokkos:sqrt` function. 
