### PR TITLE
fix compile Werror in gasaerexch_soaexch.hpp

### DIFF
--- a/src/mam4xx/gasaerexch_soaexch.hpp
+++ b/src/mam4xx/gasaerexch_soaexch.hpp
@@ -129,7 +129,7 @@ Real soa_exch_substepsize(
   // Then, for each species, we calculate the sum of its absolute value over all
   // modes, and saved the result in the array tot_frac_single_soa_species.
   //----------------------------------------------------------------------------------------------------------
-  Real tot_frac_single_soa_species[AeroConfig::num_gas_ids()];
+  Real tot_frac_single_soa_species[AeroConfig::num_gas_ids()] = {0};
   for (int i = 0; i < ntot_soaspec; ++i)
     tot_frac_single_soa_species[i] = 0.0;
 


### PR DESCRIPTION
one-liner to fix compile error on gcc 12.1
```shell
gasaerexch_soaexch.hpp:168:8: error: 'tot_frac_single_soa_species' may be used uninitialized [-Werror=maybe-uninitialized]
```