### PR TITLE
Fix calculate_gas_drydep_vlc_and_flux() test

### DIFF
--- a/src/mam4xx/mo_drydep.hpp
+++ b/src/mam4xx/mo_drydep.hpp
@@ -322,10 +322,8 @@ void calculate_resistance_rlux(
 
   // NOTE: as it stands, since rlux gets passed in, and we can't guarantee all
   // entries are initialized to 0, we do it here
-  for (size_t ispec = 0; ispec  < gas_pcnst; ++ispec)
-  {
-    for (size_t lt = 0; lt < n_land_type; ++lt)
-    {
+  for (size_t ispec = 0; ispec < gas_pcnst; ++ispec) {
+    for (size_t lt = 0; lt < n_land_type; ++lt) {
       rlux[ispec][lt] = 0.0;
     }
   }

--- a/src/validation/mo_drydep/CMakeLists.txt
+++ b/src/validation/mo_drydep/CMakeLists.txt
@@ -10,7 +10,6 @@ include_directories(${PROJECT_BINARY_DIR}/validation)
 add_executable(mo_drydep_driver
                mo_drydep_driver.cpp
                calculate_aerodynamic_and_quasilaminar_resistance.cpp
-               calculate_gas_drydep_vlc_and_flux.cpp
                calculate_obukhov_length.cpp
                calculate_resistance_rclx.cpp
                calculate_resistance_rgsx_and_rsmx.cpp
@@ -19,6 +18,7 @@ add_executable(mo_drydep_driver
                calculate_ustar.cpp
                calculate_uustar.cpp
                drydep_xactive.cpp
+               calculate_gas_drydep_vlc_and_flux.cpp
                )
 
 target_link_libraries(mo_drydep_driver skywalker;validation;${HAERO_LIBRARIES})
@@ -36,7 +36,6 @@ endforeach()
 # Run the driver in several configurations to produce datasets.
 set(TEST_LIST
     calculate_aerodynamic_and_quasilaminar_resistance
-    calculate_gas_drydep_vlc_and_flux
     calculate_obukhov_length
     calculate_resistance_rclx
     calculate_resistance_rgsx_and_rsmx
@@ -45,23 +44,22 @@ set(TEST_LIST
     calculate_ustar
     calculate_uustar
     drydep_xactive
-    stand_calculate_gas_drydep_vlc_and_flux_ts_100
+    calculate_gas_drydep_vlc_and_flux
     )
 
 set(DEFAULT_TOL 1e-11)
 
 set(ERROR_THRESHOLDS
     1e-9 # calculate_aerodynamic_and_quasilaminar_resistance
-    4e-8 # calculate_gas_drydep_vlc_and_flux FIXME: still needs work!
     7e-8 # calculate_obukhov_length
     ${DEFAULT_TOL} # calculate_resistance_rclx FIXME: still needs work!
     1.1e-6 # calculate_resistance_rgsx_and_rsmx FIXME: still needs work!
-    1e-9# calculate_resistance_rlux FIXME: still needs work!
+    1e-9 # calculate_resistance_rlux FIXME: still needs work!
     ${DEFAULT_TOL} # calculate_ustar_over_water # FIXME: still needs work, esp regarding inout parameters???
     ${DEFAULT_TOL} # calculate_ustar # FIXME: still off by too much
     ${DEFAULT_TOL} # calculate_uustar FIXME: still off by too much
     ${DEFAULT_TOL} # drydep_xactive FIXME: needs work, including reading data from fraction_landuse file!
-    ${DEFAULT_TOL}
+    1e-10 # calculate_gas_drydep_vlc_and_flux
    )
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)


### PR DESCRIPTION
This fixes the `calculate_gas_drydep_vlc_and_flux()` test, which is now passing with a tolerance of 1e-10.

It turns out that the input yaml files for the 4 sub-cases (that compose the single, merged test case) contained a small error. The variable `lcl_frc_landuse` in the input yaml file was for a 4-column chunk (4 columns x `n_land_type = 11`), rather than a single column like the remainder of the data. As a result, the test code was not reading the `lcl_frc_landuse` values that corresponded to the rest of the provided variables, since it was likely reading the first 11 values in the flattened array.

Additionally, the resulting `mam_calculate_gas_drydep_vlc_and_flux.py` validation file also appeared to be in error for the same reason (I hope 🤞). I found both of these bugs by running the standalone driver, and now the standalone driver and mam4xx produce matching output. I trust this, but I will also request new validation data from e3sm_mamrefactor, so we can be 100% sure.