### PR TITLE
aerosol_optics - switching for to Kokkos::parallel_fors.

### DIFF
--- a/src/validation/aerosol_optics/volcanic_cmip_sw.cpp
+++ b/src/validation/aerosol_optics/volcanic_cmip_sw.cpp
@@ -80,7 +80,7 @@ void volcanic_cmip_sw(Ensemble *ensemble) {
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          aer_rad_props::volcanic_cmip_sw2(zi, ilev_tropp, ext_cmip6_sw,
+          aer_rad_props::volcanic_cmip_sw2(team, zi, ilev_tropp, ext_cmip6_sw,
                                            ssa_cmip6_sw, af_cmip6_sw, tau,
                                            tau_w, tau_w_g, tau_w_f);
         });


### PR DESCRIPTION
We encountered a race condition in the CIME case involving the `SMS_D_Ln5.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.chrysalis_intel.scream-mam4xx-optics `(D is for debug) and the` eamxx-multi-process` test (`homme_shoc_cld_p3_mam_optics_rrtmgp`). This issue was reproducible on multiple machines with different compilers. The race condition only occurred with the debug build type and multiple threads. I discovered that switching the for loop to Kokkosparallel_fors resolves this race condition. As a precaution, I added a` Kokkos::single` over `tropopause_or_quit`, which is serial routine.

Switching the for loop to` Kokkos::parallel_for`s will improve performance. However, it is unclear why our eamxx test only failed with the debug build type and multiple threads on the host.