### PR TITLE
Use nested team parallel loops

### DIFF
--- a/src/mam4xx/modal_aer_opt.hpp
+++ b/src/mam4xx/modal_aer_opt.hpp
@@ -853,32 +853,33 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt, const View2D &state_q,
 
   team.team_barrier();
 
-  for (int kk = top_lev; kk < pver; ++kk) {
+  for (int isw = 0; isw < nswbands; ++isw) {
 
-    for (int isw = 0; isw < nswbands; ++isw) {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, top_lev, pver), [&] (int kk) {
+
       Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team, ntot_amode),
+          Kokkos::ThreadVectorRange(team, ntot_amode),
           [&](int imode, Real &suma) { suma += tauxar_work(kk, imode, isw); },
           tauxar(kk + 1, isw));
 
       Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team, ntot_amode),
+          Kokkos::ThreadVectorRange(team, ntot_amode),
           [&](int imode, Real &suma) { suma += wa_work(kk, imode, isw); },
           wa(kk + 1, isw));
 
       Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team, ntot_amode),
+          Kokkos::ThreadVectorRange(team, ntot_amode),
           [&](int imode, Real &suma) { suma += ga_work(kk, imode, isw); },
           ga(kk + 1, isw));
 
       Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team, ntot_amode),
+          Kokkos::ThreadVectorRange(team, ntot_amode),
           [&](int imode, Real &suma) { suma += fa_work(kk, imode, isw); },
           fa(kk + 1, isw));
 
-    } // isw
+    }); // kk
 
-  } // kk
+  } // isw
 
 } //
 
@@ -964,32 +965,33 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt,
 
   team.team_barrier();
 
-  for (int kk = top_lev; kk < pver; ++kk) {
+  for (int isw = 0; isw < nswbands; ++isw) {
 
-    for (int isw = 0; isw < nswbands; ++isw) {
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, pver), [&] (const int kk) {
+
       Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team, ntot_amode),
+          Kokkos::ThreadVectorRange(team, ntot_amode),
           [&](int imode, Real &suma) { suma += tauxar_work(kk, imode, isw); },
           tauxar(isw, kk + 1));
 
       Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team, ntot_amode),
+          Kokkos::ThreadVectorRange(team, ntot_amode),
           [&](int imode, Real &suma) { suma += wa_work(kk, imode, isw); },
           wa(isw, kk + 1));
 
       Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team, ntot_amode),
+          Kokkos::ThreadVectorRange(team, ntot_amode),
           [&](int imode, Real &suma) { suma += ga_work(kk, imode, isw); },
           ga(isw, kk + 1));
 
       Kokkos::parallel_reduce(
-          Kokkos::TeamThreadRange(team, ntot_amode),
+          Kokkos::ThreadVectorRange(team, ntot_amode),
           [&](int imode, Real &suma) { suma += fa_work(kk, imode, isw); },
           fa(isw, kk + 1));
 
-    } // isw
+    }); // kk
 
-  } // kk
+  } // isw
 
   // compute aerosol_optical depth
   aodvis = zero;


### PR DESCRIPTION
@odiazib I could not find the reason for the compute-sanitizer fail, but we can add an additional level of parallelism where the warnings occur and that indirectly resolves the issue. Let me know what you think of this. Could be a small performance gain.