### PR TITLE
enable shared libs build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,6 @@ message(STATUS "Configuring MAM4xx v${MAM4XX_VERSION}")
 # Precision of floating point numbers.
 message(STATUS "Using ${HAERO_PRECISION} precision floating point numbers")
 
-# We build static libraries only.
-set(BUILD_SHARED_LIBS OFF)
-
 # Report the installation prefix.
 message(STATUS "Installation prefix is ${CMAKE_INSTALL_PREFIX}")
 


### PR DESCRIPTION
We would like to be able to build the entire eamxx project with shared libs enabled, so making the change here.

There may be other changes needed elsewhere, but for now, I believe this is all that is needed.

Putting this PR together so that you can see how this affects your CI and so on.

Tagging @jeff-cohere @singhbalwinder @odiazib @bartgol