### PR TITLE
Use TeamVectorRange policies

### DIFF
--- a/src/mam4xx/aer_rad_props.hpp
+++ b/src/mam4xx/aer_rad_props.hpp
@@ -83,7 +83,7 @@ void volcanic_cmip_sw2(const ThreadTeam &team, const ConstColumnView &zi,
 
   constexpr Real half = 0.5;
   const Real lyr_thk = zi(ilev_tropp) - zi(ilev_tropp + 1);
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nswbands), [&](int i) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nswbands), [&](int i) {
     // NOTE: shape of ext_cmip6_sw_inv_m (nswbands,pver)
     const Real ext_unitless = lyr_thk * ext_cmip6_sw_inv_m(i, ilev_tropp);
     const Real asym_unitless = af_cmip6_sw(ilev_tropp, i);
@@ -267,7 +267,7 @@ void compute_odap_volcanic_at_troplayer_lw2(const ThreadTeam &team,
   constexpr Real half = 0.5;
   // update taus with 50% contributuions from the volcanic input file
   // and 50% from the existing model computed values at the tropopause layer
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlwbands), [&](int i) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlwbands), [&](int i) {
     odap_aer(i, ilev_tropp) =
         half * (odap_aer(i, ilev_tropp) +
                 (lyr_thk * ext_cmip6_lw_inv_m(ilev_tropp, i)));

--- a/src/mam4xx/aer_rad_props.hpp
+++ b/src/mam4xx/aer_rad_props.hpp
@@ -83,7 +83,8 @@ void volcanic_cmip_sw2(const ThreadTeam &team, const ConstColumnView &zi,
 
   constexpr Real half = 0.5;
   const Real lyr_thk = zi(ilev_tropp) - zi(ilev_tropp + 1);
-  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nswbands), [&](int i) {
+  static constexpr int nswbands_loc = nswbands;
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nswbands_loc), [&](int i) {
     // NOTE: shape of ext_cmip6_sw_inv_m (nswbands,pver)
     const Real ext_unitless = lyr_thk * ext_cmip6_sw_inv_m(i, ilev_tropp);
     const Real asym_unitless = af_cmip6_sw(ilev_tropp, i);

--- a/src/mam4xx/aero_config.hpp.in
+++ b/src/mam4xx/aero_config.hpp.in
@@ -145,8 +145,8 @@ public:
     const int nk = num_levels();
     int violations = 0;
     Kokkos::parallel_reduce(
-        Kokkos::TeamThreadRange(team, nk),
-        KOKKOS_CLASS_LAMBDA(int k, int &violation) {
+        Kokkos::TeamVectorRange(team, nk),
+        [&](int k, int &violation) {
           for (int mode = 0; mode < AeroConfig::num_modes();
                ++mode) { // check mode mmrs
             if ((n_mode_i[mode](k) < 0) || (n_mode_c[mode](k) < 0)) {

--- a/src/mam4xx/aero_config.hpp.in
+++ b/src/mam4xx/aero_config.hpp.in
@@ -21,7 +21,7 @@ using Tendencies = Prognostics; // fwd decl
 
 // Number of vertical levels per column (must match the number in the
 // host model)
-constexpr int nlev = @NUM_VERTICAL_LEVELS@;
+constexpr int nlev = @NUM_VERTICAL_LEVELS @;
 constexpr int pcnst = 40;
 /// @struct MAM4::AeroConfig: for use with all MAM4 process implementations
 class AeroConfig final {
@@ -65,7 +65,8 @@ public:
   KOKKOS_INLINE_FUNCTION
   static constexpr int num_aerosol_ids() { return 7; }
 
-  /// Returns the number of gas ids. This is the number of valid enums in mam4::GasId.
+  /// Returns the number of gas ids. This is the number of valid enums in
+  /// mam4::GasId.
   KOKKOS_INLINE_FUNCTION
   static constexpr int num_gas_ids() { return 6; }
 
@@ -481,14 +482,13 @@ public:
 
   // ********** End Wet Deposition Diagnostic Arrays ******************
   // ************************************************************************
-     
 
   // ************************************************************************
   // ********** Begin Dry Deposition Diagnostic Arrays ******************
 
   // INPUTS:
   // All the inputs are shared with other processes and are already defined:
-  
+
   // Obukhov length [m]
   // Called obklen in mam4;
   Real Obukhov_length;
@@ -510,24 +510,25 @@ public:
   Real ocean_fraction;
 
   // friction velocity from land model [m/s]
-  // call fv in mam4, seems to always be 0.1 but maybe that is just an initial value.
+  // call fv in mam4, seems to always be 0.1 but maybe that is just an initial
+  // value.
   Real friction_velocity;
 
   // aerodynamical resistance from land model [s/m]
-  // Called ram1 in mam4, seems to always be 0.1 but maybe that is just an initial value.
+  // Called ram1 in mam4, seems to always be 0.1 but maybe that is just an
+  // initial value.
   Real aerodynamical_resistance;
 
   // OUTPUTS:
 
   // Surface deposition flux of interstitial aerosols, [kg/m2/s] or [1/m2/s]
   // Length: ConvProc::gas_pcnst
-  // Called aerdepdryis in mam4 
+  // Called aerdepdryis in mam4
   ColumnView deposition_flux_of_interstitial_aerosols;
-
 
   // Surface deposition flux of cloud-borne aerosols, [kg/m2/s] or [1/m2/s]
   // Length: ConvProc::gas_pcnst
-  // Called aerdepdrycw in mam4 
+  // Called aerdepdrycw in mam4
   ColumnView deposition_flux_of_cloud_borne_aerosols;
 
   // ********** End Dry Deposition Diagnostic Arrays ******************

--- a/src/mam4xx/aero_config.hpp.in
+++ b/src/mam4xx/aero_config.hpp.in
@@ -21,7 +21,7 @@ using Tendencies = Prognostics; // fwd decl
 
 // Number of vertical levels per column (must match the number in the
 // host model)
-constexpr int nlev = @NUM_VERTICAL_LEVELS @;
+constexpr int nlev = @NUM_VERTICAL_LEVELS@;
 constexpr int pcnst = 40;
 /// @struct MAM4::AeroConfig: for use with all MAM4 process implementations
 class AeroConfig final {

--- a/src/mam4xx/aero_model.hpp
+++ b/src/mam4xx/aero_model.hpp
@@ -936,8 +936,8 @@ Real calc_sfc_flux(const ThreadTeam &team, Kokkos::View<Real *> layer_tend,
   // clang-format on
   Real scratch = 0;
   Kokkos::parallel_reduce(
-      Kokkos::TeamThreadRange(team, nlev),
-      KOKKOS_LAMBDA(int k, Real &scratch) {
+      Kokkos::TeamVectorRange(team, nlev),
+      [&](int k, Real &scratch) {
         const Real gravit = Constants::gravity;
         scratch += layer_tend[k] * pdel[k] / gravit;
       },

--- a/src/mam4xx/aero_model.hpp
+++ b/src/mam4xx/aero_model.hpp
@@ -937,9 +937,9 @@ Real calc_sfc_flux(const ThreadTeam &team, Kokkos::View<Real *> layer_tend,
   Real scratch = 0;
   Kokkos::parallel_reduce(
       Kokkos::TeamVectorRange(team, nlev),
-      [&](int k, Real &scratch) {
+      [&](int k, Real &lsum) {
         const Real gravit = Constants::gravity;
-        scratch += layer_tend[k] * pdel[k] / gravit;
+        lsum += layer_tend[k] * pdel[k] / gravit;
       },
       scratch);
   return scratch;

--- a/src/mam4xx/aging.hpp
+++ b/src/mam4xx/aging.hpp
@@ -432,7 +432,7 @@ void Aging::compute_tendencies(const AeroConfig &config, const ThreadTeam &team,
   const int nk = atm.num_levels();
 
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nk), KOKKOS_CLASS_LAMBDA(int k) {
+      Kokkos::TeamVectorRange(team, nk), [&](int k) {
         aging::aerosol_aging_rates_1box(k, config, dt, atm, progs, diags, tends,
                                         config_);
       });

--- a/src/mam4xx/aging.hpp
+++ b/src/mam4xx/aging.hpp
@@ -431,11 +431,10 @@ void Aging::compute_tendencies(const AeroConfig &config, const ThreadTeam &team,
 
   const int nk = atm.num_levels();
 
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, nk), [&](int k) {
-        aging::aerosol_aging_rates_1box(k, config, dt, atm, progs, diags, tends,
-                                        config_);
-      });
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nk), [&](int k) {
+    aging::aerosol_aging_rates_1box(k, config, dt, atm, progs, diags, tends,
+                                    config_);
+  });
 }
 
 } // namespace mam4

--- a/src/mam4xx/calcsize.hpp
+++ b/src/mam4xx/calcsize.hpp
@@ -998,226 +998,225 @@ public:
     const auto n_common_species_ait_accum = _n_common_species_ait_accum;
     const auto noxf_acc2ait = _noxf_acc2ait;
 
-    Kokkos::parallel_for(
-        Kokkos::TeamVectorRange(team, nk), [&](int k) {
-          Real dryvol_i = 0;
-          Real dryvol_c = 0;
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nk), [&](int k) {
+      Real dryvol_i = 0;
+      Real dryvol_c = 0;
 
-          //  initialize these variables that are used at the bottom of the
-          //  imode loop and are needed outside the loop scope
-          Real dryvol_i_aitsv = 0;
-          Real num_i_k_aitsv = 0;
-          Real dryvol_c_aitsv = 0;
-          Real num_c_k_aitsv = 0;
-          Real dryvol_i_accsv = 0;
-          Real num_i_k_accsv = 0;
-          Real dryvol_c_accsv = 0;
-          Real num_c_k_accsv = 0;
-          // NOTE: these were work arrays and may not be necessary
-          // Real drv_i_sv[nmodes];
-          // Real num_i_sv[nmodes];
-          // Real drv_c_sv[nmodes];
-          // Real num_c_sv[nmodes];
+      //  initialize these variables that are used at the bottom of the
+      //  imode loop and are needed outside the loop scope
+      Real dryvol_i_aitsv = 0;
+      Real num_i_k_aitsv = 0;
+      Real dryvol_c_aitsv = 0;
+      Real num_c_k_aitsv = 0;
+      Real dryvol_i_accsv = 0;
+      Real num_i_k_accsv = 0;
+      Real dryvol_c_accsv = 0;
+      Real num_c_k_accsv = 0;
+      // NOTE: these were work arrays and may not be necessary
+      // Real drv_i_sv[nmodes];
+      // Real num_i_sv[nmodes];
+      // Real drv_c_sv[nmodes];
+      // Real num_c_sv[nmodes];
 
-          // time scale for number adjustment
-          const Real adj_tscale = max(seconds_in_a_day, dt);
+      // time scale for number adjustment
+      const Real adj_tscale = max(seconds_in_a_day, dt);
 
-          // inverse of the adjustment time scale
-          const Real adj_tscale_inv =
-              FloatingPoint<Real>::safe_denominator(adj_tscale);
+      // inverse of the adjustment time scale
+      const Real adj_tscale_inv =
+          FloatingPoint<Real>::safe_denominator(adj_tscale);
 
-          for (int imode = 0; imode < nmodes; imode++) {
+      for (int imode = 0; imode < nmodes; imode++) {
 
-            // ----------------------------------------------------------------------
-            // Algorithm to compute dry aerosol diameter:
-            // calculate aerosol diameter volume, volume is computed from mass
-            // and density
-            // ----------------------------------------------------------------------
+        // ----------------------------------------------------------------------
+        // Algorithm to compute dry aerosol diameter:
+        // calculate aerosol diameter volume, volume is computed from mass
+        // and density
+        // ----------------------------------------------------------------------
 
-            // FIXME: get rid of these unused bits and related comments?
-            // find start and end index of species in this mode in the
-            // "population" array The indices are same for interstitial and
-            // cloudborne species s_spec_ind = population_offsets(imode) start
-            // index e_spec_ind = population_offsets(imode+1) - 1 end index of
-            // species for all (modes expect the last mode)
+        // FIXME: get rid of these unused bits and related comments?
+        // find start and end index of species in this mode in the
+        // "population" array The indices are same for interstitial and
+        // cloudborne species s_spec_ind = population_offsets(imode) start
+        // index e_spec_ind = population_offsets(imode+1) - 1 end index of
+        // species for all (modes expect the last mode)
 
-            // if(imode.eq.nmodes) then  for last mode
-            //    e_spec_ind = num_populations if imode==nmodes, end index is
-            //    the total number of species
-            // endif
+        // if(imode.eq.nmodes) then  for last mode
+        //    e_spec_ind = num_populations if imode==nmodes, end index is
+        //    the total number of species
+        // endif
 
-            // nspec = num_mode_species(imode) total number of species in mode
-            // "imode"
+        // nspec = num_mode_species(imode) total number of species in mode
+        // "imode"
 
-            // capture densities for each species in this mode
-            // density(1:max_nspec) = huge(density) initialize the whole array
-            // to a huge value [FIXME: NaN would be better than huge]
-            // density(1:nspec) = spec_density(imode, 1:nspec) assign density
-            // till nspec (as nspec can be different for each mode)
+        // capture densities for each species in this mode
+        // density(1:max_nspec) = huge(density) initialize the whole array
+        // to a huge value [FIXME: NaN would be better than huge]
+        // density(1:nspec) = spec_density(imode, 1:nspec) assign density
+        // till nspec (as nspec can be different for each mode)
 
-            // Initialize diameter(dgnum), volume to number
-            // ratios(num2vol_ratio_cur) and dry volume (dryvol) for both
-            // interstitial and cloudborne aerosols we did not implement
-            // set_initial_sz_and_volumes
-            dgncur_i[imode](k) = dgnnom_nmodes[imode]; // diameter [m]
-            Real num2vol_ratio_cur_i =
-                num2vol_ratio_nom_nmodes[imode]; // volume to number
+        // Initialize diameter(dgnum), volume to number
+        // ratios(num2vol_ratio_cur) and dry volume (dryvol) for both
+        // interstitial and cloudborne aerosols we did not implement
+        // set_initial_sz_and_volumes
+        dgncur_i[imode](k) = dgnnom_nmodes[imode]; // diameter [m]
+        Real num2vol_ratio_cur_i =
+            num2vol_ratio_nom_nmodes[imode]; // volume to number
 
-            dgncur_c[imode](k) = dgnnom_nmodes[imode]; // diameter [m]
-            Real num2vol_ratio_cur_c =
-                num2vol_ratio_nom_nmodes[imode]; // volume to number
+        dgncur_c[imode](k) = dgnnom_nmodes[imode]; // diameter [m]
+        Real num2vol_ratio_cur_c =
+            num2vol_ratio_nom_nmodes[imode]; // volume to number
 
-            // dry volume is set to zero inside compute_dry_volume_k
-            //----------------------------------------------------------------------
-            // Compute dry volume mixratios (aerosol diameter)
-            // Current default: number mmr is prognosed
-            //       Algorithm:calculate aerosol diameter from mass, number, and
-            //       fixed sigmag
-            //
-            // sigmag ("sigma g") is "geometric standard deviation for aerosol
-            // mode"
-            //
-            // Volume = sum_over_components{ component_mass mixratio / density }
-            //----------------------------------------------------------------------
-            // dryvol_i, dryvol_c are set to zero inside compute_dry_volume_k
-            calcsize::compute_dry_volume_k(k, imode, inv_density, prognostics,
-                                           dryvol_i, dryvol_c);
+        // dry volume is set to zero inside compute_dry_volume_k
+        //----------------------------------------------------------------------
+        // Compute dry volume mixratios (aerosol diameter)
+        // Current default: number mmr is prognosed
+        //       Algorithm:calculate aerosol diameter from mass, number, and
+        //       fixed sigmag
+        //
+        // sigmag ("sigma g") is "geometric standard deviation for aerosol
+        // mode"
+        //
+        // Volume = sum_over_components{ component_mass mixratio / density }
+        //----------------------------------------------------------------------
+        // dryvol_i, dryvol_c are set to zero inside compute_dry_volume_k
+        calcsize::compute_dry_volume_k(k, imode, inv_density, prognostics,
+                                       dryvol_i, dryvol_c);
 
-            const auto dgnmin = dgnmin_nmodes[imode];
-            const auto dgnmax = dgnmax_nmodes[imode];
-            const auto mean_std_dev = mean_std_dev_nmodes[imode];
+        const auto dgnmin = dgnmin_nmodes[imode];
+        const auto dgnmax = dgnmax_nmodes[imode];
+        const auto mean_std_dev = mean_std_dev_nmodes[imode];
 
-            // initial value of num interstitial for this Real and mode
-            auto init_num_i = n_i[imode](k);
+        // initial value of num interstitial for this Real and mode
+        auto init_num_i = n_i[imode](k);
 
-            // `adjust_num_sizes` will use the initial value, but other
-            // calculations require this to be nonzero.
-            // Make it non-negative
-            auto num_i_k = init_num_i < 0 ? zero : init_num_i;
+        // `adjust_num_sizes` will use the initial value, but other
+        // calculations require this to be nonzero.
+        // Make it non-negative
+        auto num_i_k = init_num_i < 0 ? zero : init_num_i;
 
-            auto init_num_c = n_c[imode](k);
-            // Make it non-negative
-            auto num_c_k = init_num_c < 0 ? zero : init_num_c;
+        auto init_num_c = n_c[imode](k);
+        // Make it non-negative
+        auto num_c_k = init_num_c < 0 ? zero : init_num_c;
 
-            const auto is_aitken_or_accumulation =
-                imode == accumulation_idx || imode == aitken_idx;
-            const auto do_adjust_aitken_or_accum =
-                is_aitken_or_accumulation && do_aitacc_transfer;
-            if (do_adjust) {
-              /*------------------------------------------------------------------
-               *  Do number adjustment for interstitial and activated particles
-               *------------------------------------------------------------------
-               * Adjustments that are applied over time-scale deltat
-               * (model time step in seconds):
-               *
-               *   1. make numbers non-negative or
-               *   2. make numbers zero when volume is zero
-               *
-               *
-               * Adjustments that are applied over time-scale of a day (in
-               *seconds)
-               *   3. bring numbers to within specified bounds
-               *
-               * (Adjustment details are explained in the process)
-               *------------------------------------------------------------------*/
+        const auto is_aitken_or_accumulation =
+            imode == accumulation_idx || imode == aitken_idx;
+        const auto do_adjust_aitken_or_accum =
+            is_aitken_or_accumulation && do_aitacc_transfer;
+        if (do_adjust) {
+          /*------------------------------------------------------------------
+           *  Do number adjustment for interstitial and activated particles
+           *------------------------------------------------------------------
+           * Adjustments that are applied over time-scale deltat
+           * (model time step in seconds):
+           *
+           *   1. make numbers non-negative or
+           *   2. make numbers zero when volume is zero
+           *
+           *
+           * Adjustments that are applied over time-scale of a day (in
+           *seconds)
+           *   3. bring numbers to within specified bounds
+           *
+           * (Adjustment details are explained in the process)
+           *------------------------------------------------------------------*/
 
-              // number tendencies to be updated by adjust_num_sizes subroutine
+          // number tendencies to be updated by adjust_num_sizes subroutine
 
-              auto &interstitial_tend = dnidt[imode](k);
-              auto &cloudborne_tend = dncdt[imode](k);
+          auto &interstitial_tend = dnidt[imode](k);
+          auto &cloudborne_tend = dncdt[imode](k);
 
-              /*NOTE: Only number tendencies (NOT mass mixing ratios) are
-               updated in adjust_num_sizes Effect of these adjustment will be
-               reflected in the particle diameters (via
-               "update_diameter_and_vol2num" subroutine call below) */
-              // Thus, when we are NOT doing the diameter/vol adjustments below,
-              // then we DO the num adjustment here
-              if (!do_adjust_aitken_or_accum) {
-                calcsize::adjust_num_sizes(
-                    dryvol_i, dryvol_c, init_num_i, init_num_c, dt, // in
-                    num2vol_ratio_min[imode], num2vol_ratio_max[imode],
-                    adj_tscale_inv,                      // in
-                    num_i_k, num_c_k,                    // out
-                    interstitial_tend, cloudborne_tend); // out
-              }
-            }
+          /*NOTE: Only number tendencies (NOT mass mixing ratios) are
+           updated in adjust_num_sizes Effect of these adjustment will be
+           reflected in the particle diameters (via
+           "update_diameter_and_vol2num" subroutine call below) */
+          // Thus, when we are NOT doing the diameter/vol adjustments below,
+          // then we DO the num adjustment here
+          if (!do_adjust_aitken_or_accum) {
+            calcsize::adjust_num_sizes(
+                dryvol_i, dryvol_c, init_num_i, init_num_c, dt, // in
+                num2vol_ratio_min[imode], num2vol_ratio_max[imode],
+                adj_tscale_inv,                      // in
+                num_i_k, num_c_k,                    // out
+                interstitial_tend, cloudborne_tend); // out
+          }
+        }
 
-            // update diameters and volume to num ratios for interstitial
-            // aerosols
+        // update diameters and volume to num ratios for interstitial
+        // aerosols
 
-            calcsize::update_diameter_and_vol2num(
-                dryvol_i, num_i_k, num2vol_ratio_min[imode],
-                num2vol_ratio_max[imode], dgnmin, dgnmax, mean_std_dev,
-                dgncur_i[imode](k), num2vol_ratio_cur_i);
+        calcsize::update_diameter_and_vol2num(
+            dryvol_i, num_i_k, num2vol_ratio_min[imode],
+            num2vol_ratio_max[imode], dgnmin, dgnmax, mean_std_dev,
+            dgncur_i[imode](k), num2vol_ratio_cur_i);
 
-            // update diameters and volume to num ratios for cloudborne aerosols
-            calcsize::update_diameter_and_vol2num(
-                dryvol_c, num_c_k, num2vol_ratio_min[imode],
-                num2vol_ratio_max[imode], dgnmin, dgnmax, mean_std_dev,
-                dgncur_c[imode](k), num2vol_ratio_cur_c);
+        // update diameters and volume to num ratios for cloudborne aerosols
+        calcsize::update_diameter_and_vol2num(
+            dryvol_c, num_c_k, num2vol_ratio_min[imode],
+            num2vol_ratio_max[imode], dgnmin, dgnmax, mean_std_dev,
+            dgncur_c[imode](k), num2vol_ratio_cur_c);
 
-            // save number concentrations and dry volumes for explicit
-            // aitken <--> accum mode transfer, which is the next step in
-            // the calcSize process
-            if (do_aitacc_transfer) {
-              if (imode == aitken_idx) {
-                // TODO: determine if we need to save these--i.e., is drv_i ever
-                // changed before the max() calculation in
-                // aitken_accum_exchange() if yes, maybe better to skip the
-                // logic and do it, regardless?
-                dryvol_i_aitsv = dryvol_i;
-                num_i_k_aitsv = num_i_k;
-                dryvol_c_aitsv = dryvol_c;
-                num_c_k_aitsv = num_c_k;
-              } else if (imode == accumulation_idx) {
-                dryvol_i_accsv = dryvol_i;
-                num_i_k_accsv = num_i_k;
-                dryvol_c_accsv = dryvol_c;
-                num_c_k_accsv = num_c_k;
-              }
-            }
-            // these were work variables that seem to not be used
-            // drv_i_sv[imode] = dryvol_i;
-            // num_i_sv[imode] = num_i_k;
-            // drv_c_sv[imode] = dryvol_c;
-            // num_c_sv[imode] = num_c_k;
-          } // for(imode)
+        // save number concentrations and dry volumes for explicit
+        // aitken <--> accum mode transfer, which is the next step in
+        // the calcSize process
+        if (do_aitacc_transfer) {
+          if (imode == aitken_idx) {
+            // TODO: determine if we need to save these--i.e., is drv_i ever
+            // changed before the max() calculation in
+            // aitken_accum_exchange() if yes, maybe better to skip the
+            // logic and do it, regardless?
+            dryvol_i_aitsv = dryvol_i;
+            num_i_k_aitsv = num_i_k;
+            dryvol_c_aitsv = dryvol_c;
+            num_c_k_aitsv = num_c_k;
+          } else if (imode == accumulation_idx) {
+            dryvol_i_accsv = dryvol_i;
+            num_i_k_accsv = num_i_k;
+            dryvol_c_accsv = dryvol_c;
+            num_c_k_accsv = num_c_k;
+          }
+        }
+        // these were work variables that seem to not be used
+        // drv_i_sv[imode] = dryvol_i;
+        // num_i_sv[imode] = num_i_k;
+        // drv_c_sv[imode] = dryvol_c;
+        // num_c_sv[imode] = num_c_k;
+      } // for(imode)
 
-          // ------------------------------------------------------------------
-          //  Overall logic for aitken<-->accumulation transfer:
-          //  ------------------------------------------------
-          //  when the aitken mode mean size is too big, the largest
-          //     aitken particles are transferred into the accum mode
-          //     to reduce the aitken mode mean size
-          //  when the accum mode mean size is too small, the smallest
-          //     accum particles are transferred into the aitken mode
-          //     to increase the accum mode mean size
-          // ------------------------------------------------------------------
-          if (do_aitacc_transfer) {
+      // ------------------------------------------------------------------
+      //  Overall logic for aitken<-->accumulation transfer:
+      //  ------------------------------------------------
+      //  when the aitken mode mean size is too big, the largest
+      //     aitken particles are transferred into the accum mode
+      //     to reduce the aitken mode mean size
+      //  when the accum mode mean size is too small, the smallest
+      //     accum particles are transferred into the aitken mode
+      //     to increase the accum mode mean size
+      // ------------------------------------------------------------------
+      if (do_aitacc_transfer) {
 
-            Real &dgncur_i_aitken =
-                diagnostics.dry_geometric_mean_diameter_i[aitken_idx](k);
-            Real &dgncur_i_accum =
-                diagnostics.dry_geometric_mean_diameter_i[accumulation_idx](k);
+        Real &dgncur_i_aitken =
+            diagnostics.dry_geometric_mean_diameter_i[aitken_idx](k);
+        Real &dgncur_i_accum =
+            diagnostics.dry_geometric_mean_diameter_i[accumulation_idx](k);
 
-            Real &dgncur_c_aitken =
-                diagnostics.dry_geometric_mean_diameter_c[aitken_idx](k);
-            Real &dgncur_c_accum =
-                diagnostics.dry_geometric_mean_diameter_c[accumulation_idx](k);
+        Real &dgncur_c_aitken =
+            diagnostics.dry_geometric_mean_diameter_c[aitken_idx](k);
+        Real &dgncur_c_accum =
+            diagnostics.dry_geometric_mean_diameter_c[accumulation_idx](k);
 
-            calcsize::aitken_accum_exchange(
-                k, aitken_idx, accumulation_idx, noxf_acc2ait,
-                n_common_species_ait_accum, ait_spec_in_acc, acc_spec_in_ait,
-                num2vol_ratio_max_nmodes, num2vol_ratio_min_nmodes,
-                num2vol_ratio_nom_nmodes, dgnmax_nmodes, dgnmin_nmodes,
-                dgnnom_nmodes, mean_std_dev_nmodes, inv_density, adj_tscale_inv,
-                dt, prognostics, dryvol_i_aitsv, num_i_k_aitsv, dryvol_c_aitsv,
-                num_c_k_aitsv, dryvol_i_accsv, num_i_k_accsv, dryvol_c_accsv,
-                num_c_k_accsv, dgncur_i_aitken, dgncur_i_accum, dgncur_c_aitken,
-                dgncur_c_accum, tendencies);
+        calcsize::aitken_accum_exchange(
+            k, aitken_idx, accumulation_idx, noxf_acc2ait,
+            n_common_species_ait_accum, ait_spec_in_acc, acc_spec_in_ait,
+            num2vol_ratio_max_nmodes, num2vol_ratio_min_nmodes,
+            num2vol_ratio_nom_nmodes, dgnmax_nmodes, dgnmin_nmodes,
+            dgnnom_nmodes, mean_std_dev_nmodes, inv_density, adj_tscale_inv, dt,
+            prognostics, dryvol_i_aitsv, num_i_k_aitsv, dryvol_c_aitsv,
+            num_c_k_aitsv, dryvol_i_accsv, num_i_k_accsv, dryvol_c_accsv,
+            num_c_k_accsv, dgncur_i_aitken, dgncur_i_accum, dgncur_c_aitken,
+            dgncur_c_accum, tendencies);
 
-          } // end do_aitacc_transfer
-        }); // kokkos::parfor(k)
+      } // end do_aitacc_transfer
+    }); // kokkos::parfor(k)
   }
 };
 

--- a/src/mam4xx/calcsize.hpp
+++ b/src/mam4xx/calcsize.hpp
@@ -999,7 +999,7 @@ public:
     const auto noxf_acc2ait = _noxf_acc2ait;
 
     Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, nk), KOKKOS_CLASS_LAMBDA(int k) {
+        Kokkos::TeamVectorRange(team, nk), [&](int k) {
           Real dryvol_i = 0;
           Real dryvol_c = 0;
 

--- a/src/mam4xx/coagulation.hpp
+++ b/src/mam4xx/coagulation.hpp
@@ -1210,11 +1210,10 @@ void Coagulation::compute_tendencies(const AeroConfig &config,
                                      const Tendencies &tends) const {
 
   const int nk = atm.num_levels();
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, nk), [&](int k) {
-        coagulation::coagulation_rates_1box(k, config, dt, atm, progs, diags,
-                                            tends, config_);
-      });
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nk), [&](int k) {
+    coagulation::coagulation_rates_1box(k, config, dt, atm, progs, diags, tends,
+                                        config_);
+  });
 }
 } // namespace mam4
 

--- a/src/mam4xx/coagulation.hpp
+++ b/src/mam4xx/coagulation.hpp
@@ -1211,7 +1211,7 @@ void Coagulation::compute_tendencies(const AeroConfig &config,
 
   const int nk = atm.num_levels();
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nk), KOKKOS_CLASS_LAMBDA(int k) {
+      Kokkos::TeamVectorRange(team, nk), [&](int k) {
         coagulation::coagulation_rates_1box(k, config, dt, atm, progs, diags,
                                             tends, config_);
       });

--- a/src/mam4xx/drydep.hpp
+++ b/src/mam4xx/drydep.hpp
@@ -924,7 +924,7 @@ void aero_model_drydep(
   const int nlev = mam4::nlev;
   // Calculate rho:
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nlev), KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
         const Real rair = Constants::r_gas_dry_air;
         rho[kk] = pmid[kk] / (rair * tair[kk]);
       });
@@ -949,7 +949,7 @@ void aero_model_drydep(
                   fricvel            //  out: bulk friction velocity of a grid cell
   );
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nlev), KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
         // imnt  : moment of the aerosol size distribution. 0 = number; 3 = volume
         int imnt = -1; 
         // jvlc  : index for last dimension of vlc_xxx arrays
@@ -1046,7 +1046,7 @@ void aero_model_drydep(
   //  interstial aerosols
   // =====================
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nlev), KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
         // imnt  : moment of the aerosol size distribution. 0 = number; 3 = volume
         int imnt = -1; 
         // jvlc  : index for last dimension of vlc_xxx arrays
@@ -1094,8 +1094,8 @@ void aero_model_drydep(
       });
   team.team_barrier();
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, ntot_amode * (1 + max_species)),
-      KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, ntot_amode * (1 + max_species)),
+      [&](int kk) {
         // -----------------------------------------------------------
         //  Loop over number + mass species of the mode.
         //  Calculate drydep-induced tendencies
@@ -1148,7 +1148,7 @@ void DryDeposition::compute_tendencies(const AeroConfig &config, const ThreadTea
   const int num_aerosol = AeroConfig::num_aerosol_ids();
   // Extract Prognostics
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nlev), KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
     for (int m=0; m<ntot_amode; ++m) {
       this->qqcw_tends[ConvProc::numptrcw_amode(m)][kk] = progs.n_mode_c[m][kk];
       for (int a=0; a<num_aerosol; ++a) 
@@ -1197,7 +1197,7 @@ void DryDeposition::compute_tendencies(const AeroConfig &config, const ThreadTea
 
   // Update Tendencies
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nlev), KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
     for (int m=0; m<ntot_amode; ++m) {
       tends.n_mode_c[m][kk] = qqcw_tends[ConvProc::numptrcw_amode(m)][kk]/dt; 
       for (int a=0; a<num_aerosol; ++a) 

--- a/src/mam4xx/drydep.hpp
+++ b/src/mam4xx/drydep.hpp
@@ -1147,8 +1147,9 @@ void DryDeposition::compute_tendencies(const AeroConfig &config, const ThreadTea
   static constexpr int ntot_amode = AeroConfig::num_modes();
   const int num_aerosol = AeroConfig::num_aerosol_ids();
   // Extract Prognostics
+  static constexpr int nlev_loc = nlev;
   Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
+      Kokkos::TeamVectorRange(team, nlev_loc), [&](int kk) {
     for (int m=0; m<ntot_amode; ++m) {
       this->qqcw_tends[ConvProc::numptrcw_amode(m)][kk] = progs.n_mode_c[m][kk];
       for (int a=0; a<num_aerosol; ++a) 
@@ -1197,7 +1198,7 @@ void DryDeposition::compute_tendencies(const AeroConfig &config, const ThreadTea
 
   // Update Tendencies
   Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
+      Kokkos::TeamVectorRange(team, nlev_loc), [&](int kk) {
     for (int m=0; m<ntot_amode; ++m) {
       tends.n_mode_c[m][kk] = qqcw_tends[ConvProc::numptrcw_amode(m)][kk]/dt; 
       for (int a=0; a<num_aerosol; ++a) 

--- a/src/mam4xx/gasaerexch.hpp
+++ b/src/mam4xx/gasaerexch.hpp
@@ -856,13 +856,12 @@ void GasAerExch::compute_tendencies(const AeroConfig &config,
   for (int k = 0; k < num_gas; ++k)
     uptk_rate[k] = GasAerExch::uptk_rate_factor(k);
 
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, nk), [&](int k) {
-        gasaerexch::gas_aerosol_uptake_rates_1box(
-            k, config, dt, atm, progs, diags, tends, config_,
-            l_gas_condense_to_mode, eqn_and_numerics_category, uptk_rate,
-            alnsg_aer);
-      });
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nk), [&](int k) {
+    gasaerexch::gas_aerosol_uptake_rates_1box(
+        k, config, dt, atm, progs, diags, tends, config_,
+        l_gas_condense_to_mode, eqn_and_numerics_category, uptk_rate,
+        alnsg_aer);
+  });
 }
 } // namespace mam4
 

--- a/src/mam4xx/gasaerexch.hpp
+++ b/src/mam4xx/gasaerexch.hpp
@@ -148,8 +148,8 @@ public:
     const int nk = atm.num_levels();
     int violations = 0;
     Kokkos::parallel_reduce(
-        Kokkos::TeamThreadRange(team, nk),
-        KOKKOS_LAMBDA(int k, int &violation) {
+        Kokkos::TeamVectorRange(team, nk),
+        [&](int k, int &violation) {
           if ((atm.temperature(k) < 0) || (atm.pressure(k) < 0) ||
               (atm.vapor_mixing_ratio(k) < 0)) {
             violation = 1;
@@ -857,7 +857,7 @@ void GasAerExch::compute_tendencies(const AeroConfig &config,
     uptk_rate[k] = GasAerExch::uptk_rate_factor(k);
 
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nk), KOKKOS_CLASS_LAMBDA(int k) {
+      Kokkos::TeamVectorRange(team, nk), [&](int k) {
         gasaerexch::gas_aerosol_uptake_rates_1box(
             k, config, dt, atm, progs, diags, tends, config_,
             l_gas_condense_to_mode, eqn_and_numerics_category, uptk_rate,

--- a/src/mam4xx/hetfrz.hpp
+++ b/src/mam4xx/hetfrz.hpp
@@ -1529,10 +1529,9 @@ void Hetfrz::compute_tendencies(const AeroConfig &config,
   // to the relevant cloud-microphysical parameterization.
 
   const int nk = atm.num_levels();
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, nk), [&](int k) {
-        hetfrz::hetfrz_rates_1box(k, dt, atm, progs, diags, tends, config_);
-      });
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nk), [&](int k) {
+    hetfrz::hetfrz_rates_1box(k, dt, atm, progs, diags, tends, config_);
+  });
 }
 
 } // namespace mam4

--- a/src/mam4xx/hetfrz.hpp
+++ b/src/mam4xx/hetfrz.hpp
@@ -1530,7 +1530,7 @@ void Hetfrz::compute_tendencies(const AeroConfig &config,
 
   const int nk = atm.num_levels();
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nk), KOKKOS_CLASS_LAMBDA(int k) {
+      Kokkos::TeamVectorRange(team, nk), [&](int k) {
         hetfrz::hetfrz_rates_1box(k, dt, atm, progs, diags, tends, config_);
       });
 }

--- a/src/mam4xx/lin_strat_chem.hpp
+++ b/src/mam4xx/lin_strat_chem.hpp
@@ -240,7 +240,7 @@ void lin_strat_chem_solve(
     const ColumnView &o3clim_linoz_diag, const ColumnView &sza_degrees) {
 
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, ltrop), KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, ltrop), [&](int kk) {
         lin_strat_chem_solve_kk(
             o3col(kk), temperature(kk), sza, pmid(kk), delta_t, rlats,
             // ltrop, & !in

--- a/src/mam4xx/lin_strat_chem.hpp
+++ b/src/mam4xx/lin_strat_chem.hpp
@@ -239,23 +239,22 @@ void lin_strat_chem_solve(
     const ColumnView &ss_o3, const ColumnView &o3col_du_diag,
     const ColumnView &o3clim_linoz_diag, const ColumnView &sza_degrees) {
 
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, ltrop), [&](int kk) {
-        lin_strat_chem_solve_kk(
-            o3col(kk), temperature(kk), sza, pmid(kk), delta_t, rlats,
-            // ltrop, & !in
-            linoz_o3_clim(kk), linoz_t_clim(kk), linoz_o3col_clim(kk),
-            linoz_PmL_clim(kk), linoz_dPmL_dO3(kk),
-            linoz_dPmL_dT(kk), // in
-            linoz_dPmL_dO3col(kk),
-            linoz_cariolle_psc(kk), // in
-            chlorine_loading,
-            psc_T, // PSC ozone loss T (K) threshold
-            o3_vmr(kk),
-            // diagnostic variables outputs
-            do3_linoz(kk), do3_linoz_psc(kk), ss_o3(kk), o3col_du_diag(kk),
-            o3clim_linoz_diag(kk), sza_degrees(kk));
-      });
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, ltrop), [&](int kk) {
+    lin_strat_chem_solve_kk(
+        o3col(kk), temperature(kk), sza, pmid(kk), delta_t, rlats,
+        // ltrop, & !in
+        linoz_o3_clim(kk), linoz_t_clim(kk), linoz_o3col_clim(kk),
+        linoz_PmL_clim(kk), linoz_dPmL_dO3(kk),
+        linoz_dPmL_dT(kk), // in
+        linoz_dPmL_dO3col(kk),
+        linoz_cariolle_psc(kk), // in
+        chlorine_loading,
+        psc_T, // PSC ozone loss T (K) threshold
+        o3_vmr(kk),
+        // diagnostic variables outputs
+        do3_linoz(kk), do3_linoz_psc(kk), ss_o3(kk), o3col_du_diag(kk),
+        o3clim_linoz_diag(kk), sza_degrees(kk));
+  });
 
 } // lin_strat_chem_solve
 

--- a/src/mam4xx/mo_chm_diags.hpp
+++ b/src/mam4xx/mo_chm_diags.hpp
@@ -49,20 +49,19 @@ void het_diags(
   //===========
 
   sox_wk[0] = 0;
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, gas_pcnst), [&](int mm) {
-        //
-        // compute vertical integral
-        //
-        wrk_wd(mm) = 0;
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, gas_pcnst), [&](int mm) {
+    //
+    // compute vertical integral
+    //
+    wrk_wd(mm) = 0;
 
-        for (int kk = 0; kk < pver; kk++) {
-          wrk_wd(mm) += het_rates[mm](kk) * mmr[mm](kk) *
-                        pdel(kk); // parallel_reduce in the future?
-        }
+    for (int kk = 0; kk < pver; kk++) {
+      wrk_wd(mm) += het_rates[mm](kk) * mmr[mm](kk) *
+                    pdel(kk); // parallel_reduce in the future?
+    }
 
-        wrk_wd(mm) *= rgrav * wght * haero::square(rearth);
-      });
+    wrk_wd(mm) *= rgrav * wght * haero::square(rearth);
+  });
 
   for (int mm = 0; mm < gas_pcnst; mm++) {
     for (int i = 0; i < 3; i++) { // FIXME: bad constant (len of sox species)

--- a/src/mam4xx/mo_chm_diags.hpp
+++ b/src/mam4xx/mo_chm_diags.hpp
@@ -50,7 +50,7 @@ void het_diags(
 
   sox_wk[0] = 0;
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, gas_pcnst), KOKKOS_LAMBDA(int mm) {
+      Kokkos::TeamVectorRange(team, gas_pcnst), [&](int mm) {
         //
         // compute vertical integral
         //

--- a/src/mam4xx/mo_chm_diags.hpp
+++ b/src/mam4xx/mo_chm_diags.hpp
@@ -49,19 +49,21 @@ void het_diags(
   //===========
 
   sox_wk[0] = 0;
-  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, gas_pcnst), [&](int mm) {
-    //
-    // compute vertical integral
-    //
-    wrk_wd(mm) = 0;
+  static constexpr int gas_pcnst_loc = gas_pcnst;
+  Kokkos::parallel_for(
+      Kokkos::TeamVectorRange(team, gas_pcnst_loc), [&](int mm) {
+        //
+        // compute vertical integral
+        //
+        wrk_wd(mm) = 0;
 
-    for (int kk = 0; kk < pver; kk++) {
-      wrk_wd(mm) += het_rates[mm](kk) * mmr[mm](kk) *
-                    pdel(kk); // parallel_reduce in the future?
-    }
+        for (int kk = 0; kk < pver; kk++) {
+          wrk_wd(mm) += het_rates[mm](kk) * mmr[mm](kk) *
+                        pdel(kk); // parallel_reduce in the future?
+        }
 
-    wrk_wd(mm) *= rgrav * wght * haero::square(rearth);
-  });
+        wrk_wd(mm) *= rgrav * wght * haero::square(rearth);
+      });
 
   for (int mm = 0; mm < gas_pcnst; mm++) {
     for (int i = 0; i < 3; i++) { // FIXME: bad constant (len of sox species)

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -117,20 +117,23 @@ void gas_washout(
   Real xrm = .189;    // mean diameter of rain drop [cm]
   Real xum = 748.0;   // mean rain drop terminal velocity [cm/s]
 
+  static constexpr int pver_loc = pver;
+
   //-----------------------------------------------------------------
   //       ... calculate the saturation concentration eqca
   //-----------------------------------------------------------------
-  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, plev, pver), [&](int k) {
-    // cal washout below cloud
-    xeqca(k) = xgas(k) /
-               (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
-               xliq_ik * avo2;
-    //-----------------------------------------------------------------
-    //       ... calculate ca; inside cloud concentration in  #/cm3(air)
-    //-----------------------------------------------------------------
-    xca(k) =
-        geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq_ik * cm3_2_m3;
-  });
+  Kokkos::parallel_for(
+      Kokkos::TeamVectorRange(team, plev, pver_loc), [&](int k) {
+        // cal washout below cloud
+        xeqca(k) = xgas(k) /
+                   (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
+                   xliq_ik * avo2;
+        //-----------------------------------------------------------------
+        //       ... calculate ca; inside cloud concentration in  #/cm3(air)
+        //-----------------------------------------------------------------
+        xca(k) = geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq_ik *
+                 cm3_2_m3;
+      });
 
   //-----------------------------------------------------------------
   //       ... if is not saturated (take hno3 as an example)

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -121,7 +121,7 @@ void gas_washout(
   //       ... calculate the saturation concentration eqca
   //-----------------------------------------------------------------
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, plev, pver), KOKKOS_LAMBDA(int k) {
+      Kokkos::TeamVectorRange(team, plev, pver), [&](int k) {
         // cal washout below cloud
         xeqca(k) = xgas(k) /
                    (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -120,18 +120,17 @@ void gas_washout(
   //-----------------------------------------------------------------
   //       ... calculate the saturation concentration eqca
   //-----------------------------------------------------------------
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, plev, pver), [&](int k) {
-        // cal washout below cloud
-        xeqca(k) = xgas(k) /
-                   (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
-                   xliq_ik * avo2;
-        //-----------------------------------------------------------------
-        //       ... calculate ca; inside cloud concentration in  #/cm3(air)
-        //-----------------------------------------------------------------
-        xca(k) = geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq_ik *
-                 cm3_2_m3;
-      });
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, plev, pver), [&](int k) {
+    // cal washout below cloud
+    xeqca(k) = xgas(k) /
+               (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
+               xliq_ik * avo2;
+    //-----------------------------------------------------------------
+    //       ... calculate ca; inside cloud concentration in  #/cm3(air)
+    //-----------------------------------------------------------------
+    xca(k) =
+        geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq_ik * cm3_2_m3;
+  });
 
   //-----------------------------------------------------------------
   //       ... if is not saturated (take hno3 as an example)

--- a/src/mam4xx/mo_setinv.hpp
+++ b/src/mam4xx/mo_setinv.hpp
@@ -100,7 +100,7 @@ void setinv(const ThreadTeam &team, const ColumnView invariants[nfs],
   constexpr int nk = mam4::nlev;
 
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nk), KOKKOS_LAMBDA(int k) {
+      Kokkos::TeamVectorRange(team, nk), [&](int k) {
         const Real tfld_k = tfld(k);
         const Real h2ovmr_k = h2ovmr(k);
         const Real pmid_k = pmid(k);
@@ -131,7 +131,7 @@ void setinv(const ThreadTeam &team, const ColumnView invariants[nfs],
   constexpr int nk = mam4::nlev;
 
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nk), KOKKOS_LAMBDA(int k) {
+      Kokkos::TeamVectorRange(team, nk), [&](int k) {
         const Real tfld_k = tfld(k);
         const Real h2ovmr_k = h2ovmr(k);
         const Real pmid_k = pmid(k);

--- a/src/mam4xx/mo_setinv.hpp
+++ b/src/mam4xx/mo_setinv.hpp
@@ -99,27 +99,26 @@ void setinv(const ThreadTeam &team, const ColumnView invariants[nfs],
   Config setinv_config_;
   constexpr int nk = mam4::nlev;
 
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, nk), [&](int k) {
-        const Real tfld_k = tfld(k);
-        const Real h2ovmr_k = h2ovmr(k);
-        const Real pmid_k = pmid(k);
-        Real invariants_k[nfs];
-        const int nspec = AeroConfig::num_gas_phase_species();
-        Real vmr_k[nspec];
-        for (int i = 0; i < nspec; ++i) {
-          vmr_k[i] = vmr[i](k);
-        }
-        Real cnst_offline_k[num_tracer_cnst];
-        for (int i = 0; i < num_tracer_cnst; ++i) {
-          cnst_offline_k[i] = cnst_offline[i](k);
-        }
-        setinv_single_level(invariants_k, tfld_k, h2ovmr_k, vmr_k, pmid_k,
-                            cnst_offline_k, setinv_config_);
-        for (int i = 0; i < nfs; ++i) {
-          invariants[i](k) = invariants_k[i];
-        }
-      }); // end kokkos::parfor(k)
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nk), [&](int k) {
+    const Real tfld_k = tfld(k);
+    const Real h2ovmr_k = h2ovmr(k);
+    const Real pmid_k = pmid(k);
+    Real invariants_k[nfs];
+    const int nspec = AeroConfig::num_gas_phase_species();
+    Real vmr_k[nspec];
+    for (int i = 0; i < nspec; ++i) {
+      vmr_k[i] = vmr[i](k);
+    }
+    Real cnst_offline_k[num_tracer_cnst];
+    for (int i = 0; i < num_tracer_cnst; ++i) {
+      cnst_offline_k[i] = cnst_offline[i](k);
+    }
+    setinv_single_level(invariants_k, tfld_k, h2ovmr_k, vmr_k, pmid_k,
+                        cnst_offline_k, setinv_config_);
+    for (int i = 0; i < nfs; ++i) {
+      invariants[i](k) = invariants_k[i];
+    }
+  }); // end kokkos::parfor(k)
 } // end setinv_nlev()
 
 KOKKOS_INLINE_FUNCTION
@@ -130,22 +129,21 @@ void setinv(const ThreadTeam &team, const ColumnView invariants[nfs],
   Config setinv_config_;
   constexpr int nk = mam4::nlev;
 
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, nk), [&](int k) {
-        const Real tfld_k = tfld(k);
-        const Real h2ovmr_k = h2ovmr(k);
-        const Real pmid_k = pmid(k);
-        Real invariants_k[nfs];
-        View1D vmr_k = Kokkos::subview(vmr, k, Kokkos::ALL());
-        View1D cnst_offline_k = Kokkos::subview(cnst_offline, k, Kokkos::ALL());
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nk), [&](int k) {
+    const Real tfld_k = tfld(k);
+    const Real h2ovmr_k = h2ovmr(k);
+    const Real pmid_k = pmid(k);
+    Real invariants_k[nfs];
+    View1D vmr_k = Kokkos::subview(vmr, k, Kokkos::ALL());
+    View1D cnst_offline_k = Kokkos::subview(cnst_offline, k, Kokkos::ALL());
 
-        setinv_single_level(invariants_k, tfld_k, h2ovmr_k, vmr_k.data(),
-                            pmid_k, cnst_offline_k.data(), setinv_config_);
+    setinv_single_level(invariants_k, tfld_k, h2ovmr_k, vmr_k.data(), pmid_k,
+                        cnst_offline_k.data(), setinv_config_);
 
-        for (int i = 0; i < nfs; ++i) {
-          invariants[i](k) = invariants_k[i];
-        }
-      }); // end kokkos::parfor(k)
+    for (int i = 0; i < nfs; ++i) {
+      invariants[i](k) = invariants_k[i];
+    }
+  }); // end kokkos::parfor(k)
 } // end setinv_nlev()
 } // namespace mo_setinv
 } // namespace mam4

--- a/src/mam4xx/mo_setsox.hpp
+++ b/src/mam4xx/mo_setsox.hpp
@@ -1319,28 +1319,27 @@ void setsox(const ThreadTeam &team, const int loffset, const Real dt,
 
   // NOTE: pdel and mbar seem to be entirely unused and only used in mam4 to
   // calculate a quantity that is written out and otherwise unused
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, nk), [&](int k) {
-        // auto press = mam4::Atmosphere.pressure;
-        const Real press_k = press(k);
-        const Real pdel_k = pdel(k);
-        const Real tfld_k = tfld(k);
-        const Real mbar_k = mbar(k);
-        const Real lwc_k = lwc(k);
-        const Real cldfrc_k = cldfrc(k);
-        const Real cldnum_k = cldnum(k);
-        const Real xhnm_k = xhnm(k);
-        const int nspec = AeroConfig::num_gas_phase_species();
-        Real qcw_k[nspec];
-        Real qin_k[nspec];
-        for (int i = 0; i < nspec; ++i) {
-          qcw_k[i] = qcw[i](k);
-          qin_k[i] = qin[i](k);
-        }
-        setsox_single_level(loffset, dt, press_k, pdel_k, tfld_k, mbar_k, lwc_k,
-                            cldfrc_k, cldnum_k, xhnm_k, setsox_config_, qcw_k,
-                            qin_k);
-      }); // end kokkos::parfor(k)
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nk), [&](int k) {
+    // auto press = mam4::Atmosphere.pressure;
+    const Real press_k = press(k);
+    const Real pdel_k = pdel(k);
+    const Real tfld_k = tfld(k);
+    const Real mbar_k = mbar(k);
+    const Real lwc_k = lwc(k);
+    const Real cldfrc_k = cldfrc(k);
+    const Real cldnum_k = cldnum(k);
+    const Real xhnm_k = xhnm(k);
+    const int nspec = AeroConfig::num_gas_phase_species();
+    Real qcw_k[nspec];
+    Real qin_k[nspec];
+    for (int i = 0; i < nspec; ++i) {
+      qcw_k[i] = qcw[i](k);
+      qin_k[i] = qin[i](k);
+    }
+    setsox_single_level(loffset, dt, press_k, pdel_k, tfld_k, mbar_k, lwc_k,
+                        cldfrc_k, cldnum_k, xhnm_k, setsox_config_, qcw_k,
+                        qin_k);
+  }); // end kokkos::parfor(k)
 } // end setsox()
 
 } // namespace mo_setsox

--- a/src/mam4xx/mo_setsox.hpp
+++ b/src/mam4xx/mo_setsox.hpp
@@ -1320,7 +1320,7 @@ void setsox(const ThreadTeam &team, const int loffset, const Real dt,
   // NOTE: pdel and mbar seem to be entirely unused and only used in mam4 to
   // calculate a quantity that is written out and otherwise unused
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, nk), KOKKOS_LAMBDA(int k) {
+      Kokkos::TeamVectorRange(team, nk), [&](int k) {
         // auto press = mam4::Atmosphere.pressure;
         const Real press_k = press(k);
         const Real pdel_k = pdel(k);

--- a/src/mam4xx/modal_aer_opt.hpp
+++ b/src/mam4xx/modal_aer_opt.hpp
@@ -807,7 +807,7 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt, const View2D &state_q,
 
   constexpr Real zero = 0;
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nswbands), [&](int i) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nswbands), [&](int i) {
     // BAD CONSTANT
     tauxar(0, i) = zero; // BAD CONSTANT
     wa(0, i) = 0.925;    // BAD CONSTANT
@@ -815,7 +815,7 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt, const View2D &state_q,
     fa(0, i) = 0.7225;   // BAD CONSTANT
   });
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, 1, pver), [&](int kk) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 1, pver), [&](int kk) {
     for (int i = 0; i < nswbands; ++i) {
       tauxar(kk, i) = zero;
       wa(kk, i) = zero;
@@ -827,7 +827,7 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt, const View2D &state_q,
   team.team_barrier();
 
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, top_lev, pver), [&](int kk) {
+      Kokkos::TeamVectorRange(team, top_lev, pver), [&](int kk) {
         const auto state_q_kk = Kokkos::subview(state_q, kk, Kokkos::ALL());
         const auto qqcw_k = Kokkos::subview(qqcw, kk, Kokkos::ALL());
         Real cldn_kk = cldn(kk);
@@ -912,7 +912,7 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt,
 
   constexpr Real zero = 0;
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nswbands), [&](int i) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nswbands), [&](int i) {
     // BAD CONSTANT
     tauxar(i, 0) = zero; // BAD CONSTANT
     wa(i, 0) = 0.925;    // BAD CONSTANT
@@ -920,7 +920,7 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt,
     fa(i, 0) = 0.7225;   // BAD CONSTANT
   });
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, 1, pver), [&](int kk) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 1, pver), [&](int kk) {
     for (int i = 0; i < nswbands; ++i) {
       tauxar(i, kk) = zero;
       wa(i, kk) = zero;
@@ -932,7 +932,7 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt,
   team.team_barrier();
 
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, top_lev, pver), [&](int kk) {
+      Kokkos::TeamVectorRange(team, top_lev, pver), [&](int kk) {
         Real state_q[pcnst] = {};
         Real qqcw[pcnst] = {};
 
@@ -995,7 +995,7 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt,
   // compute aerosol_optical depth
   aodvis = zero;
   Kokkos::parallel_reduce(
-      Kokkos::TeamThreadRange(team, top_lev, pver),
+      Kokkos::TeamVectorRange(team, top_lev, pver),
       [&](int kk, Real &suma) {
         for (int imode = 0; imode < ntot_amode; ++imode) {
           //  aerosol species loop
@@ -1148,7 +1148,7 @@ void modal_aero_lw(const ThreadTeam &team, const Real dt, const View2D &state_q,
   // tauxar(pcols,pver,nlwbands)  layer absorption optical depth
   constexpr Real zero = 0.0;
   // dry mass in each cell
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, pver), [&](int kk) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver), [&](int kk) {
     // initialize output variables
     for (int i = 0; i < nlwbands; ++i) {
       tauxar(kk, i) = zero;
@@ -1157,7 +1157,7 @@ void modal_aero_lw(const ThreadTeam &team, const Real dt, const View2D &state_q,
   team.team_barrier();
   // inputs
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, top_lev, pver), [&](int kk) {
+      Kokkos::TeamVectorRange(team, top_lev, pver), [&](int kk) {
         Real cldn_kk = cldn(kk);
         const auto state_q_kk = Kokkos::subview(state_q, kk, Kokkos::ALL());
         const auto qqcw_k = Kokkos::subview(qqcw, kk, Kokkos::ALL());
@@ -1196,7 +1196,7 @@ void modal_aero_lw(const ThreadTeam &team, const Real dt,
 
   constexpr Real zero = 0.0;
   // dry mass in each cell
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, pver), [&](int kk) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver), [&](int kk) {
     // initialize output variables
     for (int i = 0; i < nlwbands; ++i) {
       tauxar(i, kk) = zero;
@@ -1207,7 +1207,7 @@ void modal_aero_lw(const ThreadTeam &team, const Real dt,
   // inputs
 
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, top_lev, pver), [&](int kk) {
+      Kokkos::TeamVectorRange(team, top_lev, pver), [&](int kk) {
         Real cldn_kk = cldn(kk);
 
         Real state_q[pcnst] = {};

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -1600,14 +1600,16 @@ void dropmixnuc(
         for (int imode = 0; imode < ntot_amode; ++imode)
           factnum(imode, k) = factnum_k[imode];
       }); // end k
-  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 1, pver), [&](int k) {
+  static constexpr int pver_loc = pver;
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 1, pver_loc), [&](int k) {
     EKAT_KERNEL_ASSERT_MSG(0 < zm(k - 1) - zm(k),
                            "Error: Geopotential height at level should be "
                            "monotonically decreasing.\n");
   });
   team.team_barrier();
+  static constexpr int top_lev_loc = top_lev;
   Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, top_lev, pver), [&](int k) {
+      Kokkos::TeamVectorRange(team, top_lev_loc, pver_loc), [&](int k) {
         zn(k) = gravity * rpdel[k];
         if (k < pver - 1) {
           csbot(k) = two * pint(k + 1) / (rair * (temp(k) + temp(k + 1)));

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -1218,7 +1218,7 @@ void update_from_explmix(
   // cldn will be columnviews of length pver,
   // overlaps also to columnview pass as parameter so it is allocated elsewhere
   Kokkos::parallel_reduce(
-      Kokkos::TeamThreadRange(team, pver - top_lev + 1),
+      Kokkos::TeamVectorRange(team, pver - top_lev + 1),
       [&](int kk, Real &min_val) {
         const int k = top_lev - 1 + kk;
         const int kp1 = haero::min(k + 1, pver - 1);
@@ -1287,8 +1287,8 @@ void update_from_explmix(
 
   for (int isub = 0; isub < nsubmix; isub++) {
     Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, pver - top_lev + 1),
-        KOKKOS_LAMBDA(int k) {
+        Kokkos::TeamVectorRange(team, pver - top_lev + 1),
+        [&](int k) {
           const int kk = top_lev - 1 + k;
           qncld(kk) = qcld(kk);
           srcn(kk) = zero;
@@ -1310,7 +1310,7 @@ void update_from_explmix(
       // rce-comment- activation source in layer k involves particles from k+1
       //         srcn(:)=srcn(:)+nact(:,m)*(raercol(:,mm,nsav))
       Kokkos::parallel_for(
-          Kokkos::TeamThreadRange(team, pver - top_lev), KOKKOS_LAMBDA(int kk) {
+          Kokkos::TeamVectorRange(team, pver - top_lev), [&](int kk) {
             const int k = top_lev - 1 + kk;
             const int kp1 = haero::min(k + 1, pver - 1);
             srcn(k) += nact(k, imode) * raercol[kp1][nsav](mm);
@@ -1328,8 +1328,8 @@ void update_from_explmix(
 
     team.team_barrier();
     Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, pver - top_lev + 1),
-        KOKKOS_LAMBDA(int kk) {
+        Kokkos::TeamVectorRange(team, pver - top_lev + 1),
+        [&](int kk) {
           const int k = top_lev - 1 + kk;
           const int kp1 = haero::min(k + 1, pver - 1);
           const int km1 = haero::max(k - 1, top_lev - 1);
@@ -1352,8 +1352,8 @@ void update_from_explmix(
       // rce-comment - activation source in layer k involves particles from k+1
       // source(:)= nact(:,m)*(raercol(:,mm,nsav))
       Kokkos::parallel_for(
-          Kokkos::TeamThreadRange(team, pver - top_lev + 1),
-          KOKKOS_LAMBDA(int kk) {
+          Kokkos::TeamVectorRange(team, pver - top_lev + 1),
+          [&](int kk) {
             const int k = top_lev - 1 + kk;
             const int kp1 = haero::min(k + 1, pver - 1);
             source(k) = nact(k, imode) * raercol[kp1][nsav](mm);
@@ -1364,8 +1364,8 @@ void update_from_explmix(
       source(pver - 1) = haero::max(zero, tmpa);
 
       Kokkos::parallel_for(
-          Kokkos::TeamThreadRange(team, pver - top_lev + 1),
-          KOKKOS_LAMBDA(int kk) {
+          Kokkos::TeamVectorRange(team, pver - top_lev + 1),
+          [&](int kk) {
             const int k = top_lev - 1 + kk;
             const int kp1 = haero::min(k + 1, pver - 1);
             const int km1 = haero::max(k - 1, top_lev - 1);
@@ -1390,8 +1390,8 @@ void update_from_explmix(
         // rce-comment: activation source in layer k involves particles from k+1
         // source(:)= mact(:,m)*(raercol(:,mm,nsav))
         Kokkos::parallel_for(
-            Kokkos::TeamThreadRange(team, pver - top_lev + 1),
-            KOKKOS_LAMBDA(int kk) {
+            Kokkos::TeamVectorRange(team, pver - top_lev + 1),
+            [&](int kk) {
               const int k = top_lev - 1 + kk;
               const int kp1 = haero::min(k + 1, pver - 1);
               source(k) = mact(k, imode) * raercol[kp1][nsav](mm);
@@ -1400,8 +1400,8 @@ void update_from_explmix(
                raercol_cw[pver - 1][nsav](mm) * nact(pver - 1, imode);
         source(pver - 1) = haero::max(zero, tmpa);
         Kokkos::parallel_for(
-            Kokkos::TeamThreadRange(team, pver - top_lev + 1),
-            KOKKOS_LAMBDA(int kk) {
+            Kokkos::TeamVectorRange(team, pver - top_lev + 1),
+            [&](int kk) {
               const int k = top_lev - 1 + kk;
               const int kp1 = haero::min(k + 1, pver - 1);
               const int km1 = haero::max(k - 1, top_lev - 1);
@@ -1425,7 +1425,7 @@ void update_from_explmix(
 
   // evaporate particles again if no cloud
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, pver - top_lev + 1), KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, pver - top_lev + 1), [&](int kk) {
         const int k = top_lev - 1 + kk;
         if (cldn(k) == zero) {
           // no cloud
@@ -1554,7 +1554,7 @@ void dropmixnuc(
   // Initialize 1D (in space) versions of interstitial and cloud borne aerosol
   int nsav = 0;
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, pver - top_lev + 1), KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, pver - top_lev + 1), [&](int kk) {
         const int k = kk + top_lev - 1;
 
         wtke(k) = haero::max(wsub(k), wmixmin);
@@ -1607,14 +1607,14 @@ void dropmixnuc(
           factnum(imode, k) = factnum_k[imode];
       }); // end k
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, 1, pver), KOKKOS_LAMBDA(int k) {
+      Kokkos::TeamVectorRange(team, 1, pver), [&](int k) {
         EKAT_KERNEL_ASSERT_MSG(0 < zm(k - 1) - zm(k),
                                "Error: Geopotential height at level should be "
                                "monotonically decreasing.\n");
       });
   team.team_barrier();
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, top_lev, pver), KOKKOS_LAMBDA(int k) {
+      Kokkos::TeamVectorRange(team, top_lev, pver), [&](int k) {
         zn(k) = gravity * rpdel[k];
         if (k < pver - 1) {
           csbot(k) = two * pint(k + 1) / (rair * (temp(k) + temp(k + 1)));
@@ -1637,7 +1637,7 @@ void dropmixnuc(
 
   // NOTE: update_from_cldn_profile loops from 7 to 71 in fortran code.
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, pver - top_lev), KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, pver - top_lev), [&](int kk) {
         const int k = kk + top_lev - 1;
         const int kp1 = haero::min(k + 1, pver - 1);
 
@@ -1686,14 +1686,14 @@ void dropmixnuc(
   team.team_barrier();
 
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, top_lev - 1), KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, top_lev - 1), [&](int kk) {
         for (int i = 0; i < ncnst_tot; ++i) {
           qqcw_fld[i](kk) = zero;
         }
       });
   team.team_barrier();
   Kokkos::parallel_for(
-      Kokkos::TeamThreadRange(team, pver - top_lev + 1), KOKKOS_LAMBDA(int kk) {
+      Kokkos::TeamVectorRange(team, pver - top_lev + 1), [&](int kk) {
         const int k = kk + top_lev - 1;
         // droplet number mixing ratio tendency due to mixing [#/kg/s]
         ndropmix(k) = (qcld(k) - ncldwtr(k)) * dtinv - nsource(k);

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -1286,13 +1286,12 @@ void update_from_explmix(
   //  nnew stores index of most recent updated values (either 1 or 2).
 
   for (int isub = 0; isub < nsubmix; isub++) {
-    Kokkos::parallel_for(
-        Kokkos::TeamVectorRange(team, pver - top_lev + 1),
-        [&](int k) {
-          const int kk = top_lev - 1 + k;
-          qncld(kk) = qcld(kk);
-          srcn(kk) = zero;
-        });
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver - top_lev + 1),
+                         [&](int k) {
+                           const int kk = top_lev - 1 + k;
+                           qncld(kk) = qcld(kk);
+                           srcn(kk) = zero;
+                         });
     // after first pass, switch nsav, nnew so that nsav is the
     // recently updated aerosol
     team.team_barrier();
@@ -1309,12 +1308,12 @@ void update_from_explmix(
 
       // rce-comment- activation source in layer k involves particles from k+1
       //         srcn(:)=srcn(:)+nact(:,m)*(raercol(:,mm,nsav))
-      Kokkos::parallel_for(
-          Kokkos::TeamVectorRange(team, pver - top_lev), [&](int kk) {
-            const int k = top_lev - 1 + kk;
-            const int kp1 = haero::min(k + 1, pver - 1);
-            srcn(k) += nact(k, imode) * raercol[kp1][nsav](mm);
-          });
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver - top_lev),
+                           [&](int kk) {
+                             const int k = top_lev - 1 + kk;
+                             const int kp1 = haero::min(k + 1, pver - 1);
+                             srcn(k) += nact(k, imode) * raercol[kp1][nsav](mm);
+                           });
 
       // rce-comment- new formulation for k=pver
       // srcn(  pver  )=srcn(  pver  )+nact(  pver  ,m)*(raercol(pver,mm,nsav))
@@ -1327,16 +1326,15 @@ void update_from_explmix(
     // qncld == qnew
 
     team.team_barrier();
-    Kokkos::parallel_for(
-        Kokkos::TeamVectorRange(team, pver - top_lev + 1),
-        [&](int kk) {
-          const int k = top_lev - 1 + kk;
-          const int kp1 = haero::min(k + 1, pver - 1);
-          const int km1 = haero::max(k - 1, top_lev - 1);
-          explmix(qncld(km1), qncld(k), qncld(kp1), qcld(k), srcn(k),
-                  eddy_diff_kp(k), eddy_diff_km(k), overlapp(k), overlapm(k),
-                  dtmix);
-        });
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver - top_lev + 1),
+                         [&](int kk) {
+                           const int k = top_lev - 1 + kk;
+                           const int kp1 = haero::min(k + 1, pver - 1);
+                           const int km1 = haero::max(k - 1, top_lev - 1);
+                           explmix(qncld(km1), qncld(k), qncld(kp1), qcld(k),
+                                   srcn(k), eddy_diff_kp(k), eddy_diff_km(k),
+                                   overlapp(k), overlapm(k), dtmix);
+                         });
 
     team.team_barrier();
     // update aerosol number
@@ -1352,8 +1350,7 @@ void update_from_explmix(
       // rce-comment - activation source in layer k involves particles from k+1
       // source(:)= nact(:,m)*(raercol(:,mm,nsav))
       Kokkos::parallel_for(
-          Kokkos::TeamVectorRange(team, pver - top_lev + 1),
-          [&](int kk) {
+          Kokkos::TeamVectorRange(team, pver - top_lev + 1), [&](int kk) {
             const int k = top_lev - 1 + kk;
             const int kp1 = haero::min(k + 1, pver - 1);
             source(k) = nact(k, imode) * raercol[kp1][nsav](mm);
@@ -1364,8 +1361,7 @@ void update_from_explmix(
       source(pver - 1) = haero::max(zero, tmpa);
 
       Kokkos::parallel_for(
-          Kokkos::TeamVectorRange(team, pver - top_lev + 1),
-          [&](int kk) {
+          Kokkos::TeamVectorRange(team, pver - top_lev + 1), [&](int kk) {
             const int k = top_lev - 1 + kk;
             const int kp1 = haero::min(k + 1, pver - 1);
             const int km1 = haero::max(k - 1, top_lev - 1);
@@ -1390,8 +1386,7 @@ void update_from_explmix(
         // rce-comment: activation source in layer k involves particles from k+1
         // source(:)= mact(:,m)*(raercol(:,mm,nsav))
         Kokkos::parallel_for(
-            Kokkos::TeamVectorRange(team, pver - top_lev + 1),
-            [&](int kk) {
+            Kokkos::TeamVectorRange(team, pver - top_lev + 1), [&](int kk) {
               const int k = top_lev - 1 + kk;
               const int kp1 = haero::min(k + 1, pver - 1);
               source(k) = mact(k, imode) * raercol[kp1][nsav](mm);
@@ -1400,8 +1395,7 @@ void update_from_explmix(
                raercol_cw[pver - 1][nsav](mm) * nact(pver - 1, imode);
         source(pver - 1) = haero::max(zero, tmpa);
         Kokkos::parallel_for(
-            Kokkos::TeamVectorRange(team, pver - top_lev + 1),
-            [&](int kk) {
+            Kokkos::TeamVectorRange(team, pver - top_lev + 1), [&](int kk) {
               const int k = top_lev - 1 + kk;
               const int kp1 = haero::min(k + 1, pver - 1);
               const int km1 = haero::max(k - 1, top_lev - 1);
@@ -1606,12 +1600,11 @@ void dropmixnuc(
         for (int imode = 0; imode < ntot_amode; ++imode)
           factnum(imode, k) = factnum_k[imode];
       }); // end k
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, 1, pver), [&](int k) {
-        EKAT_KERNEL_ASSERT_MSG(0 < zm(k - 1) - zm(k),
-                               "Error: Geopotential height at level should be "
-                               "monotonically decreasing.\n");
-      });
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 1, pver), [&](int k) {
+    EKAT_KERNEL_ASSERT_MSG(0 < zm(k - 1) - zm(k),
+                           "Error: Geopotential height at level should be "
+                           "monotonically decreasing.\n");
+  });
   team.team_barrier();
   Kokkos::parallel_for(
       Kokkos::TeamVectorRange(team, top_lev, pver), [&](int k) {
@@ -1685,12 +1678,11 @@ void dropmixnuc(
 
   team.team_barrier();
 
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, top_lev - 1), [&](int kk) {
-        for (int i = 0; i < ncnst_tot; ++i) {
-          qqcw_fld[i](kk) = zero;
-        }
-      });
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, top_lev - 1), [&](int kk) {
+    for (int i = 0; i < ncnst_tot; ++i) {
+      qqcw_fld[i](kk) = zero;
+    }
+  });
   team.team_barrier();
   Kokkos::parallel_for(
       Kokkos::TeamVectorRange(team, pver - top_lev + 1), [&](int kk) {

--- a/src/mam4xx/nucleate_ice.hpp
+++ b/src/mam4xx/nucleate_ice.hpp
@@ -360,7 +360,7 @@ public:
     const Real alnsg_amode_aitken = _alnsg_amode_aitken;
 
     Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, nk), KOKKOS_CLASS_LAMBDA(int kk) {
+        Kokkos::TeamVectorRange(team, nk), [&](int kk) {
           const Real temp = atmosphere.temperature(kk);
           if (temp < tmelt_m_five) {
 

--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -696,49 +696,47 @@ public:
         6.02214e26; // BAD_CONSTANT (Avogadro's number ~ molecules/kmole)
     static constexpr Real r_universal = boltzmann * avogadro; // BAD_CONSTANT
     const int nk = atm.num_levels();
-    Kokkos::parallel_for(
-        Kokkos::TeamVectorRange(team, nk), [&](int k) {
-          // extract atmospheric state
-          Real temp = atm.temperature(k);
-          Real pmid = atm.pressure(k);
-          Real aircon = pmid / (r_universal * temp);
-          Real zmid = atm.height(k);
-          Real pblh = atm.planetary_boundary_layer_height;
-          Real qv = atm.vapor_mixing_ratio(k);
-          Real relhum = conversions::relative_humidity_from_vapor_mixing_ratio(
-              qv, temp, pmid);
-          Real uptkrate_so4 = 0;
-          Real del_h2so4_gasprod = 0;
-          Real del_h2so4_aeruptk = 0;
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nk), [&](int k) {
+      // extract atmospheric state
+      Real temp = atm.temperature(k);
+      Real pmid = atm.pressure(k);
+      Real aircon = pmid / (r_universal * temp);
+      Real zmid = atm.height(k);
+      Real pblh = atm.planetary_boundary_layer_height;
+      Real qv = atm.vapor_mixing_ratio(k);
+      Real relhum = conversions::relative_humidity_from_vapor_mixing_ratio(
+          qv, temp, pmid);
+      Real uptkrate_so4 = 0;
+      Real del_h2so4_gasprod = 0;
+      Real del_h2so4_aeruptk = 0;
 
-          // extract relevant gas mixing ratios (H2SO4 only for now)
-          Real qgas_cur[num_gases], qgas_avg[num_gases];
-          qgas_cur[igas_h2so4] = progs.q_gas[igas_h2so4](k);
-          qgas_avg[igas_h2so4] =
-              progs.q_gas[igas_h2so4](k); // is this good enough?
+      // extract relevant gas mixing ratios (H2SO4 only for now)
+      Real qgas_cur[num_gases], qgas_avg[num_gases];
+      qgas_cur[igas_h2so4] = progs.q_gas[igas_h2so4](k);
+      qgas_avg[igas_h2so4] = progs.q_gas[igas_h2so4](k); // is this good enough?
 
-          // extract relevant aerosol mixing ratios (SO4 in aitken mode only for
-          // now)
-          Real qnum_cur[num_modes], qaer_cur[num_modes][max_num_mode_species];
-          qnum_cur[nait] = progs.n_mode_i[nait](k);
-          qaer_cur[nait][iaer_so4] = progs.q_aero_i[nait][iaer_so4](k);
+      // extract relevant aerosol mixing ratios (SO4 in aitken mode only for
+      // now)
+      Real qnum_cur[num_modes], qaer_cur[num_modes][max_num_mode_species];
+      qnum_cur[nait] = progs.n_mode_i[nait](k);
+      qaer_cur[nait][iaer_so4] = progs.q_aero_i[nait][iaer_so4](k);
 
-          Real qwtr_cur[num_modes] = {}; // water vapor mmr
-          qwtr_cur[nait] = qv;
+      Real qwtr_cur[num_modes] = {}; // water vapor mmr
+      qwtr_cur[nait] = qv;
 
-          // compute tendencies at this level
-          Real dndt_ait, dmdt_ait, dso4dt_ait, dnh4dt_ait, dnclusterdt;
-          compute_tendencies_(dt, temp, pmid, aircon, zmid, pblh, relhum,
-                              uptkrate_so4, del_h2so4_gasprod,
-                              del_h2so4_aeruptk, qgas_cur, qgas_avg, qnum_cur,
-                              qaer_cur, qwtr_cur, dndt_ait, dmdt_ait,
-                              dso4dt_ait, dnh4dt_ait, dnclusterdt);
+      // compute tendencies at this level
+      Real dndt_ait, dmdt_ait, dso4dt_ait, dnh4dt_ait, dnclusterdt;
+      compute_tendencies_(dt, temp, pmid, aircon, zmid, pblh, relhum,
+                          uptkrate_so4, del_h2so4_gasprod, del_h2so4_aeruptk,
+                          qgas_cur, qgas_avg, qnum_cur, qaer_cur, qwtr_cur,
+                          dndt_ait, dmdt_ait, dso4dt_ait, dnh4dt_ait,
+                          dnclusterdt);
 
-          // Store the computed tendencies.
-          tends.n_mode_i[nait](k) = dndt_ait;
-          tends.q_aero_i[nait][iaer_so4](k) = dso4dt_ait;
-          tends.q_gas[igas_h2so4](k) = -dso4dt_ait;
-        });
+      // Store the computed tendencies.
+      tends.n_mode_i[nait](k) = dndt_ait;
+      tends.q_aero_i[nait][iaer_so4](k) = dso4dt_ait;
+      tends.q_gas[igas_h2so4](k) = -dso4dt_ait;
+    });
   }
 
   // This function computes relevant tendencies at a single vertical level. It

--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -697,7 +697,7 @@ public:
     static constexpr Real r_universal = boltzmann * avogadro; // BAD_CONSTANT
     const int nk = atm.num_levels();
     Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, nk), KOKKOS_CLASS_LAMBDA(int k) {
+        Kokkos::TeamVectorRange(team, nk), [&](int k) {
           // extract atmospheric state
           Real temp = atm.temperature(k);
           Real pmid = atm.pressure(k);

--- a/src/mam4xx/rename.hpp
+++ b/src/mam4xx/rename.hpp
@@ -662,7 +662,7 @@ public:
     // =======================================================================
 
     Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, nk), KOKKOS_CLASS_LAMBDA(int kk) {
+        Kokkos::TeamVectorRange(team, nk), [&](int kk) {
           Real qnum_i_cur[AeroConfig::num_modes()];
           Real qmol_i_cur[AeroConfig::num_modes()]
                          [AeroConfig::num_aerosol_ids()];

--- a/src/mam4xx/rename.hpp
+++ b/src/mam4xx/rename.hpp
@@ -661,64 +661,59 @@ public:
     // qaercw_del_grow4rnam -> qmol_c_del
     // =======================================================================
 
-    Kokkos::parallel_for(
-        Kokkos::TeamVectorRange(team, nk), [&](int kk) {
-          Real qnum_i_cur[AeroConfig::num_modes()];
-          Real qmol_i_cur[AeroConfig::num_modes()]
-                         [AeroConfig::num_aerosol_ids()];
-          Real qmol_i_del[AeroConfig::num_modes()]
-                         [AeroConfig::num_aerosol_ids()];
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nk), [&](int kk) {
+      Real qnum_i_cur[AeroConfig::num_modes()];
+      Real qmol_i_cur[AeroConfig::num_modes()][AeroConfig::num_aerosol_ids()];
+      Real qmol_i_del[AeroConfig::num_modes()][AeroConfig::num_aerosol_ids()];
 
-          //
-          Real qnum_c_cur[AeroConfig::num_modes()];
-          Real qmol_c_cur[AeroConfig::num_modes()]
-                         [AeroConfig::num_aerosol_ids()];
-          Real qmol_c_del[AeroConfig::num_modes()]
-                         [AeroConfig::num_aerosol_ids()];
+      //
+      Real qnum_c_cur[AeroConfig::num_modes()];
+      Real qmol_c_cur[AeroConfig::num_modes()][AeroConfig::num_aerosol_ids()];
+      Real qmol_c_del[AeroConfig::num_modes()][AeroConfig::num_aerosol_ids()];
 
-          const bool &is_cloudy_cur = is_cloudy(kk);
-          int rename_idx = 0;
+      const bool &is_cloudy_cur = is_cloudy(kk);
+      int rename_idx = 0;
 
-          // FIXME: adjust these to use mamRefactor's MW's
-          for (int imode = 0; imode < nmodes; ++imode) {
-            qnum_i_cur[imode] = prognostics.n_mode_i[imode](kk);
-            qnum_c_cur[imode] = prognostics.n_mode_c[imode](kk);
-            for (int jspec = 0; jspec < nspec; ++jspec) {
-              // get the mapping from the mam4xx species ordering to rename's
-              rename_idx = _mam4xx2rename_idx[imode][jspec];
-              // convert mass mixing ratios to molar mixing ratios
-              qmol_i_cur[imode][rename_idx] = conversions::vmr_from_mmr(
-                  prognostics.q_aero_i[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
-              qmol_i_del[imode][rename_idx] = conversions::vmr_from_mmr(
-                  tendencies.q_aero_i[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
-              qmol_c_cur[imode][rename_idx] = conversions::vmr_from_mmr(
-                  prognostics.q_aero_c[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
-              qmol_c_del[imode][rename_idx] = conversions::vmr_from_mmr(
-                  tendencies.q_aero_c[imode][rename_idx](kk),
-                  aero_species(rename_idx).molecular_weight);
-            }
-          }
+      // FIXME: adjust these to use mamRefactor's MW's
+      for (int imode = 0; imode < nmodes; ++imode) {
+        qnum_i_cur[imode] = prognostics.n_mode_i[imode](kk);
+        qnum_c_cur[imode] = prognostics.n_mode_c[imode](kk);
+        for (int jspec = 0; jspec < nspec; ++jspec) {
+          // get the mapping from the mam4xx species ordering to rename's
+          rename_idx = _mam4xx2rename_idx[imode][jspec];
+          // convert mass mixing ratios to molar mixing ratios
+          qmol_i_cur[imode][rename_idx] = conversions::vmr_from_mmr(
+              prognostics.q_aero_i[imode][rename_idx](kk),
+              aero_species(rename_idx).molecular_weight);
+          qmol_i_del[imode][rename_idx] = conversions::vmr_from_mmr(
+              tendencies.q_aero_i[imode][rename_idx](kk),
+              aero_species(rename_idx).molecular_weight);
+          qmol_c_cur[imode][rename_idx] = conversions::vmr_from_mmr(
+              prognostics.q_aero_c[imode][rename_idx](kk),
+              aero_species(rename_idx).molecular_weight);
+          qmol_c_del[imode][rename_idx] = conversions::vmr_from_mmr(
+              tendencies.q_aero_c[imode][rename_idx](kk),
+              aero_species(rename_idx).molecular_weight);
+        }
+      }
 
-          mam_rename_1subarea_(is_cloudy_cur, smallest_dryvol_value,
-                               dest_mode_of_mode,                  // in
-                               mean_std_dev,                       // in
-                               fmode_dist_tail_fac,                // in
-                               num2vol_ratio_lo_rlx,               // in
-                               num2vol_ratio_hi_rlx,               // in
-                               ln_diameter_tail_fac,               // in
-                               num_pairs,                          // in
-                               diameter_cutoff,                    // in
-                               ln_dia_cutoff,                      // in
-                               diameter_threshold,                 // in
-                               mass_2_vol,                         // in
-                               dgnum_amode,                        // in
-                               qnum_i_cur, qmol_i_cur,             // out
-                               qmol_i_del, qnum_c_cur, qmol_c_cur, // out
-                               qmol_c_del);                        // out
-        }); // end kokkos::parfor(kk)
+      mam_rename_1subarea_(is_cloudy_cur, smallest_dryvol_value,
+                           dest_mode_of_mode,                  // in
+                           mean_std_dev,                       // in
+                           fmode_dist_tail_fac,                // in
+                           num2vol_ratio_lo_rlx,               // in
+                           num2vol_ratio_hi_rlx,               // in
+                           ln_diameter_tail_fac,               // in
+                           num_pairs,                          // in
+                           diameter_cutoff,                    // in
+                           ln_dia_cutoff,                      // in
+                           diameter_threshold,                 // in
+                           mass_2_vol,                         // in
+                           dgnum_amode,                        // in
+                           qnum_i_cur, qmol_i_cur,             // out
+                           qmol_i_del, qnum_c_cur, qmol_c_cur, // out
+                           qmol_c_del);                        // out
+    }); // end kokkos::parfor(kk)
     // FIXME: convert back to mass mixing ratios and store in progs/tends
     // prognostics = ???
     // tendencies = ???

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1146,12 +1146,12 @@ template <typename VIEWTYPE>
 KOKKOS_INLINE_FUNCTION void sum_values(const ThreadTeam &team,
                                        const View1D &sum, VIEWTYPE x,
                                        VIEWTYPE y, const int nlev) {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev),
                        [&](int k) { sum[k] = x[k] + y[k]; });
 }
 KOKKOS_INLINE_FUNCTION
 void zero_values(const ThreadTeam &team, const View1D &vec, const int nlev) {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev),
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev),
                        [&](int k) { vec[k] = 0; });
 }
 
@@ -1163,7 +1163,7 @@ void sum_deep_and_shallow(const ThreadTeam &team, const View1D &conicw,
                           const ConstView1D &sh_frac, const int nlev) {
   // BAD CONSTANT
   const Real small_value_2 = 1.e-2;
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev), [&](int k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int k) {
     // sum deep and shallow convection contributions
     conicw[k] = (icwmrdp[k] * dp_frac[k] + icwmrsh[k] * sh_frac[k]) /
                 haero::max(small_value_2, sh_frac[k] + dp_frac[k]);
@@ -1182,7 +1182,7 @@ void cloud_diagnostics(const ThreadTeam &team,
                        const View1D &cldv, const View1D &cldvcu,
                        const View1D &cldvst, const View1D &rain,
                        const int nlev) {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, 1), [&](int k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 1), [&](int k) {
     wetdep::clddiag(nlev, temperature.data(), pmid.data(), pdel.data(),
                     cmfdqr.data(), evapc.data(), cldt.data(), cldcu.data(),
                     cldst.data(), evapr.data(), prain.data(),
@@ -1201,7 +1201,7 @@ void set_f_act(const ThreadTeam &team, Kokkos::View<bool *> isprx,
                const View2D &state_q, const View2D &ptend_q, const Real dt,
                const int nlev) {
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev), [&](int k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int k) {
     isprx[k] = aero_model::examine_prec_exist(k, pdel.data(), prain.data(),
                                               cmfdqr.data(), evapr.data());
 
@@ -1222,7 +1222,7 @@ void modal_aero_bcscavcoef_get(
                             [AeroConfig::num_modes()],
     const View1D &scavcoefnum, const View1D &scavcoefvol, const int imode,
     const int nlev) {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev), [&](int k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int k) {
     const Real dgnum_amode_imode = modes(imode).nom_diameter;
     ColumnView dgn_awet_imode = diags.wet_geometric_mean_diameter_i[imode];
     const Real dgn_awet_imode_k = dgn_awet_imode[k];
@@ -1243,7 +1243,7 @@ void modal_aero_bcscavcoef_get(
                             [AeroConfig::num_modes()],
     const View1D &scavcoefnum, const View1D &scavcoefvol, const int imode,
     const int nlev) {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev), [&](int k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int k) {
     const Real dgnum_amode_imode = modes(imode).nom_diameter;
     const Real dgn_awet_imode_k = wet_geometric_mean_diameter_i(imode, k);
     aero_model::modal_aero_bcscavcoef_get(
@@ -1258,7 +1258,7 @@ void define_act_frac(const ThreadTeam &team, const View1D &sol_facti,
                      const View1D &sol_factic, const View1D &sol_factb,
                      const View1D &f_act_conv, const int lphase,
                      const int imode, const int nlev) {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev), [&](int k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int k) {
     aero_model::define_act_frac(lphase, imode, sol_facti[k], sol_factic[k],
                                 sol_factb[k], f_act_conv[k]);
   });
@@ -1399,7 +1399,7 @@ void compute_q_tendencies(
   Real precnumc_base = 0;
   // NOTE: The following k loop cannot be converted to parallel_for
   // because precabs requires values from the previous elevation (k-1).
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, 1), [&](int idummy) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 1), [&](int idummy) {
     for (int k = 0; k < nlev; ++k) {
       const auto rtscavt_sv_k = ekat::subview(rtscavt_sv, k);
       // mam_prevap_resusp_optcc values control the prevap_resusp
@@ -1486,7 +1486,7 @@ void compute_q_tendencies(
 KOKKOS_INLINE_FUNCTION
 void update_q_tendencies(const ThreadTeam &team, const View2D &ptend_q,
                          const View1D &scavt, const int mm, const int nlev) {
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev), [&](int k) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int k) {
     Kokkos::atomic_add(&ptend_q(k, mm), scavt[k]);
   });
 }
@@ -1712,7 +1712,7 @@ void aero_model_wetdep(
   haero::ConstColumnView q_liq = atm.liquid_mixing_ratio;
   haero::ConstColumnView q_ice = atm.ice_mixing_ratio;
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev), [&](int kk) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
     // copy data from prog to stateq
     const auto state_q_kk = ekat::subview(state_q, kk);
     const auto qqcw_kk = ekat::subview(qqcw, kk);
@@ -1734,7 +1734,7 @@ void aero_model_wetdep(
   // accumulation modes is done in conjunction with the dry radius calculation
   // compute calcsize and
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, 0, nlev), [&](int kk) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 0, nlev), [&](int kk) {
     const auto state_q_kk = ekat::subview(state_q, kk);
     const auto qqcw_kk = ekat::subview(qqcw, kk);
     const auto ptend_q_kk = ekat::subview(ptend_q, kk);
@@ -1866,7 +1866,7 @@ void aero_model_wetdep(
     // Stratiform cloud fraction cldst  = cldt - cldcu  Stratiform cloud
     // fraction
     team.team_barrier();
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev),
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev),
                          [&](int k) { cldst[k] = cldt[k] - cldcu[k]; });
 
     // FIXME: where does eq come from?
@@ -2081,7 +2081,7 @@ void aero_model_wetdep(
   }
   // make sure that ptend is updated in tendencies
   team.team_barrier();
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, 0, nlev), [&](int kk) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 0, nlev), [&](int kk) {
     const auto ptend_q_kk = ekat::subview(ptend_q, kk);
     const auto state_q_kk = ekat::subview(state_q, kk);
     const auto qqcw_kk = ekat::subview(qqcw, kk);
@@ -2268,7 +2268,7 @@ void WetDeposition::compute_tendencies(
   Diagnostics::ColumnTracerView state_q = diags.tracer_mixing_ratio;
   Diagnostics::ColumnTracerView ptend_q = diags.d_tracer_mixing_ratio_dt;
 
-  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, nlev), [&](int kk) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
     // copy data from prog to stateq
     const auto state_q_kk = ekat::subview(state_q, kk);
     utils::extract_stateq_from_prognostics(progs, atm, state_q_kk.data(), kk);
@@ -2280,16 +2280,16 @@ void WetDeposition::compute_tendencies(
 
   Real rprdshsum = 0, rprddpsum = 0, evapcdpsum = 0, evapcshsum = 0;
   Kokkos::parallel_reduce(
-      Kokkos::TeamThreadRange(team, nlev),
+      Kokkos::TeamVectorRange(team, nlev),
       [&](int kk, Real &suma) { suma += rprdsh[kk]; }, rprdshsum);
   Kokkos::parallel_reduce(
-      Kokkos::TeamThreadRange(team, nlev),
+      Kokkos::TeamVectorRange(team, nlev),
       [&](int kk, Real &suma) { suma += rprddp[kk]; }, rprddpsum);
   Kokkos::parallel_reduce(
-      Kokkos::TeamThreadRange(team, nlev),
+      Kokkos::TeamVectorRange(team, nlev),
       [&](int kk, Real &suma) { suma += evapcdp[kk]; }, evapcdpsum);
   Kokkos::parallel_reduce(
-      Kokkos::TeamThreadRange(team, nlev),
+      Kokkos::TeamVectorRange(team, nlev),
       [&](int kk, Real &suma) { suma += evapcsh[kk]; }, evapcshsum);
 
   // cumulus cloud fraction =  dp_frac + sh_frac

--- a/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
+++ b/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
@@ -122,7 +122,7 @@ void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
           const int top_lev = 0; // 1( in fortran )
 
           Kokkos::parallel_for(
-              Kokkos::TeamThreadRange(team, top_lev, pver), [&](int kk) {
+              Kokkos::TeamVectorRange(team, top_lev, pver), [&](int kk) {
                 const auto state_q_k =
                     Kokkos::subview(state_q, kk, Kokkos::ALL());
                 const auto qqcw_k = Kokkos::subview(qqcw, kk, Kokkos::ALL());

--- a/src/validation/aero_model/aero_model_wetdep.cpp
+++ b/src/validation/aero_model/aero_model_wetdep.cpp
@@ -150,7 +150,7 @@ void aero_model_wetdep(Ensemble *ensemble) {
 
           // we need to inject validation values to progs.
           Kokkos::parallel_for(
-              Kokkos::TeamThreadRange(team, nlev), [&](int kk) {
+              Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
                 // copy data from prog to stateq
                 const auto state_q_kk = ekat::subview(state_q, kk);
                 const auto qqcw_kk = ekat::subview(qqcw, kk);
@@ -173,7 +173,7 @@ void aero_model_wetdep(Ensemble *ensemble) {
 
           team.team_barrier();
           Kokkos::parallel_for(
-              Kokkos::TeamThreadRange(team, 0, nlev), [&](int kk) {
+              Kokkos::TeamVectorRange(team, 0, nlev), [&](int kk) {
                 const auto ptend_q_kk = ekat::subview(ptend_q, kk);
                 utils::extract_ptend_from_tendencies(tends_in,
                                                      ptend_q_kk.data(), kk);

--- a/src/validation/aerosol_optics/data_transfer_state_q_qqwc_to_prog.cpp
+++ b/src/validation/aerosol_optics/data_transfer_state_q_qqwc_to_prog.cpp
@@ -115,7 +115,7 @@ void data_transfer_state_q_qqwc_to_prog(Ensemble *ensemble) {
           auto progs_in = progs;
           // we need to inject validation values to progs.
           Kokkos::parallel_for(
-              Kokkos::TeamThreadRange(team, nlev), [&](int kk) {
+              Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
                 // copy data from prog to stateq
                 const auto &state_q_kk = ekat::subview(state_q, kk);
                 const auto qqcw_kk = ekat::subview(qqcw, kk);
@@ -126,7 +126,7 @@ void data_transfer_state_q_qqwc_to_prog(Ensemble *ensemble) {
           team.team_barrier();
           // 2. Let's extract state_q and qqcw from prog.
           Kokkos::parallel_for(
-              Kokkos::TeamThreadRange(team, pver), [&](int kk) {
+              Kokkos::TeamVectorRange(team, pver), [&](int kk) {
                 const auto state_q_output_kk =
                     Kokkos::subview(state_q_output, kk, Kokkos::ALL());
                 const auto qqcw_output_k =

--- a/src/validation/aerosol_optics/data_transfer_state_q_qqwc_to_prog.cpp
+++ b/src/validation/aerosol_optics/data_transfer_state_q_qqwc_to_prog.cpp
@@ -105,7 +105,6 @@ void data_transfer_state_q_qqwc_to_prog(Ensemble *ensemble) {
     Kokkos::deep_copy(state_q_output_non, state_non);
 
     mam4::Prognostics progs = validation::create_prognostics(nlev);
-
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -113,9 +112,10 @@ void data_transfer_state_q_qqwc_to_prog(Ensemble *ensemble) {
           //  inject_qqcw_to_prognostics and inject_stateq_to_prognostics are
           //  use in validation and testing.
           auto progs_in = progs;
+          static constexpr int nlev_loc = nlev;
           // we need to inject validation values to progs.
           Kokkos::parallel_for(
-              Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
+              Kokkos::TeamVectorRange(team, nlev_loc), [&](int kk) {
                 // copy data from prog to stateq
                 const auto &state_q_kk = ekat::subview(state_q, kk);
                 const auto qqcw_kk = ekat::subview(qqcw, kk);


### PR DESCRIPTION
Changes:
- Use `TeamVectorRange` if only a single level of parallelism exists within a team policy loop. Given the TeamPolicy used in EAMxx for MAM4xx code, I don't think these fixes will solve non-determinism, but if in the future a vector length >1 is used in the TeamPolicy it might be necessary.
- Use `[&]` for the capture in inner parallel loops. This may clear up some compiler errors/warnings on some arch and should be slightly more performant.
- Found a case where a parallel_reduce had the local and global sum variables having the same name. This should work fine, but is confusing.