### PR TITLE
Fix Failing Validation Tests for Online Emissions

### DIFF
--- a/src/mam4xx/aero_model_emissions.hpp
+++ b/src/mam4xx/aero_model_emissions.hpp
@@ -901,10 +901,8 @@ void marine_organic_emissions(
 KOKKOS_INLINE_FUNCTION
 void aero_model_emissions(
     // in
-    const ThreadTeam &team,
-    OnlineEmissionsData online_emiss_data,
-    SeasaltEmissionsData seasalt_data,
-    DustEmissionsData dust_data,
+    const ThreadTeam &team, OnlineEmissionsData online_emiss_data,
+    SeasaltEmissionsData seasalt_data, DustEmissionsData dust_data,
     // inout
     // NOTE: fortran: cam_in%cflx
     Real (&cflux)[pcnst]) {
@@ -991,8 +989,7 @@ void aero_model_emissions(
 KOKKOS_INLINE_FUNCTION
 void aero_model_emissions(
     // in
-    OnlineEmissionsData online_emiss_data,
-    SeasaltEmissionsData seasalt_data,
+    OnlineEmissionsData online_emiss_data, SeasaltEmissionsData seasalt_data,
     DustEmissionsData dust_data,
     // inout
     // NOTE: fortran: cam_in%cflx

--- a/src/validation/aero_emissions/CMakeLists.txt
+++ b/src/validation/aero_emissions/CMakeLists.txt
@@ -51,9 +51,9 @@ set(DEFAULT_TOL 2e-10)
 set(ERROR_THRESHOLDS
     3e-9           # calc_om_seasalt
     8e-10          # calculate_seasalt_numflux_in_bins
-    2.2e-10        # marine_organic_emis
+    3e-10        # marine_organic_emis
     ${DEFAULT_TOL} # marine_organic_massflx_calc
-    2.2e-10        # marine_organic_numflx_calc
+    3e-10        # marine_organic_numflx_calc
     ${DEFAULT_TOL} # seasalt_emisflx_calc_massflx
     ${DEFAULT_TOL} # seasalt_emisflx_calc_numflx
     ${DEFAULT_TOL} # seasalt_emis

--- a/src/validation/aero_emissions/calc_om_seasalt.cpp
+++ b/src/validation/aero_emissions/calc_om_seasalt.cpp
@@ -46,16 +46,17 @@ void calc_om_seasalt(Ensemble *ensemble) {
         mam4::aero_model_emissions::n_organic_species_max;
     const int salt_nsection = mam4::aero_model_emissions::salt_nsection;
 
-    const auto mpoly_in = input.get_array("mpoly_in")[0];
-    const auto mprot_in = input.get_array("mprot_in")[0];
-    const auto mlip_in = input.get_array("mlip_in")[0];
     Real mass_frac_bub_section[n_organic_species_max][salt_nsection] = {0.0};
     Real om_ssa[salt_nsection] = {0.0};
 
     mam4::aero_model_emissions::SeasaltEmissionsData data;
     mam4::aero_model_emissions::init_seasalt(data);
+    data.mpoly = input.get_array("mpoly_in")[0];
+    data.mprot = input.get_array("mprot_in")[0];
+    data.mlip = input.get_array("mlip_in")[0];
+
     mam4::aero_model_emissions::calc_org_matter_seasalt(
-        mpoly_in, mprot_in, mlip_in, data, mass_frac_bub_section, om_ssa);
+        data, mass_frac_bub_section, om_ssa);
 
     std::vector<Real> mfb_out;
     for (int i = 0; i < salt_nsection; ++i) {

--- a/src/validation/aero_emissions/dust_emis.cpp
+++ b/src/validation/aero_emissions/dust_emis.cpp
@@ -36,7 +36,6 @@ void dust_emis(Ensemble *ensemble) {
       }
     }
 
-    const int salt_nsection = mam4::aero_model_emissions::salt_nsection;
     const int dust_nflux_in = mam4::aero_model_emissions::dust_nflux_in;
     const int dust_nbin = mam4::aero_model_emissions::dust_nbin;
     int dust_indices[4];
@@ -51,7 +50,8 @@ void dust_emis(Ensemble *ensemble) {
     const auto dust_dmt_vwr_ = input.get_array("dust_dmt_vwr");
     Real soil_erodibility = input.get_array("soil_erodibility")[0];
 
-    Real cflux[salt_nsection] = {0.0};
+    constexpr int pcnst = mam4::pcnst;
+    Real cflux[pcnst] = {0.0};
 
     Real dust_flux_in[dust_nflux_in];
     for (int i = 0; i < dust_nflux_in; ++i) {
@@ -68,18 +68,18 @@ void dust_emis(Ensemble *ensemble) {
 
     std::vector<Real> cflux_out;
     // NOTE: the only entries that are changed are (c++ indexing):
-    //       10, 19, 13, 26
+    //       19, 28, 22, 35
     // i.e.,
     // cflux[dust_indices[{0, 1}]]
-    //      == cflux[10, 19]
+    //      == cflux[19, 28]
     // AND:
     // cflux[dust_indices[{0, 1} + dust_nbin]]
     //      == cflux[dust_indices[{0, 1} + 2]]
-    //      == cflux[13, 26]
-    cflux_out.push_back(cflux[10]);
+    //      == cflux[22, 35]
     cflux_out.push_back(cflux[19]);
-    cflux_out.push_back(cflux[13]);
-    cflux_out.push_back(cflux[26]);
+    cflux_out.push_back(cflux[28]);
+    cflux_out.push_back(cflux[22]);
+    cflux_out.push_back(cflux[35]);
 
     output.set("cflx", cflux_out);
     output.set("soil_erod", soil_erodibility);

--- a/src/validation/aero_emissions/marine_organic_massflx_calc.cpp
+++ b/src/validation/aero_emissions/marine_organic_massflx_calc.cpp
@@ -52,7 +52,8 @@ void marine_organic_massflx_calc(Ensemble *ensemble) {
         input.get_array("mass_frac_bub_section");
     const auto emit_this_mode_ = input.get_array("emit_this_mode");
 
-    Real cflux[salt_nsection];
+    constexpr int pcnst = mam4::pcnst;
+    Real cflux[pcnst] = {0.0};
 
     Real fi[salt_nsection];
     Real om_seasalt[salt_nsection];
@@ -83,14 +84,14 @@ void marine_organic_massflx_calc(Ensemble *ensemble) {
 
     std::vector<Real> cflux_out;
 
-    // NOTE: the only entries that are changed are (c++ indexing): 12, 17, 29
+    // NOTE: the only entries that are changed are (c++ indexing): 21, 26, 38
     // i.e.,
     // cflux[seasalt_indices[nsalt + ispec]]
     //      == cflux[seasalt_indices[3 + {0, 1, 2}]]
-    //      == cflux[12, 17, 29]
-    cflux_out.push_back(cflux[12]);
-    cflux_out.push_back(cflux[17]);
-    cflux_out.push_back(cflux[29]);
+    //      == cflux[21, 26, 38]
+    cflux_out.push_back(cflux[21]);
+    cflux_out.push_back(cflux[26]);
+    cflux_out.push_back(cflux[38]);
 
     output.set("cflx", cflux_out);
   });

--- a/src/validation/aero_emissions/marine_organic_numflx_calc.cpp
+++ b/src/validation/aero_emissions/marine_organic_numflx_calc.cpp
@@ -53,11 +53,11 @@ void marine_organic_numflx_calc(Ensemble *ensemble) {
     Real om_seasalt[salt_nsection];
     bool emit_this_mode[organic_num_modes];
 
-    // this test depends on the initial value of the entries that get calculated
-    // thus, we have to pick out the initial values from the fortran data
-    Real cflux[salt_nsection] = {0.0};
-    cflux[13] = cflux_[22];
-    cflux[18] = cflux_[27];
+    constexpr int pcnst = mam4::pcnst;
+    Real cflux[pcnst];
+    for (int i = 0; i < pcnst; ++i) {
+      cflux[i] = cflux_[i];
+    }
 
     for (int i = 0; i < salt_nsection; ++i) {
       fi[i] = fi_[i];
@@ -75,18 +75,9 @@ void marine_organic_numflx_calc(Ensemble *ensemble) {
         cflux);
 
     std::vector<Real> cflux_out;
-
-    // NOTE: the only entries that are changed are (c++ indexing): 13, 18
-    // i.e.,
-    // cflux[num_mode_idx];
-    //    Where:
-    //      num_mode_idx = seasalt_indices[nsalt + nsalt_om + om_num_idx],
-    //      om_num_idx = organic_num_idx[{0, 1}] == {0, 1}
-    //      om_num_idx = organic_num_idx[3 + 3 + {0, 1}]
-    //      == cflux[seasalt_indices[{6, 7}]]
-    //      == cflux[13, 18]
-    cflux_out.push_back(cflux[13]);
-    cflux_out.push_back(cflux[18]);
+    for (int i = 0; i < pcnst; ++i) {
+      cflux_out.push_back(cflux[i]);
+    }
 
     output.set("cflx", cflux_out);
   });

--- a/src/validation/aero_emissions/seasalt_emis.cpp
+++ b/src/validation/aero_emissions/seasalt_emis.cpp
@@ -34,7 +34,8 @@ void seasalt_emis(Ensemble *ensemble) {
     const Real ocean_frac = input.get_array("ocnfrc")[0];
     const Real emis_scalefactor = input.get_array("emis_scale")[0];
 
-    Real cflux[salt_nsection] = {0.0};
+    constexpr int pcnst = mam4::pcnst;
+    Real cflux[pcnst] = {0.0};
 
     Real fi[salt_nsection];
     for (int i = 0; i < salt_nsection; ++i) {
@@ -48,15 +49,15 @@ void seasalt_emis(Ensemble *ensemble) {
 
     std::vector<Real> cflux_out;
     // NOTE: the only entries that are changed are (c++ indexing):
-    //       11, 16, 20, 13, 18, 26
+    //       20, 25, 29, 22, 27, 35
     // see seasalt_emisflx_calc_numflx.cpp and seasalt_emisflx_calc_massflx.cpp
     // to get a deeper explanation on this
-    cflux_out.push_back(cflux[11]);
-    cflux_out.push_back(cflux[16]);
     cflux_out.push_back(cflux[20]);
-    cflux_out.push_back(cflux[13]);
-    cflux_out.push_back(cflux[18]);
-    cflux_out.push_back(cflux[26]);
+    cflux_out.push_back(cflux[25]);
+    cflux_out.push_back(cflux[29]);
+    cflux_out.push_back(cflux[22]);
+    cflux_out.push_back(cflux[27]);
+    cflux_out.push_back(cflux[35]);
 
     output.set("cflx", cflux_out);
   });

--- a/src/validation/aero_emissions/seasalt_emisflx_calc_massflx.cpp
+++ b/src/validation/aero_emissions/seasalt_emisflx_calc_massflx.cpp
@@ -46,7 +46,8 @@ void seasalt_emisflx_calc_massflx(Ensemble *ensemble) {
     const Real ocean_frac = input.get_array("ocnfrc")[0];
     const Real emis_scalefactor = input.get_array("emis_scale")[0];
 
-    Real cflux[salt_nsection] = {0.0};
+    constexpr int pcnst = mam4::pcnst;
+    Real cflux[pcnst] = {0.0};
 
     Real fi[salt_nsection];
     for (int i = 0; i < salt_nsection; ++i) {
@@ -62,14 +63,14 @@ void seasalt_emisflx_calc_massflx(Ensemble *ensemble) {
         fi, ocean_frac, emis_scalefactor, flux_type, data, cflux);
 
     std::vector<Real> cflux_out;
-    // NOTE: the only entries that are changed are (c++ indexing): 11, 16, 20
+    // NOTE: the only entries that are changed are (c++ indexing): 20, 27, 29
     // i.e.,
     // cflux[seasalt_indices[num_idx_append + ispec]]
     //      == cflux[seasalt_indices[0 + {0, 1, 2}]]
-    //      == cflux[11, 16, 20]
-    cflux_out.push_back(cflux[11]);
-    cflux_out.push_back(cflux[16]);
+    //      == cflux[20, 27, 29]
     cflux_out.push_back(cflux[20]);
+    cflux_out.push_back(cflux[27]);
+    cflux_out.push_back(cflux[29]);
 
     output.set("cflx", cflux_out);
   });

--- a/src/validation/aero_emissions/seasalt_emisflx_calc_numflx.cpp
+++ b/src/validation/aero_emissions/seasalt_emisflx_calc_numflx.cpp
@@ -46,7 +46,8 @@ void seasalt_emisflx_calc_numflx(Ensemble *ensemble) {
     const Real ocean_frac = input.get_array("ocnfrc")[0];
     const Real emis_scalefactor = input.get_array("emis_scale")[0];
 
-    Real cflux[salt_nsection] = {0.0};
+    constexpr int pcnst = mam4::pcnst;
+    Real cflux[pcnst] = {0.0};
 
     Real fi[salt_nsection];
     for (int i = 0; i < salt_nsection; ++i) {
@@ -62,14 +63,14 @@ void seasalt_emisflx_calc_numflx(Ensemble *ensemble) {
         fi, ocean_frac, emis_scalefactor, flux_type, data, cflux);
 
     std::vector<Real> cflux_out;
-    // NOTE: the only entries that are changed are (c++ indexing): 13, 18, 26
+    // NOTE: the only entries that are changed are (c++ indexing): 22, 27, 35
     // i.e.,
     // cflux[seasalt_indices[num_idx_append + ispec]]
     //      == cflux[seasalt_indices[6 + {0, 1, 2}]]
-    //      == cflux[13, 18, 26]
-    cflux_out.push_back(cflux[13]);
-    cflux_out.push_back(cflux[18]);
-    cflux_out.push_back(cflux[26]);
+    //      == cflux[22, 27, 35]
+    cflux_out.push_back(cflux[22]);
+    cflux_out.push_back(cflux[27]);
+    cflux_out.push_back(cflux[35]);
 
     output.set("cflx", cflux_out);
   });


### PR DESCRIPTION
I mistakenly pushed some updates to `mam_x_validation` that correspond to some working changes in the eamxx integration for `aero_model_emissions`. This adds the new changes to fix the failing tests on main.