### PR TITLE
Fix for reordering of aerosols within modes.

### DIFF
--- a/src/mam4xx/gasaerexch.hpp
+++ b/src/mam4xx/gasaerexch.hpp
@@ -480,9 +480,6 @@ void gas_aer_uptkrates_1box1gas(
     // --------------------------------------------------------------------
     uptkaer[n] = l_condense_to_mode[n] ? uptkrate : 0.0; // zero means no uptake
   }
-  for (int n = 0; n < GasAerExch::num_mode; ++n)
-    std::cout << __FILE__ << ":" << __LINE__ << "  uptkaer[" << n
-              << "]:" << uptkaer[n] << std::endl;
 }
 
 KOKKOS_INLINE_FUNCTION

--- a/src/mam4xx/gasaerexch.hpp
+++ b/src/mam4xx/gasaerexch.hpp
@@ -63,10 +63,12 @@ public:
   // 2. SOAG  -> SOA
   KOKKOS_INLINE_FUNCTION
   static constexpr AeroId gas_to_aer(const GasId gas) {
-    const AeroId gas_to_aer[num_gas] = {AeroId::None, AeroId::None,
-                                        AeroId::SO4,  AeroId::None,
-                                        AeroId::None, AeroId::SOA};
-    return gas_to_aer[static_cast<int>(gas)];
+    AeroId air = AeroId::None;
+    if (GasId::H2SO4 == gas)
+      air = AeroId::SO4;
+    else if (GasId::SOAG == gas)
+      air = AeroId::SOA;
+    return air;
   }
   //------------------------------------------------------------------
   // MAM4xx currently assumes that the uptake rate of other gases
@@ -478,6 +480,9 @@ void gas_aer_uptkrates_1box1gas(
     // --------------------------------------------------------------------
     uptkaer[n] = l_condense_to_mode[n] ? uptkrate : 0.0; // zero means no uptake
   }
+  for (int n = 0; n < GasAerExch::num_mode; ++n)
+    std::cout << __FILE__ << ":" << __LINE__ << "  uptkaer[" << n
+              << "]:" << uptkaer[n] << std::endl;
 }
 
 KOKKOS_INLINE_FUNCTION
@@ -648,8 +653,7 @@ void mam_gasaerexch_1subarea(
   const int npoa = 1;
   Real qaer_poa[npoa][num_mode] = {};
   for (ModeIndex mode : GasAerExch::Modes()) {
-    const int idxs =
-        aerosol_index_for_mode(ModeIndex::Accumulation, AeroId::POM);
+    const int idxs = static_cast<int>(AeroId::POM);
     const int n = static_cast<int>(mode);
     qaer_poa[0][n] = haero::max(qaer_cur[idxs][n], 0);
   }

--- a/src/mam4xx/mo_setsox.hpp
+++ b/src/mam4xx/mo_setsox.hpp
@@ -75,7 +75,7 @@ struct Config {
   int itermax = 20;
   // Real small_value_20 = 1.0e-20;
   // Real small_value_30 = 1.0e-30;
-  int numptrcw_amode[AeroConfig::num_modes()] = {23, 28, 36, 40};
+  int numptrcw_amode[AeroConfig::num_modes()] = {22, 27, 35, 39};
 
   Config() = default;
   Config(const Config &) = default;


### PR DESCRIPTION
Balwinder has a branch in which he changes the ordering of aerosols within modes. This should not make a difference but an extra call to aerosol_index_for_mode was breaking Gas/Aerosol exchange in this case.  Once this fix is merged into Balwinder's branch, it should fix his tests.