### PR TITLE
Oscar/calcsize ptend

### DIFF
--- a/src/mam4xx/calcsize.hpp
+++ b/src/mam4xx/calcsize.hpp
@@ -523,7 +523,6 @@ void update_num_tends(const int jmode, const int aer_type, Real &dqdt_src,
   dqdt_src -= xfertend;
   dqdt_dest += xfertend;
 
-
 } // end update_num_tends
 
 //------------------------------------------------------------------------------------------------
@@ -669,7 +668,6 @@ void aitken_accum_exchange(
   const auto num2vol_ratio_geomean =
       haero::sqrt(voltonum_ait) * haero::sqrt(voltonum_acc);
 
-  
   compute_coef_ait_acc_transfer(
       accum_idx, num2vol_ratio_geomean, adj_tscale_inv, drv_i_aitsv,
       drv_c_aitsv, num_i_aitsv, num_c_aitsv, voltonum_acc, ait2acc_index,

--- a/src/mam4xx/calcsize.hpp
+++ b/src/mam4xx/calcsize.hpp
@@ -520,9 +520,6 @@ KOKKOS_INLINE_FUNCTION
 void update_num_tends(const int jmode, const int aer_type, Real &dqdt_src,
                       Real &dqdt_dest, const Real xfertend_num[2][2]) {
   const Real xfertend = xfertend_num[jmode][aer_type];
-  printf("xfertend %e %d %d  \n", xfertend, jmode, aer_type);
-  printf("dqdt_src %e \n", dqdt_src);
-  printf("dqdt_dest %e \n", dqdt_dest);
   dqdt_src -= xfertend;
   dqdt_dest += xfertend;
 

--- a/src/mam4xx/calcsize.hpp
+++ b/src/mam4xx/calcsize.hpp
@@ -520,8 +520,12 @@ KOKKOS_INLINE_FUNCTION
 void update_num_tends(const int jmode, const int aer_type, Real &dqdt_src,
                       Real &dqdt_dest, const Real xfertend_num[2][2]) {
   const Real xfertend = xfertend_num[jmode][aer_type];
+  printf("xfertend %e %d %d  \n", xfertend, jmode, aer_type);
+  printf("dqdt_src %e \n", dqdt_src);
+  printf("dqdt_dest %e \n", dqdt_dest);
   dqdt_src -= xfertend;
   dqdt_dest += xfertend;
+
 
 } // end update_num_tends
 
@@ -668,7 +672,7 @@ void aitken_accum_exchange(
   const auto num2vol_ratio_geomean =
       haero::sqrt(voltonum_ait) * haero::sqrt(voltonum_acc);
 
-  // Compute aitken -> accumulation transfer
+  
   compute_coef_ait_acc_transfer(
       accum_idx, num2vol_ratio_geomean, adj_tscale_inv, drv_i_aitsv,
       drv_c_aitsv, num_i_aitsv, num_c_aitsv, voltonum_acc, ait2acc_index,

--- a/src/mam4xx/modal_aer_opt.hpp
+++ b/src/mam4xx/modal_aer_opt.hpp
@@ -574,6 +574,8 @@ void compute_calcsize_and_water_uptake_dr(
 
   Real dgncur_c_kk[ntot_amode] = {};
   Real dgnumdry_m_kk[ntot_amode] = {};
+  Real dnidt[ntot_amode] = {};
+  Real dncdt[ntot_amode] = {};
   //  Calculate aerosol size distribution parameters and aerosol water uptake
   // For prognostic aerosols
   modal_aero_calcsize::modal_aero_calcsize_sub(
@@ -587,7 +589,7 @@ void compute_calcsize_and_water_uptake_dr(
       dgnmax_nmodes, dgnnom_nmodes, mean_std_dev_nmodes,
       // outputs
       noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-      acc_spec_in_ait, dgnumdry_m_kk, dgncur_c_kk);
+      acc_spec_in_ait, dgnumdry_m_kk, dgncur_c_kk, dnidt, dncdt);
 
   mam4::water_uptake::modal_aero_water_uptake_dr(
       nspec_amode, specdens_amode, spechygro, lspectype_amode, state_q_kk,

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -63,9 +63,14 @@ void init_calcsize(
         // false : can be transfer.
         noxf_acc2ait[isp] = false;
         // save index for transfer from accumulation to aitken mode
-        acc_spec_in_ait[count] = isp;
+        // adding offset because we are using this index for state_q 
+        // Note: we assuimg accum mode is the first mode
+        acc_spec_in_ait[count] = isp + utils::aero_start_ind();
         // save index for transfer from aitken to accumulation mode
-        ait_spec_in_acc[count] = jsp;
+        // adding offset because we are using this index for state_q
+        // offset: aero_start + num of spec accum + 1 (number concentration)  
+        // Note: we assuimg accum mode is the second mode
+        ait_spec_in_acc[count] = jsp + utils::aero_start_ind() + num_species_mode(accum_idx) +1;
         count++;
         break;
       }

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -118,7 +118,7 @@ void compute_coef_acc_ait_transfer(
     const Real voltonum_ait,
     const Real inv_density[AeroConfig::num_modes()]
                           [AeroConfig::num_aerosol_ids()],
-    const Real num2vol_ratio_min_nmodes[AeroConfig::num_modes()],
+    const Real num2vol_ratio_max_nmodes[AeroConfig::num_modes()],
     // additional parameters
     const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
     Real &drv_i_noxf, Real &drv_c_noxf, int &acc2_ait_index,
@@ -166,8 +166,9 @@ void compute_coef_acc_ait_transfer(
       drv_t_noxf =
           drv_i_noxf +
           drv_c_noxf; // total volume that can't be moved to the aitken mode
+      // Note: voltonumblo is equivalent to num2vol_ratio_max_nmodes    
       num_t_noxf = drv_t_noxf *
-                   num2vol_ratio_min_nmodes[iacc]; // total number that can't be
+                   num2vol_ratio_max_nmodes[iacc]; // total number that can't be
                                                    // moved to the aitken mode
       num_t0 = num_t;
       num_t = max(zero, num_t - num_t_noxf);
@@ -542,23 +543,10 @@ void aitken_accum_exchange(
       haero::sqrt(voltonum_ait) * haero::sqrt(voltonum_acc);
 
   // Compute aitken -> accumulation transfer
-  printf("accum_idx %d \n", accum_idx);
-  printf("num2vol_ratio_geomean %e \n", num2vol_ratio_geomean);
-  printf("adj_tscale_inv %e \n", adj_tscale_inv);
-  printf(" drv_i_aitsv %e \n", drv_i_aitsv);
-  printf(" drv_c_aitsv %e \n", drv_c_aitsv);
-  printf(" num_i_aitsv %e \n", num_i_aitsv);
-  printf(" num_c_aitsv %e \n", num_c_aitsv);
-  printf(" voltonum_acc %e \n", voltonum_acc);
-
   calcsize::compute_coef_ait_acc_transfer(
       accum_idx, num2vol_ratio_geomean, adj_tscale_inv, drv_i_aitsv,
       drv_c_aitsv, num_i_aitsv, num_c_aitsv, voltonum_acc, ait2acc_index,
       xfercoef_num_ait2acc, xfercoef_vol_ait2acc, xfertend_num);
-  printf(" ait2acc_index %d \n", ait2acc_index);
-  printf(" xfercoef_num_ait2acc %e \n", xfercoef_num_ait2acc);
-  printf(" xfercoef_vol_ait2acc %e \n", xfercoef_vol_ait2acc);
-
   //  ----------------------------------------------------------------------------------------
   //   compute accum --> aitken transfer rates
   //
@@ -572,12 +560,9 @@ void aitken_accum_exchange(
   compute_coef_acc_ait_transfer(
       accum_idx, num2vol_ratio_geomean, adj_tscale_inv, state_q, qqcw,
       drv_i_accsv, drv_c_accsv, num_i_accsv, num_c_accsv, noxf_acc2ait,
-      voltonum_ait, inv_density, num2vol_ratio_min_nmodes, lmassptr_amode,
+      voltonum_ait, inv_density, num2vol_ratio_max_nmodes, lmassptr_amode,
       drv_i_noxf, drv_c_noxf, acc2_ait_index, xfercoef_num_acc2ait,
       xfercoef_vol_acc2ait, xfertend_num);
-
-  printf(" xfertend_num[1][0] %e \n", xfertend_num[1][0]);
-  printf(" xfertend_num1][1] %e \n", xfertend_num[1][1]);
 
   // jump to end of loop if no transfer is needed
   if (ait2acc_index + acc2_ait_index > 0) {
@@ -676,7 +661,6 @@ void aitken_accum_exchange(
         mean_std_dev_nmodes[accum_idx], dgncur_c_accum,
         num2vol_ratio_cur_c_accum);
 
-#if 1
     //------------------------------------------------------------------
     // compute tendency amounts for aitken <--> accum transfer
     //------------------------------------------------------------------
@@ -723,7 +707,6 @@ void aitken_accum_exchange(
           dnidt,
           dncdt);
     } // end if (acc2_ait_index)
-#endif
   } // end if (ait2acc_index+acc2_ait_index > 0)
 
   utils::transfer_tendencies_num_to_tendecines(dnidt,ptend); 
@@ -912,8 +895,6 @@ void modal_aero_calcsize_sub(
                     drv_c_sv[imode], num_i_k_accsv, num_c_k_accsv,
                     num_i_k_aitsv, num_c_k_aitsv, num_i_sv[imode],
                     num_c_sv[imode], dnidt[imode], dncdt[imode]);
-  
-  printf("dnidt[%d] %e \n", imode, dnidt[imode]);
   } // imode
 
 

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -69,7 +69,7 @@ void init_calcsize(
         // save index for transfer from aitken to accumulation mode
         // adding offset because we are using this index for state_q
         // offset: aero_start + num of spec accum + 1 (number concentration)
-        // Note: we assuimg accum mode is the second mode
+        // Note: we assumig Aitken mode is the second mode
         ait_spec_in_acc[count] =
             jsp + utils::aero_start_ind() + num_species_mode(accum_idx) + 1;
         count++;

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -624,9 +624,11 @@ void modal_aero_calcsize_sub(
     const int *acc_spec_in_ait,
 
     Real dgncur_i[AeroConfig::num_modes()],
-    Real dgncur_c[AeroConfig::num_modes()]
+    Real dgncur_c[AeroConfig::num_modes()],
     // ncol, lchnk, state_q, pdel, deltat, qqcw, ptend, do_adjust_in, &
     // do_aitacc_transfer_in, list_idx_in, update_mmr_in, dgnumdry_m
+    Real dnidt[AeroConfig::num_modes()], 
+    Real dncdt[AeroConfig::num_modes()]
 ) {
 
   const Real zero = 0.0;
@@ -679,8 +681,7 @@ void modal_aero_calcsize_sub(
   Real num_c_k_aitsv = zero;
   Real num_i_sv[nmodes] = {};
   Real num_c_sv[nmodes] = {};
-  Real dnidt[nmodes] = {};
-  Real dncdt[nmodes] = {};
+  
   for (int imode = 0; imode < nmodes; imode++) {
     /*----------------------------------------------------------------------
    Initialize all parameters to the default values for the mode

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -405,10 +405,10 @@ void update_tends_flx(
                       const int *src_species_idx, //
                       const int *dest_species_idx,
                       const Real xfertend_num[2][2], const Real xfercoef,
-                      const Real q_i[4][7],
-                      const Real q_c[4][7],
-                      Real didt[4][7],
-                      Real dcdt[4][7],
+                      const Real *state_q,
+                      const Real *qqcw, 
+                      Real *ptend,
+                      Real *dqqcwdt,
                       Real dnidt[],
                       Real dncdt[]) {
 
@@ -442,15 +442,15 @@ void update_tends_flx(
     const int ispec_dest = dest_species_idx[i];
     // interstitial species
     const Real xfertend_i =
-        haero::max(zero, q_i[src_mode_ixd][ispec_src]) * xfercoef;
-    didt[src_mode_ixd][ispec_src] -= xfertend_i;
-    didt[dest_mode_ixd][ispec_dest] += xfertend_i;
+        haero::max(zero, state_q[ispec_src]) * xfercoef;
+    ptend[ispec_src] -= xfertend_i;
+    ptend[ispec_dest] += xfertend_i;
 
     // cloud borne species
     const Real xfertend_c =
-        haero::max(zero, q_c[src_mode_ixd][ispec_src]) * xfercoef;
-    dcdt[src_mode_ixd][ispec_src] -= xfertend_c;
-    dcdt[dest_mode_ixd][ispec_dest] += xfertend_c;
+        haero::max(zero, qqcw[ispec_src]) * xfercoef;
+    dqqcwdt[ispec_src] -= xfertend_c;
+    dqqcwdt[ispec_dest] += xfertend_c;
   }
 
 } // end update_tends_flx
@@ -496,18 +496,9 @@ void aitken_accum_exchange(
   // -----------------------------------------------------------------------------
 
   const Real zero = 0;
-  //
-  // const Real q_i[][],
-  // const Real q_c[][],
-  // Real didt[][],
-  // Real dcdt[][],
-  // Real dnidt[],
-  // Real dncdt[]
+  Real ptend[40]={};
+  Real dqqcwdt[40]={};
 
-  Real q_i[4][7]={};
-  Real q_c[4][7]={};
-  Real didt[4][7]={};
-  Real dcdt[4][7]={};
   // Real dnidt[4]={};
   // Real dncdt[4]={};
 
@@ -704,10 +695,10 @@ void aitken_accum_exchange(
           ait_spec_in_acc, // defined in aero_modes - src => aitken
           acc_spec_in_ait, // defined in aero_modes - src => accumulation
           xfertend_num, xfercoef_vol_ait2acc,
-          q_i,
-          q_c,
-          didt,
-          dcdt,
+          state_q,
+          qqcw, 
+          ptend,
+          dqqcwdt,
           dnidt,
           dncdt);
     } // end if (ait2acc_index)
@@ -728,10 +719,10 @@ void aitken_accum_exchange(
           acc_spec_in_ait, // defined in aero_modes - src => accumulation
           ait_spec_in_acc, // defined in aero_modes - src => aitken
           xfertend_num, xfercoef_vol_acc2ait,
-          q_i,
-          q_c,
-          didt,
-          dcdt,
+          state_q,
+          qqcw, 
+          ptend,
+          dqqcwdt,
           dnidt,
           dncdt);
     } // end if (acc2_ait_index)

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -793,8 +793,9 @@ void modal_aero_calcsize_sub(
   Real num_i_sv[nmodes] = {};
   Real num_c_sv[nmodes] = {};
 
-  Real dnidt[4] = {};
-  Real dncdt[4] = {};
+  // get index of num concentration in state_q
+  int num_idx_state_q[nmodes]={};
+  utils::get_num_idx_in_state_q(num_idx_state_q);
   
   for (int imode = 0; imode < nmodes; imode++) {
     /*----------------------------------------------------------------------
@@ -891,12 +892,9 @@ void modal_aero_calcsize_sub(
                     dryvol_i_aitsv, dryvol_c_aitsv, drv_i_sv[imode],
                     drv_c_sv[imode], num_i_k_accsv, num_c_k_accsv,
                     num_i_k_aitsv, num_c_k_aitsv, num_i_sv[imode],
-                    num_c_sv[imode], dnidt[imode], dncdt[imode]);
-  } // imode
-
-
-  
-  utils::transfer_tendencies_num_to_tendecines(dnidt,ptend); 
+                    num_c_sv[imode],
+                    ptend[num_idx_state_q[imode]], dqqcwdt[num_idx_state_q[imode]]);
+  } // imode  
 
   /*------------------------------------------------------------------------------
   ! when the aitken mode mean size is too big, the largest

--- a/src/mam4xx/utils.hpp
+++ b/src/mam4xx/utils.hpp
@@ -202,7 +202,8 @@ void transfer_tendencies_num_to_tendecines(const  Real n_mode_i[],
       // q[s_idx] = progs.q_aero_i[m][a](klev);
       s_idx++; // update index even if we lack some aerosol mmrs
     }
-    q[s_idx] = n_mode_i[m];
+    q[s_idx] += n_mode_i[m];
+    printf("q[%d] %e n_mode_i[%d] %e \n", s_idx, q[s_idx], m, n_mode_i[m]);
     s_idx++; // update index
     // printf(" %d ", s_idx);
   }

--- a/src/mam4xx/utils.hpp
+++ b/src/mam4xx/utils.hpp
@@ -172,8 +172,42 @@ void transfer_work_arrays_to_prognostics(const Real q[gas_pcnst()],
   }
 }
 
+
 #undef DECLARE_PROG_TRANSFER_CONSTANTS
 
+// given q and qqcs get arrays
+// FIXME!!!: need aditional work. 
+KOKKOS_INLINE_FUNCTION
+void transfer_tendencies_num_to_tendecines(const  Real n_mode_i[],
+                                        // const Real n_mode_c[],
+                                        Real q[gas_pcnst()]
+                                        // ,
+                                        // Real qqcw[gas_pcnst()],
+                                        )
+{
+    int s_idx = ekat::ScalarTraits<int>::invalid();
+    s_idx = gasses_start_ind(); // gases start at index 9 (index 10 in Fortran
+                                // version)
+    for (int g = 0; g < AeroConfig::num_gas_ids(); ++g) {
+      // get mmr at level "klev"
+      // q[s_idx] = progs.q_gas[g](klev);
+      s_idx++; // update index
+    }
+
+
+  // Now start adding aerosols mmr into the state_q
+  for (int m = 0; m < AeroConfig::num_modes(); ++m) {
+    // First add the aerosol species mmr
+    for (int a = 0; a < mam4::num_species_mode(m); ++a) {
+      // q[s_idx] = progs.q_aero_i[m][a](klev);
+      s_idx++; // update index even if we lack some aerosol mmrs
+    }
+    q[s_idx] = n_mode_i[m];
+    s_idx++; // update index
+    // printf(" %d ", s_idx);
+  }
+  // printf("\n "); 
+}
 // Given an AerosolState with views for dry aerosol quantities, creates a
 // interstitial aerosols 1D view (state_q) for the column with the given index.
 // This object can be provided to mam4xx for the column.
@@ -310,6 +344,7 @@ void inject_qqcw_to_prognostics(const Real *qqcw, mam4::Prognostics &progs,
     s_idx++; // update index
   }
 }
+
 
 } // end namespace mam4::utils
 

--- a/src/mam4xx/utils.hpp
+++ b/src/mam4xx/utils.hpp
@@ -200,6 +200,20 @@ void transfer_tendencies_num_to_tendecines(const  Real n_mode_i[],
 
   // printf("\n "); 
 }
+
+// return idx of num concentration in state_q
+KOKKOS_INLINE_FUNCTION
+void get_num_idx_in_state_q(int idxs[AeroConfig::num_modes()])
+{
+  // index of accum and aitken mode for num concetration in state_q 
+  int s_idx = gasses_start_ind() + AeroConfig::num_gas_ids(); // gases start at index 9 (index 10 in Fortran
+  for (int m = 0; m < AeroConfig::num_modes(); ++m) {
+    s_idx+=mam4::num_species_mode(m);
+    idxs[m]=s_idx;
+    s_idx++; // update index
+  }
+}
+
 // Given an AerosolState with views for dry aerosol quantities, creates a
 // interstitial aerosols 1D view (state_q) for the column with the given index.
 // This object can be provided to mam4xx for the column.

--- a/src/mam4xx/utils.hpp
+++ b/src/mam4xx/utils.hpp
@@ -186,27 +186,18 @@ void transfer_tendencies_num_to_tendecines(const  Real n_mode_i[],
                                         )
 {
     int s_idx = ekat::ScalarTraits<int>::invalid();
-    s_idx = gasses_start_ind(); // gases start at index 9 (index 10 in Fortran
+    s_idx = gasses_start_ind()+ AeroConfig::num_gas_ids(); // gases start at index 9 (index 10 in Fortran
                                 // version)
-    for (int g = 0; g < AeroConfig::num_gas_ids(); ++g) {
-      // get mmr at level "klev"
-      // q[s_idx] = progs.q_gas[g](klev);
-      s_idx++; // update index
-    }
-
 
   // Now start adding aerosols mmr into the state_q
   for (int m = 0; m < AeroConfig::num_modes(); ++m) {
-    // First add the aerosol species mmr
-    for (int a = 0; a < mam4::num_species_mode(m); ++a) {
-      // q[s_idx] = progs.q_aero_i[m][a](klev);
-      s_idx++; // update index even if we lack some aerosol mmrs
-    }
+    s_idx+=mam4::num_species_mode(m);
     q[s_idx] += n_mode_i[m];
     printf("q[%d] %e n_mode_i[%d] %e \n", s_idx, q[s_idx], m, n_mode_i[m]);
     s_idx++; // update index
     // printf(" %d ", s_idx);
   }
+
   // printf("\n "); 
 }
 // Given an AerosolState with views for dry aerosol quantities, creates a

--- a/src/mam4xx/utils.hpp
+++ b/src/mam4xx/utils.hpp
@@ -172,44 +172,44 @@ void transfer_work_arrays_to_prognostics(const Real q[gas_pcnst()],
   }
 }
 
-
 #undef DECLARE_PROG_TRANSFER_CONSTANTS
 
 // given q and qqcs get arrays
-// FIXME!!!: need aditional work. 
+// FIXME!!!: need aditional work.
 KOKKOS_INLINE_FUNCTION
-void transfer_tendencies_num_to_tendecines(const  Real n_mode_i[],
-                                        // const Real n_mode_c[],
-                                        Real q[gas_pcnst()]
-                                        // ,
-                                        // Real qqcw[gas_pcnst()],
-                                        )
-{
-    int s_idx = ekat::ScalarTraits<int>::invalid();
-    s_idx = gasses_start_ind()+ AeroConfig::num_gas_ids(); // gases start at index 9 (index 10 in Fortran
-                                // version)
+void transfer_tendencies_num_to_tendecines(const Real n_mode_i[],
+                                           // const Real n_mode_c[],
+                                           Real q[gas_pcnst()]
+                                           // ,
+                                           // Real qqcw[gas_pcnst()],
+) {
+  int s_idx = ekat::ScalarTraits<int>::invalid();
+  s_idx = gasses_start_ind() +
+          AeroConfig::num_gas_ids(); // gases start at index 9 (index 10 in
+                                     // Fortran version)
 
   // Now start adding aerosols mmr into the state_q
   for (int m = 0; m < AeroConfig::num_modes(); ++m) {
-    s_idx+=mam4::num_species_mode(m);
+    s_idx += mam4::num_species_mode(m);
     q[s_idx] += n_mode_i[m];
     printf("q[%d] %e n_mode_i[%d] %e \n", s_idx, q[s_idx], m, n_mode_i[m]);
     s_idx++; // update index
     // printf(" %d ", s_idx);
   }
 
-  // printf("\n "); 
+  // printf("\n ");
 }
 
 // return idx of num concentration in state_q
 KOKKOS_INLINE_FUNCTION
-void get_num_idx_in_state_q(int idxs[AeroConfig::num_modes()])
-{
-  // index of accum and aitken mode for num concetration in state_q 
-  int s_idx = gasses_start_ind() + AeroConfig::num_gas_ids(); // gases start at index 9 (index 10 in Fortran
+void get_num_idx_in_state_q(int idxs[AeroConfig::num_modes()]) {
+  // index of accum and aitken mode for num concetration in state_q
+  int s_idx =
+      gasses_start_ind() +
+      AeroConfig::num_gas_ids(); // gases start at index 9 (index 10 in Fortran
   for (int m = 0; m < AeroConfig::num_modes(); ++m) {
-    s_idx+=mam4::num_species_mode(m);
-    idxs[m]=s_idx;
+    s_idx += mam4::num_species_mode(m);
+    idxs[m] = s_idx;
     s_idx++; // update index
   }
 }
@@ -350,7 +350,6 @@ void inject_qqcw_to_prognostics(const Real *qqcw, mam4::Prognostics &progs,
     s_idx++; // update index
   }
 }
-
 
 } // end namespace mam4::utils
 

--- a/src/validation/calcsize/CMakeLists.txt
+++ b/src/validation/calcsize/CMakeLists.txt
@@ -51,7 +51,7 @@ set(ERROR_THRESHOLDS
     1e-12
     1e-12
     5e-11
-    1e-14
+    3e-5
    )
 
 

--- a/src/validation/calcsize/CMakeLists.txt
+++ b/src/validation/calcsize/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(calcsize_driver calcsize_driver.cpp
                adjust_num_sizes.cpp
                compute_tendencies.cpp
                modal_aero_calcsize_sub.cpp
+               modal_aero_calcsize_sub_ptend.cpp
                aitken_accum_exchange.cpp)
 target_link_libraries(calcsize_driver skywalker;validation;${HAERO_LIBRARIES})
 
@@ -37,6 +38,7 @@ set(TEST_LIST
     aitken_accum_exchange_case1
     calcsize_compute_dry_volume
     stand_modal_aero_calcsize_sub
+    stand_modal_aero_calcsize_sub_update_ptend
     )
 # # matching the tests and errors, just for convenience
 
@@ -49,6 +51,7 @@ set(ERROR_THRESHOLDS
     1e-12
     1e-12
     5e-11
+    1e-14
    )
 
 

--- a/src/validation/calcsize/calcsize_driver.cpp
+++ b/src/validation/calcsize/calcsize_driver.cpp
@@ -30,6 +30,8 @@ void adjust_num_sizes(Ensemble *ensemble);
 void compute_tendencies(Ensemble *ensemble);
 void aitken_accum_exchange(Ensemble *ensemble);
 void modal_aero_calcsize_sub(Ensemble *ensemble);
+void modal_aero_calcsize_sub_ptend(Ensemble *ensemble);
+
 int main(int argc, char **argv) {
   if (argc == 1) {
     usage();
@@ -61,6 +63,8 @@ int main(int argc, char **argv) {
       aitken_accum_exchange(ensemble);
     } else if (func_name == "modal_aero_calcsize_sub") {
       modal_aero_calcsize_sub(ensemble);
+    } else if (func_name == "modal_aero_calcsize_sub_ptend") {
+      modal_aero_calcsize_sub_ptend(ensemble);
     }
 
   } catch (std::exception &e) {

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -106,11 +106,8 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
             const auto dgncur_i =
                 Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
             Real dgncur_c[ntot_amode] = {};
-            // update_mmr is false. Hence,  dqqcwdt and  ptend will not be
-            // updated. if update_mmr is true. these two variables need to have
-            // a different size.
-            Real ptend[1] = {};
-            Real dqqcwdt[1] = {};
+            Real ptend[pcnst] = {};
+            Real dqqcwdt[pcnst] = {};
             modal_aero_calcsize::modal_aero_calcsize_sub(
                 state_q_k.data(), // in
                 qqcw_k.data(),    // in/out

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -61,6 +61,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
           int n_common_species_ait_accum = {};
           int ait_spec_in_acc[AeroConfig::num_aerosol_ids()] = {};
           int acc_spec_in_ait[AeroConfig::num_aerosol_ids()] = {};
+          
 
           modal_aero_calcsize::init_calcsize(
               inv_density, num2vol_ratio_min, num2vol_ratio_max,
@@ -69,7 +70,8 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
               dgnnom_nmodes, mean_std_dev_nmodes,
               // outputs
               noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-              acc_spec_in_ait);
+              acc_spec_in_ait
+              );
 
           const bool do_adjust = true;
           const bool do_aitacc_transfer = true;
@@ -106,6 +108,8 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
             const auto dgncur_i =
                 Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
             Real dgncur_c[ntot_amode] = {};
+            Real dnidt[AeroConfig::num_modes()]={}; 
+            Real dncdt[AeroConfig::num_modes()]={};
             modal_aero_calcsize::modal_aero_calcsize_sub(
                 state_q_k.data(), // in
                 qqcw_k.data(),    // in/out
@@ -118,7 +122,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
                 mean_std_dev_nmodes,
                 // outputs
                 noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-                acc_spec_in_ait, dgncur_i.data(), dgncur_c);
+                acc_spec_in_ait, dgncur_i.data(), dgncur_c, dnidt, dncdt);
           } // k
         });
 

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -106,8 +106,10 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
             const auto dgncur_i =
                 Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
             Real dgncur_c[ntot_amode] = {};
-            Real dnidt[AeroConfig::num_modes()] = {};
-            Real dncdt[AeroConfig::num_modes()] = {};
+            // update_mmr is false. Hence,  dqqcwdt and  ptend will not be updated. 
+            // if update_mmr is true. these two variables need to have a different size. 
+            Real ptend[1] = {};
+            Real dqqcwdt[1] = {};
             modal_aero_calcsize::modal_aero_calcsize_sub(
                 state_q_k.data(), // in
                 qqcw_k.data(),    // in/out
@@ -120,7 +122,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
                 mean_std_dev_nmodes,
                 // outputs
                 noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-                acc_spec_in_ait, dgncur_i.data(), dgncur_c, dnidt, dncdt);
+                acc_spec_in_ait, dgncur_i.data(), dgncur_c, ptend, dqqcwdt);
           } // k
         });
 

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -106,8 +106,9 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
             const auto dgncur_i =
                 Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
             Real dgncur_c[ntot_amode] = {};
-            // update_mmr is false. Hence,  dqqcwdt and  ptend will not be updated. 
-            // if update_mmr is true. these two variables need to have a different size. 
+            // update_mmr is false. Hence,  dqqcwdt and  ptend will not be
+            // updated. if update_mmr is true. these two variables need to have
+            // a different size.
             Real ptend[1] = {};
             Real dqqcwdt[1] = {};
             modal_aero_calcsize::modal_aero_calcsize_sub(

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -61,7 +61,6 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
           int n_common_species_ait_accum = {};
           int ait_spec_in_acc[AeroConfig::num_aerosol_ids()] = {};
           int acc_spec_in_ait[AeroConfig::num_aerosol_ids()] = {};
-          
 
           modal_aero_calcsize::init_calcsize(
               inv_density, num2vol_ratio_min, num2vol_ratio_max,
@@ -70,8 +69,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
               dgnnom_nmodes, mean_std_dev_nmodes,
               // outputs
               noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-              acc_spec_in_ait
-              );
+              acc_spec_in_ait);
 
           const bool do_adjust = true;
           const bool do_aitacc_transfer = true;
@@ -108,8 +106,8 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
             const auto dgncur_i =
                 Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
             Real dgncur_c[ntot_amode] = {};
-            Real dnidt[AeroConfig::num_modes()]={}; 
-            Real dncdt[AeroConfig::num_modes()]={};
+            Real dnidt[AeroConfig::num_modes()] = {};
+            Real dncdt[AeroConfig::num_modes()] = {};
             modal_aero_calcsize::modal_aero_calcsize_sub(
                 state_q_k.data(), // in
                 qqcw_k.data(),    // in/out

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -78,6 +78,15 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
           int n_common_species_ait_accum_2 = 4; 
           int ait_spec_in_acc_2[4] ={23, 24, 25, 26}; //frm aitken
           int acc_spec_in_ait_2[4] = {15, 17, 20, 21 };// to accum
+          bool noxf_acc2ait_2[AeroConfig::num_aerosol_ids()]  = {true};
+          
+          noxf_acc2ait_2[0] = false;
+          noxf_acc2ait_2[1] = false;
+          noxf_acc2ait_2[2] = true;
+          noxf_acc2ait_2[3] = true;
+          noxf_acc2ait_2[4] = false;
+          noxf_acc2ait_2[5] = true;
+          noxf_acc2ait_2[6] = false;
 
           const bool do_adjust = true;
           const bool do_aitacc_transfer = true;
@@ -131,7 +140,7 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
                 dgnmin_nmodes, dgnmax_nmodes, dgnnom_nmodes,
                 mean_std_dev_nmodes,
                 // outputs
-                noxf_acc2ait, n_common_species_ait_accum_2, ait_spec_in_acc_2,
+                noxf_acc2ait_2, n_common_species_ait_accum_2, ait_spec_in_acc_2,
                 acc_spec_in_ait_2, dgncur_i.data(), dgncur_c, ptend_q_k.data(), dqqcwdt_k.data());
           } // k
         });

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -1,0 +1,168 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <mam4xx/mam4.hpp>
+
+#include <mam4xx/calcsize.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+using namespace skywalker;
+using namespace mam4;
+using namespace haero;
+
+void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
+  ensemble->process([=](const Input &input, Output &output) {
+    constexpr int pcnst = aero_model::pcnst;
+    constexpr int pver = ndrop::pver;
+    constexpr int ntot_amode = AeroConfig::num_modes();
+    constexpr int nspec_max = ndrop::nspec_max;
+    constexpr int maxd_aspectype = ndrop::maxd_aspectype;
+
+    using View2D = DeviceType::view_2d<Real>;
+
+    auto state_q_db = input.get_array("state_q");
+    auto qqcw_db = input.get_array("qqcw");
+    const auto dt = input.get_array("dt")[0];
+
+    View2D state_q("state_q", pver, pcnst);
+    mam4::validation::convert_1d_vector_to_2d_view_device(state_q_db, state_q);
+    View2D qqcw("qqcw", pver, pcnst);
+    auto qqcw_host = create_mirror_view(qqcw);
+
+    int count = 0;
+    for (int kk = 0; kk < pver; ++kk) {
+      for (int i = 0; i < pcnst; ++i) {
+        qqcw_host(kk, i) = qqcw_db[count];
+        count++;
+      }
+    }
+    Kokkos::deep_copy(qqcw, qqcw_host);
+    View2D dgnumdry_m("dgnumdry_m", pver, ntot_amode);
+
+    View2D ptend_q("ptend_q", pver, pcnst);
+
+    auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
+    Kokkos::parallel_for(
+        team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
+          Real inv_density[AeroConfig::num_modes()]
+                          [AeroConfig::num_aerosol_ids()] = {};
+          Real num2vol_ratio_min[AeroConfig::num_modes()] = {};
+          Real num2vol_ratio_max[AeroConfig::num_modes()] = {};
+          Real num2vol_ratio_max_nmodes[AeroConfig::num_modes()] = {};
+          Real num2vol_ratio_min_nmodes[AeroConfig::num_modes()] = {};
+          Real num2vol_ratio_nom_nmodes[AeroConfig::num_modes()] = {};
+          Real dgnmin_nmodes[AeroConfig::num_modes()] = {};
+          Real dgnmax_nmodes[AeroConfig::num_modes()] = {};
+          Real dgnnom_nmodes[AeroConfig::num_modes()] = {};
+          Real mean_std_dev_nmodes[AeroConfig::num_modes()] = {};
+          // outputs
+          bool noxf_acc2ait[AeroConfig::num_aerosol_ids()] = {};
+          int n_common_species_ait_accum = {};
+          int ait_spec_in_acc[AeroConfig::num_aerosol_ids()] = {};
+          int acc_spec_in_ait[AeroConfig::num_aerosol_ids()] = {};
+          
+
+          modal_aero_calcsize::init_calcsize(
+              inv_density, num2vol_ratio_min, num2vol_ratio_max,
+              num2vol_ratio_max_nmodes, num2vol_ratio_min_nmodes,
+              num2vol_ratio_nom_nmodes, dgnmin_nmodes, dgnmax_nmodes,
+              dgnnom_nmodes, mean_std_dev_nmodes,
+              // outputs
+              noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
+              acc_spec_in_ait
+              );
+
+          const bool do_adjust = true;
+          const bool do_aitacc_transfer = true;
+          const bool update_mmr = true;
+
+          int nspec_amode[ntot_amode];
+          int lspectype_amode[maxd_aspectype][ntot_amode];
+          int lmassptr_amode[maxd_aspectype][ntot_amode];
+          Real specdens_amode[maxd_aspectype];
+          Real spechygro[maxd_aspectype];
+          int numptr_amode[ntot_amode];
+          int mam_idx[ntot_amode][nspec_max];
+          int mam_cnst_idx[ntot_amode][nspec_max];
+
+          ndrop::get_e3sm_parameters(
+              nspec_amode, lspectype_amode, lmassptr_amode, numptr_amode,
+              specdens_amode, spechygro, mam_idx, mam_cnst_idx);
+
+          // Note: Need to compute inv density using indexing from e3sm
+          for (int imode = 0; imode < ntot_amode; ++imode) {
+            const int nspec = nspec_amode[imode];
+            for (int isp = 0; isp < nspec; ++isp) {
+              const int idx = lspectype_amode[isp][imode] - 1;
+              inv_density[imode][isp] = 1.0 / specdens_amode[idx];
+            } // isp
+          }   // imode
+
+          // FIXME: top_lev is set to 1 in calcsize ?
+          const int top_lev = 0; // 1( in fortran )
+
+          for (int kk = top_lev; kk < pver; ++kk) {
+            const auto state_q_k = Kokkos::subview(state_q, kk, Kokkos::ALL());
+            
+
+            const auto qqcw_k = Kokkos::subview(qqcw, kk, Kokkos::ALL());
+            const auto dgncur_i =
+                Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
+            Real dgncur_c[ntot_amode] = {};
+            Real dnidt[AeroConfig::num_modes()]={}; 
+            Real dncdt[AeroConfig::num_modes()]={};
+            modal_aero_calcsize::modal_aero_calcsize_sub(
+                state_q_k.data(), // in
+                qqcw_k.data(),    // in/out
+                dt, do_adjust, do_aitacc_transfer, update_mmr, lmassptr_amode,
+                numptr_amode,
+                inv_density, // in
+                num2vol_ratio_min, num2vol_ratio_max, num2vol_ratio_max_nmodes,
+                num2vol_ratio_min_nmodes, num2vol_ratio_nom_nmodes,
+                dgnmin_nmodes, dgnmax_nmodes, dgnnom_nmodes,
+                mean_std_dev_nmodes,
+                // outputs
+                noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
+                acc_spec_in_ait, dgncur_i.data(), dgncur_c, dnidt, dncdt);
+
+          const auto ptend_q_k = Kokkos::subview(ptend_q, kk, Kokkos::ALL());
+          printf("dnidt at %d: \n",kk);
+          for (int m = 0; m < AeroConfig::num_modes(); ++m)
+          {
+            printf(" %e ",dnidt[m]);
+          }
+          printf(" \n ");
+          utils::transfer_tendencies_num_to_tendecines(dnidt,
+                                        ptend_q_k.data()
+                                        // ,
+                                        // Real qqcw[gas_pcnst()],
+                                        );   
+          } // k
+        });
+
+    constexpr Real zero = 0;
+    std::vector<Real> dgnumdry_m_out(pver * ntot_amode, zero);
+    mam4::validation::convert_2d_view_device_to_1d_vector(dgnumdry_m,
+                                                          dgnumdry_m_out);
+    
+    std::vector<Real> ptend_q_out(pver * pcnst, zero);
+    mam4::validation::convert_2d_view_device_to_1d_vector(ptend_q,
+                                                          ptend_q_out);
+
+    Kokkos::deep_copy(qqcw_host, qqcw);
+    count = 0;
+    for (int kk = 0; kk < pver; ++kk) {
+      for (int i = 0; i < pcnst; ++i) {
+        qqcw_db[count] = qqcw_host(kk, i);
+        count++;
+      }
+    }
+
+    output.set("qqcw", qqcw_db);
+    output.set("dgnumdry_m", dgnumdry_m_out);
+    output.set("ptend_q", ptend_q_out);
+  });
+}

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -76,9 +76,6 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
               acc_spec_in_ait
           );
 
-          int ait_spec_in_acc_2[4] ={23, 24, 25, 26}; //frm aitken
-          int acc_spec_in_ait_2[4] ={15, 17, 20, 21};// to accum
-
           const bool do_adjust = true;
           const bool do_aitacc_transfer = true;
           const bool update_mmr = true;
@@ -119,8 +116,8 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
                 num2vol_ratio_min_nmodes, num2vol_ratio_nom_nmodes,
                 dgnmin_nmodes, dgnmax_nmodes, dgnnom_nmodes,
                 mean_std_dev_nmodes,
-                noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc_2,
-                acc_spec_in_ait_2,
+                noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
+                acc_spec_in_ait,
                 // outputs 
                 dgncur_i.data(), dgncur_c, ptend_q_k.data(), dqqcwdt_k.data());
           } // k

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -74,19 +74,10 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
               // outputs
               noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
               acc_spec_in_ait
-              );
-          int n_common_species_ait_accum_2 = 4; 
+          );
+
           int ait_spec_in_acc_2[4] ={23, 24, 25, 26}; //frm aitken
-          int acc_spec_in_ait_2[4] = {15, 17, 20, 21 };// to accum
-          bool noxf_acc2ait_2[AeroConfig::num_aerosol_ids()]  = {true};
-          
-          noxf_acc2ait_2[0] = false;
-          noxf_acc2ait_2[1] = false;
-          noxf_acc2ait_2[2] = true;
-          noxf_acc2ait_2[3] = true;
-          noxf_acc2ait_2[4] = false;
-          noxf_acc2ait_2[5] = true;
-          noxf_acc2ait_2[6] = false;
+          int acc_spec_in_ait_2[4] ={15, 17, 20, 21};// to accum
 
           const bool do_adjust = true;
           const bool do_aitacc_transfer = true;
@@ -104,15 +95,6 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
           ndrop::get_e3sm_parameters(
               nspec_amode, lspectype_amode, lmassptr_amode, numptr_amode,
               specdens_amode, spechygro, mam_idx, mam_cnst_idx);
-
-          // Note: Need to compute inv density using indexing from e3sm
-          for (int imode = 0; imode < ntot_amode; ++imode) {
-            const int nspec = nspec_amode[imode];
-            for (int isp = 0; isp < nspec; ++isp) {
-              const int idx = lspectype_amode[isp][imode] - 1;
-              inv_density[imode][isp] = 1.0 / specdens_amode[idx];
-            } // isp
-          }   // imode
 
           // FIXME: top_lev is set to 1 in calcsize ?
           const int top_lev = 0; // 1( in fortran )
@@ -137,9 +119,10 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
                 num2vol_ratio_min_nmodes, num2vol_ratio_nom_nmodes,
                 dgnmin_nmodes, dgnmax_nmodes, dgnnom_nmodes,
                 mean_std_dev_nmodes,
-                // outputs
-                noxf_acc2ait_2, n_common_species_ait_accum_2, ait_spec_in_acc_2,
-                acc_spec_in_ait_2, dgncur_i.data(), dgncur_c, ptend_q_k.data(), dqqcwdt_k.data());
+                noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc_2,
+                acc_spec_in_ait_2,
+                // outputs 
+                dgncur_i.data(), dgncur_c, ptend_q_k.data(), dqqcwdt_k.data());
           } // k
         });
 

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -105,6 +105,8 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
           const int top_lev = 0; // 1( in fortran )
 
           for (int kk = top_lev; kk < pver; ++kk) {
+            printf("---- \n");
+            printf("kk %d \n", kk);
             const auto state_q_k = Kokkos::subview(state_q, kk, Kokkos::ALL());
             
 

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -118,8 +118,6 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
           const int top_lev = 0; // 1( in fortran )
 
           for (int kk = top_lev; kk < pver; ++kk) {
-            printf("---- \n");
-            printf("kk %d \n", kk);
             const auto state_q_k = Kokkos::subview(state_q, kk, Kokkos::ALL());
             
 

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -64,7 +64,6 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
           int n_common_species_ait_accum = {};
           int ait_spec_in_acc[AeroConfig::num_aerosol_ids()] = {};
           int acc_spec_in_ait[AeroConfig::num_aerosol_ids()] = {};
-          
 
           modal_aero_calcsize::init_calcsize(
               inv_density, num2vol_ratio_min, num2vol_ratio_max,
@@ -73,8 +72,7 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
               dgnnom_nmodes, mean_std_dev_nmodes,
               // outputs
               noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-              acc_spec_in_ait
-          );
+              acc_spec_in_ait);
 
           const bool do_adjust = true;
           const bool do_aitacc_transfer = true;
@@ -98,7 +96,6 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
 
           for (int kk = top_lev; kk < pver; ++kk) {
             const auto state_q_k = Kokkos::subview(state_q, kk, Kokkos::ALL());
-            
 
             const auto qqcw_k = Kokkos::subview(qqcw, kk, Kokkos::ALL());
             const auto dgncur_i =
@@ -115,10 +112,9 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
                 num2vol_ratio_min, num2vol_ratio_max, num2vol_ratio_max_nmodes,
                 num2vol_ratio_min_nmodes, num2vol_ratio_nom_nmodes,
                 dgnmin_nmodes, dgnmax_nmodes, dgnnom_nmodes,
-                mean_std_dev_nmodes,
-                noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-                acc_spec_in_ait,
-                // outputs 
+                mean_std_dev_nmodes, noxf_acc2ait, n_common_species_ait_accum,
+                ait_spec_in_acc, acc_spec_in_ait,
+                // outputs
                 dgncur_i.data(), dgncur_c, ptend_q_k.data(), dqqcwdt_k.data());
           } // k
         });
@@ -127,10 +123,9 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
     std::vector<Real> dgnumdry_m_out(pver * ntot_amode, zero);
     mam4::validation::convert_2d_view_device_to_1d_vector(dgnumdry_m,
                                                           dgnumdry_m_out);
-    
+
     std::vector<Real> ptend_q_out(pver * pcnst, zero);
-    mam4::validation::convert_2d_view_device_to_1d_vector(ptend_q,
-                                                          ptend_q_out);
+    mam4::validation::convert_2d_view_device_to_1d_vector(ptend_q, ptend_q_out);
 
     Kokkos::deep_copy(qqcw_host, qqcw);
     count = 0;


### PR DESCRIPTION
Computing tendencies (`ptend` and `dqqcwdt`) in `modal_aero_calcsize_sub`. 

This PR has one validation test using synthetic validation data ( data is generated by a standalone driver). This test passes with relative error of 3e-5, which is produced by kk =22 index=39.

|kk| ptend idx | mam4xx value  | mam4 value |absolute diff| absolute dif/ mam4 value|
| -------- | ------- |------- |------- |------- |------- |
|22 |39 | 0.04501103476 | 0.04499599655 |1.5038209999998498e-05 |0.00033410051735496913|

