### PR TITLE
Changes species order to match MAM4 in E3SMv2

### DIFF
--- a/src/mam4xx/aero_modes.hpp
+++ b/src/mam4xx/aero_modes.hpp
@@ -128,12 +128,12 @@ KOKKOS_INLINE_FUNCTION const mam4::Mode &modes(const int i) {
 
 /// Identifiers for aerosol species that inhabit MAM4 modes.
 enum class AeroId {
-  SOA = 0,  // secondary organic aerosol
-  SO4 = 1,  // sulphate
-  POM = 2,  // primary organic matter
+  SO4 = 0,  // sulphate
+  POM = 1,  // primary organic matter
+  SOA = 2,  // secondary organic aerosol
   BC = 3,   // black carbon
-  NaCl = 4, // sodium chloride
-  DST = 5,  // dust
+  DST = 4,  // dust
+  NaCl = 5, // sodium chloride
   MOM = 6,  // marine organic matter,
   None = 7  // invalid aerosol species
 };
@@ -215,12 +215,12 @@ KOKKOS_INLINE_FUNCTION AeroId mode_aero_species(const int modeNo,
   // A list of species within each mode for MAM4.
   static constexpr AeroId mode_aero_species[4][7] = {
       {// accumulation mode
-       AeroId::SOA, AeroId::SO4, AeroId::POM, AeroId::BC, AeroId::NaCl,
-       AeroId::DST, AeroId::MOM},
+       AeroId::SO4, AeroId::POM, AeroId::SOA, AeroId::BC, AeroId::DST,
+       AeroId::NaCl, AeroId::MOM},
       {
           // aitken mode
-          AeroId::SOA,
           AeroId::SO4,
+          AeroId::SOA,
           AeroId::NaCl,
           AeroId::MOM,
           AeroId::None,
@@ -228,8 +228,8 @@ KOKKOS_INLINE_FUNCTION AeroId mode_aero_species(const int modeNo,
           AeroId::None,
       },
       {// coarse mode
-       AeroId::SOA, AeroId::SO4, AeroId::POM, AeroId::BC, AeroId::NaCl,
-       AeroId::DST, AeroId::MOM},
+       AeroId::DST, AeroId::NaCl, AeroId::SO4, AeroId::BC, AeroId::POM,
+       AeroId::SOA, AeroId::MOM},
       {// primary carbon mode
        AeroId::POM, AeroId::BC, AeroId::MOM, AeroId::None, AeroId::None,
        AeroId::None, AeroId::None}};

--- a/src/mam4xx/aero_modes.hpp
+++ b/src/mam4xx/aero_modes.hpp
@@ -128,12 +128,12 @@ KOKKOS_INLINE_FUNCTION const mam4::Mode &modes(const int i) {
 
 /// Identifiers for aerosol species that inhabit MAM4 modes.
 enum class AeroId {
-  SO4 = 0,  // sulphate
-  POM = 1,  // primary organic matter
-  SOA = 2,  // secondary organic aerosol
+  SOA = 0,  // secondary organic aerosol
+  SO4 = 1,  // sulphate
+  POM = 2,  // primary organic matter
   BC = 3,   // black carbon
-  DST = 4,  // dust
-  NaCl = 5, // sodium chloride
+  NaCl = 4, // sodium chloride
+  DST = 5,  // dust
   MOM = 6,  // marine organic matter,
   None = 7  // invalid aerosol species
 };

--- a/src/validation/calcsize/compute_dry_volume.cpp
+++ b/src/validation/calcsize/compute_dry_volume.cpp
@@ -29,18 +29,15 @@ void compute_dry_volume_k(Ensemble *ensemble) {
     const auto imode = int(input.get_array("imode")[0]) - 1;
     const auto n_spec = num_species_mode(imode);
     for (int isp = 0; isp < n_spec; ++isp) {
-      // using indexing from mam4xx.
-      const int isp_mam4xx = validation::e3sm_to_mam4xx_aerosol_idx[imode][isp];
-
       auto h_prog_aero_i =
-          Kokkos::create_mirror_view(progs.q_aero_i[imode][isp_mam4xx]);
+          Kokkos::create_mirror_view(progs.q_aero_i[imode][isp]);
       h_prog_aero_i(0) = q_i[isp];
-      Kokkos::deep_copy(progs.q_aero_i[imode][isp_mam4xx], h_prog_aero_i);
+      Kokkos::deep_copy(progs.q_aero_i[imode][isp], h_prog_aero_i);
 
       auto h_prog_aero_c =
-          Kokkos::create_mirror_view(progs.q_aero_c[imode][isp_mam4xx]);
+          Kokkos::create_mirror_view(progs.q_aero_c[imode][isp]);
       h_prog_aero_c(0) = q_c[isp];
-      Kokkos::deep_copy(progs.q_aero_c[imode][isp_mam4xx], h_prog_aero_c);
+      Kokkos::deep_copy(progs.q_aero_c[imode][isp], h_prog_aero_c);
     } // end species
 
     DeviceType::view_1d<Real> dryvol_i("Return dryvol_i", 1);

--- a/src/validation/calcsize/compute_tendencies.cpp
+++ b/src/validation/calcsize/compute_tendencies.cpp
@@ -107,9 +107,8 @@ void compute_tendencies(Ensemble *ensemble) {
       for (int isp = 0; isp < n_spec; ++isp) {
 
         // save outputs using the same indexing from e3sm.
-        const int isp_mam4xx =
-            count_species + isp;
-            
+        const int isp_mam4xx = count_species + isp;
+
         auto h_tend_aero_i =
             Kokkos::create_mirror_view(tends.q_aero_i[imode][isp]);
         Kokkos::deep_copy(h_tend_aero_i, tends.q_aero_i[imode][isp]);

--- a/src/validation/calcsize/compute_tendencies.cpp
+++ b/src/validation/calcsize/compute_tendencies.cpp
@@ -56,17 +56,15 @@ void compute_tendencies(Ensemble *ensemble) {
       const auto n_spec = num_species_mode(imode);
       for (int isp = 0; isp < n_spec; ++isp) {
         // correcting index for inputs.
-        const int isp_mam4xx =
-            validation::e3sm_to_mam4xx_aerosol_idx[imode][isp];
         auto h_prog_aero_i =
-            Kokkos::create_mirror_view(progs.q_aero_i[imode][isp_mam4xx]);
+            Kokkos::create_mirror_view(progs.q_aero_i[imode][isp]);
         h_prog_aero_i(0) = q_i[count];
-        Kokkos::deep_copy(progs.q_aero_i[imode][isp_mam4xx], h_prog_aero_i);
+        Kokkos::deep_copy(progs.q_aero_i[imode][isp], h_prog_aero_i);
 
         auto h_prog_aero_c =
-            Kokkos::create_mirror_view(progs.q_aero_c[imode][isp_mam4xx]);
+            Kokkos::create_mirror_view(progs.q_aero_c[imode][isp]);
         h_prog_aero_c(0) = q_c[count];
-        Kokkos::deep_copy(progs.q_aero_c[imode][isp_mam4xx], h_prog_aero_c);
+        Kokkos::deep_copy(progs.q_aero_c[imode][isp], h_prog_aero_c);
 
         count++;
       } // end species
@@ -110,8 +108,8 @@ void compute_tendencies(Ensemble *ensemble) {
 
         // save outputs using the same indexing from e3sm.
         const int isp_mam4xx =
-            count_species + validation::mam4xx_to_e3sm_aerosol_idx[imode][isp];
-
+            count_species + isp;
+            
         auto h_tend_aero_i =
             Kokkos::create_mirror_view(tends.q_aero_i[imode][isp]);
         Kokkos::deep_copy(h_tend_aero_i, tends.q_aero_i[imode][isp]);

--- a/src/validation/validation.hpp
+++ b/src/validation/validation.hpp
@@ -48,65 +48,6 @@ void finalize();
 /// @param [in] input_file The name of the Skywalker input YAML file.
 std::string output_name(const std::string &input_file);
 
-/// The E3SM code has different indexing than mam4xx for the aerosol species in
-// the accumulation, aitken, coarse, and primary carbon modes.
-//  Therefore for validation proposes, we need to convert the index of the
-//  aerosol species from the e3sm convention to that of mam4xx and vice versa.
-//  We use these variables to convert inputs from e3sm
-static constexpr int e3sm_to_mam4xx_aerosol_idx[4][7] = {
-    // these arrays provide the index in the e3sm array that corresponds to the
-    // species in the given position. an index of -1 means that species is not
-    // present in the mam4xx array.
-
-    // accumulation
-    // e3sm   : SO4(1), POM(2), SOA(0), BC(3), DST(5), NaCl(4), MOM(6)
-    // mam4xx : SOA(0), SO4(1), POM(2), BC(3), NaCl(4), DST(5), MOM(6)
-    {1, 2, 0, 3, 5, 4, 6},
-
-    // aitken
-    // e3sm:    SO4(1), SOA(0), NaCl(2), MOM(3)
-    // mam4xx : SOA(0), SO4(1), NaCl(2), MOM(3)
-    {1, 0, 2, 3, -1, -1, -1},
-
-    // coarse
-    // e3sm: DST(5), NaCl(4), SO4(1), BC(3), POM(2), SOA(0), MOM(6)
-    // mam4xx : SOA(0), SO4(1), POM(2), BC(3), NaCl(4), DST(5), MOM(6)
-    {5, 4, 1, 3, 2, 0, 6},
-
-    // primary carbon mode
-    // e3sm : POM, BC, MOM
-    // mam4xx : POM(0), BC(1), MOM(2)
-    {0, 1, 2, -1, -1, -1, -1}};
-
-// Because we need to compare with output arrays from e3sm we must save outputs
-// from mam4xx using same indexing as e3sm. The following variable gives the
-// index of the aerosol species using the e3sm indexing w.r.t mam4xx indexing.
-//  we use these variables to convert outputs from mam4xx
-static constexpr int mam4xx_to_e3sm_aerosol_idx[4][7] = {
-    // these arrays provide the index in the mam4xx array that corresponds to
-    // the species in the given position. an index of -1 means that species is
-    // not present in the e3sm array.
-
-    // accumulation
-    // e3sm   : SO4(0), POM(1), SOA(2), BC(3), DST(4), NaCl(5), MOM(6)
-    // mam4xx : SOA(2), SO4(0), POM(1), BC(3), NaCl(5), DST(4), MOM(6)
-    {2, 0, 1, 3, 5, 4, 6},
-
-    // aitken
-    // e3sm:    SO4(0), SOA(1), NaCl(2), MOM(3)
-    // mam4xx : SOA(1), SO4(0), NaCl(2), MOM(3)
-    {1, 0, 2, 3, -1, -1, -1},
-
-    // coarse
-    // e3sm: DST(0), NaCl(1), SO4(2), BC(3), POM(4), SOA(5), MOM(6)
-    // mam4xx : SOA(5), SO4(2), POM(4), BC(3), NaCl(1), DST(0), MOM(6)
-    {5, 2, 4, 3, 1, 0, 6},
-
-    // primary carbon mode
-    // e3sm : POM, BC, MOM
-    // mam4xx : POM(0), BC(1), MOM(2)
-    {0, 1, 2, -1, -1, -1, -1}};
-
 // Convert 1D std::vector to 2D Real array for aerosol mass/molar mixing ratios
 void convert_vector_to_mass_mixing_ratios(
     const std::vector<Real> &vector_in,                                   // in


### PR DESCRIPTION
Species order is revised to match MAM4 in E3SMv2. This should help us in making a direct comparison with MAM4 codes and output files.