### PR TITLE
Port refactored version of `mer07_veh02_nuc_mosaic_1box()` and add validation tests

### DIFF
--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -1240,11 +1240,11 @@ public:
 
     // This is assumed for our purposes, but throw an error message if
     // incorrect, for safety's sake
-    EKAT_ASSERT_MSG(
+    EKAT_KERNEL_ASSERT_MSG(
         sizeof(dp_lo_mode) / sizeof(Real) == nsize &&
             sizeof(dp_hi_mode) / sizeof(Real) == nsize && nsize == 1,
         "ERROR: mam4xx::Nucleation is only configured for "
-            << "extent(dp_lo_mode) == extent(dp_lo_mode) == nsize == 1");
+        "extent(dp_lo_mode) == extent(dp_lo_mode) == nsize == 1\n");
 
     Real rh_in;
 

--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -75,9 +75,9 @@ void pbl_nuc_wang2008(Real so4vol, Real pi, int pbl_nuc_wang2008_user_choice,
   // Calculate nucleation rate using incoming so4 concentration.
   //-------------------------------------------------------------
   Real tmp_ratenucl;
-  if (pbl_nuc_wang2008_user_choice == 1) {
+  if (pbl_nuc_wang2008_user_choice == 11) {
     tmp_ratenucl = wang2008::first_order_pbl_nucleation_rate(so4vol);
-  } else if (pbl_nuc_wang2008_user_choice == 2) {
+  } else if (pbl_nuc_wang2008_user_choice == 12) {
     tmp_ratenucl = wang2008::second_order_pbl_nucleation_rate(so4vol);
   } else {
     return;
@@ -477,7 +477,8 @@ void mer07_veh02_wang08_nuc_1box(
   qnh3_del = 0.0;
   dnclusterdt = 0.0;
 
-  if ((newnuc_method_flagaa != 1) && (newnuc_method_flagaa != 2))
+  if ((newnuc_method_flagaa != 1) && (newnuc_method_flagaa != 2) &&
+      (newnuc_method_flagaa != 11) && (newnuc_method_flagaa != 12))
     return;
 
   // make call to parameterization routine
@@ -518,7 +519,7 @@ void mer07_veh02_wang08_nuc_1box(
              haero::log(haero::max(1.0e-38, adjust_factor_bin_tern_ratenucl));
 
   // do boundary layer nuc
-  if ((newnuc_method_flagaa == 1) || (newnuc_method_flagaa == 2)) {
+  if ((newnuc_method_flagaa == 11) || (newnuc_method_flagaa == 12)) {
     // FIXME: BAD CONSTANT
     if (zm_in <= max(pblh_in, 100.0)) {
       Real so4vol_bb = so4vol_in;
@@ -1046,6 +1047,9 @@ public:
     KOKKOS_INLINE_FUNCTION
     Config()
         : dens_so4a_host(mam4_density_so4), mw_nh4a_host(mw_nh4a),
+          // FIXME: newnuc_method_user_choice and pbl_nuc_wang2008_user_choice
+          //        should likely be 11 or 12, to correspond to the values used
+          //        in modal_aero_newnuc.F90 (mam_refactor)
           mw_so4a_host(mw_so4a), newnuc_method_user_choice(2),
           pbl_nuc_wang2008_user_choice(1), adjust_factor_bin_tern_ratenucl(1.0),
           adjust_factor_pbl_ratenucl(1.0), accom_coef_h2so4(1.0),
@@ -1118,6 +1122,8 @@ public:
            progs.quantities_nonnegative(team);
   }
 
+  // FIXME: the compute_tendencies_() that this calls corresponds to the box
+  //        model version of mer07_veh02_wang08_nuc_1box()
   // compute_tendencies -- computes tendencies and updates diagnostics
   // NOTE: that both diags and tends are const below--this means their views
   // NOTE: are fixed, but the data in those views is allowed to vary.
@@ -1177,6 +1183,7 @@ public:
     });
   }
 
+  // FIXME: this calls the box model version of mer07_veh02_wang08_nuc_1box()
   // This function computes relevant tendencies at a single vertical level. It
   // was ported directly from the compute_tendencies subroutine in the
   // modal_aero_newnuc module from the MAM4 box model.
@@ -1297,6 +1304,7 @@ public:
       // are used below in the calculation of cluster "growth". I chose to keep
       // these variable names the same as in the old subroutine
       // mer07_veh02_nuc_mosaic_1box to facilitate comparison.
+      // FIXME: this is the box model version
       nucleation::mer07_veh02_wang08_nuc_1box(
           newnuc_method_user_choice, newnuc_method_actual,       // in, out
           pbl_nuc_wang2008_user_choice, pbl_nuc_wang2008_actual, // in, out

--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -265,6 +265,25 @@ void mer07_veh02_wang08_nuc_1box(int newnuc_method_user_choice,
   // if nitrate aerosol is considered in the aerosol population
   // and ammonia concentration is non-negligible
   //---------------------------------------------------------------
+  // FIXME: in modal_aero_newnuc.F90:283 we have:
+  //        if (so4vol_in >= 1.0e4_r8) then
+  // if ( (newnuc_method_flagaa /=  2) .and. &
+  //      (nh3ppt >= 0.1_r8) ) then
+  //     newnuc_method_flagaa2 = 1
+  // FIXME: this is the part that differs
+  // else
+  //     if (so4vol_in >= 1.0e4_r8) then
+  //        temp_bb = max( 230.15_r8, min( 305.15_r8, temp_in ) )
+  //        rh_bb = max( 1.0e-4_r8, min( 1.0_r8, rh_in ) )
+  //        so4vol_bb = max( 1.0e4_r8, min( 1.0e11_r8, so4vol_in ) )
+  //        call binary_nuc_vehk2002(   &
+  //           temp_bb, rh_bb, so4vol_bb,   &
+  //           ratenuclt, rateloge,   &
+  //           cnum_h2so4, cnum_tot, radius_cluster )
+  //     end if
+  //     cnum_nh3 = 0.0_r8
+  //     newnuc_method_flagaa2 = 2
+  // end if
   if ((newnuc_method_user_choice == 3) && (nh3ppt_in >= 0.1)) {
     if (so4vol_in >= 5.0e4) {
       temp_bb = max(235.0, min(295.0, temp_in));
@@ -317,6 +336,17 @@ void mer07_veh02_wang08_nuc_1box(int newnuc_method_user_choice,
     // ratenuclt is #/cm3/s; dnclusterdt is #/m3/s
     dnclusterdt = exp(rateloge) * 1.0e6;
   }
+  // NOTE: this is modal_aero_newnuc.F90:319
+  // FIXME: mer07_veh02_nuc_mosaic_1box() continues for ~200 more lines
+  //        (plus more for writing quantities out)
+  // Out variables that are changed after this point:
+    //  - isize_nuc (L342, 348)
+    //  - qnuma_del (L518)
+    //  - qso4a_del (L515)
+    //  - qnh4a_del (L516)
+    //  - qh2so4_del (L509, 511)
+    //  - qnh3_del (L510, 512)
+    //  - dens_nh4so4a (L394)
 }
 
 KOKKOS_INLINE_FUNCTION

--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -267,25 +267,6 @@ void mer07_veh02_wang08_nuc_1box(int newnuc_method_user_choice,
   // if nitrate aerosol is considered in the aerosol population
   // and ammonia concentration is non-negligible
   //---------------------------------------------------------------
-  // FIXME: in modal_aero_newnuc.F90:283 we have:
-  //        if (so4vol_in >= 1.0e4_r8) then
-  // if ( (newnuc_method_flagaa /=  2) .and. &
-  //      (nh3ppt >= 0.1_r8) ) then
-  //     newnuc_method_flagaa2 = 1
-  // FIXME: this is the part that differs
-  // else
-  //     if (so4vol_in >= 1.0e4_r8) then
-  //        temp_bb = max( 230.15_r8, min( 305.15_r8, temp_in ) )
-  //        rh_bb = max( 1.0e-4_r8, min( 1.0_r8, rh_in ) )
-  //        so4vol_bb = max( 1.0e4_r8, min( 1.0e11_r8, so4vol_in ) )
-  //        call binary_nuc_vehk2002(   &
-  //           temp_bb, rh_bb, so4vol_bb,   &
-  //           ratenuclt, rateloge,   &
-  //           cnum_h2so4, cnum_tot, radius_cluster )
-  //     end if
-  //     cnum_nh3 = 0.0_r8
-  //     newnuc_method_flagaa2 = 2
-  // end if
   if ((newnuc_method_user_choice == 3) && (nh3ppt_in >= 0.1)) {
     if (so4vol_in >= 5.0e4) {
       temp_bb = max(235.0, min(295.0, temp_in));

--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -230,6 +230,8 @@ void ternary_nuc_merik2007(Real t, Real rh, Real c2, Real c3, Real &j_log,
 //   Aerosol indirect forcing in a global model with particle nucleation,
 //   Atmos. Chem. Phys. Discuss., 8, 13943-13998
 //   Atmos. Chem. Phys.  9, 239-260, 2009
+
+// NOTE: This is the version from the box model repo
 KOKKOS_INLINE_FUNCTION
 void mer07_veh02_wang08_nuc_1box(int newnuc_method_user_choice,
                                  int &newnuc_method_actual,        // in, out
@@ -336,18 +338,7 @@ void mer07_veh02_wang08_nuc_1box(int newnuc_method_user_choice,
     // ratenuclt is #/cm3/s; dnclusterdt is #/m3/s
     dnclusterdt = exp(rateloge) * 1.0e6;
   }
-  // NOTE: this is modal_aero_newnuc.F90:319
-  // FIXME: mer07_veh02_nuc_mosaic_1box() continues for ~200 more lines
-  //        (plus more for writing quantities out)
-  // Out variables that are changed after this point:
-  //  - isize_nuc (L342, 348)
-  //  - qnuma_del (L518)
-  //  - qso4a_del (L515)
-  //  - qnh4a_del (L516)
-  //  - qh2so4_del (L509, 511)
-  //  - qnh3_del (L510, 512)
-  //  - dens_nh4so4a (L394)
-}
+} // end mer07_veh02_wang08_nuc_1box()
 
 //-----------------------------------------------------------------------------
 // Calculates new particle production from homogeneous nucleation
@@ -372,24 +363,26 @@ void mer07_veh02_wang08_nuc_1box(int newnuc_method_user_choice,
 //   Aerosol indirect forcing in a global model with particle nucleation,
 //   Atmos. Chem. Phys. Discuss., 8, 13943-13998
 //   Atmos. Chem. Phys.  9, 239-260, 2009
+
+// This is the version from the E3SM mam refactor repo
 KOKKOS_INLINE_FUNCTION
 void mer07_veh02_wang08_nuc_1box(
     // in
-    int newnuc_method_flagaa, Real dtnuc, Real temp_in, Real rh_in,
-    Real press_in, Real zm_in, Real pblh_in, Real qh2so4_cur, Real qh2so4_avg,
-    Real qnh3_cur, Real h2so4_uptkrate, Real mw_so4a_host, int nsize,
-    int maxd_asize,
+    const int newnuc_method_flagaa, const Real dtnuc, const Real temp_in,
+    const Real rh_in, const Real press_in, const Real zm_in, const Real pblh_in,
+    const Real qh2so4_cur, const Real qh2so4_avg, const Real qnh3_cur,
+    const Real h2so4_uptkrate, const Real mw_so4a_host, const int nsize,
     // NOTE: in fortran dplom_sect is given/accessed as an array with extent
     //       maxd_asize defined as "dimension for dplom_sect, ..."
     //       however, as provided in validation data, it is a scalar
-    Real dplom_sect,
-    Real dphim_sect, int ldiagaa,
+    // const int maxd_asize,
+    const Real dplom_sect, const Real dphim_sect, const int ldiagaa,
     // in fortran provided by mo_constants
-    Real rgas, Real avogad,
+    const Real rgas, const Real avogad,
     // in fortran provided by physconst
-    Real mw_nh4a, Real mw_so4a,
+    const Real mw_nh4a, const Real mw_so4a,
     // in fortran provided by mo_constants
-    Real pi,
+    const Real pi,
     //  out
     int &isize_nuc, Real &qnuma_del, Real &qso4a_del, Real &qnh4a_del,
     Real &qh2so4_del, Real &qnh3_del, Real &dens_nh4so4a, Real &dnclusterdt) {
@@ -399,7 +392,7 @@ void mer07_veh02_wang08_nuc_1box(
   // kk2002 "cs_prime" parameter (1/m2)
   Real cs_prime_kk;
   // kk2002 "cs" parameter (1/s)
-  Real cs_kk;
+  // Real cs_kk;
   // "grown" single-particle dry density (kg/m3)
   Real dens_part;
   // kk2002 final/initial new particle wet diameter (nm)
@@ -408,14 +401,14 @@ void mer07_veh02_wang08_nuc_1box(
   Real dpdry_clus;
   // "grown" single-particle dry diameter (m)
   Real dpdry_part;
-  // Real tmpa
-  Real tmpb, tmpc, tmpe, tmpq;
-  Real tmpa1, tmpb1;
+  // Real tmpa, tmpc, tmpq
+  Real tmpb, tmpe;
+  // Real tmpb1;
   Real tmp_m1, tmp_m2, tmp_m3, tmp_n1, tmp_n2, tmp_n3;
   // h2so4 vapor molecular speed (m/s)
   Real tmp_spd;
   Real factor_kk;
-  Real fogas, foso4a, fonh4a, fonuma;
+  // Real fogas, foso4a, fonh4a, fonuma;
   // reduction factor applied to nucleation rate
   Real freduce;
   // due to limited availability of h2so4 & nh3 gases
@@ -432,7 +425,7 @@ void mer07_veh02_wang08_nuc_1box(
   Real molenh4a_per_moleso4a;
   // actual and bounded nh3 (ppt)
   // Real nh3ppt;
-  Real nh3ppt_bb;
+  // Real nh3ppt_bb;
   // kk2002 "nu" parameter (nm)
   Real nu_kk;
   // max production of aerosol nh4 over dtnuc (mol/mol-air)
@@ -471,10 +464,9 @@ void mer07_veh02_wang08_nuc_1box(
   Real adjust_factor_bin_tern_ratenucl = 1.0;
   Real adjust_factor_pbl_ratenucl = 1.0;
 
-
-  const int icase = 0;
-  const int icase_reldiffmax = 0;
-  int lun;
+  // const int icase = 0;
+  // const int icase_reldiffmax = 0;
+  // int lun;
   int newnuc_method_flagaa2;
 
   // FIXME: BAD CONSTANTS
@@ -501,7 +493,7 @@ void mer07_veh02_wang08_nuc_1box(
   Real mw_ammsulf = 132.0;
   Real mw_ammbisulf = 114.0;
   Real mw_sulfacid = 96.0;
-  Real reldiffmax = 0.0;
+  // Real reldiffmax = 0.0;
 
   isize_nuc = 1;
   qnuma_del = 0.0;
@@ -545,7 +537,8 @@ void mer07_veh02_wang08_nuc_1box(
   if ((newnuc_method_flagaa == 1) || (newnuc_method_flagaa == 2)) {
     if (zm_in <= max(pblh_in, 100.0)) {
       so4vol_bb = so4vol_in;
-      // void pbl_nuc_wang2008(Real so4vol, Real pi, int pbl_nuc_wang2008_user_choice,
+      // void pbl_nuc_wang2008(Real so4vol, Real pi, int
+      // pbl_nuc_wang2008_user_choice,
       //                 Real adjust_factor_pbl_ratenucl,
       //                 int &pbl_nuc_wang2008_actual, Real &ratenucl,
       //                 Real &rateloge, Real &cnum_tot, Real &cnum_h2so4,
@@ -639,7 +632,6 @@ void mer07_veh02_wang08_nuc_1box(
 
   tmp_m1 = tmp_n1 * mw_ammsulf;
   tmp_m2 = tmp_n2 * mw_ammbisulf;
-
   tmp_m3 = tmp_n3 * mw_sulfacid;
   dens_part = (tmp_m1 + tmp_m2 + tmp_m3) /
               ((tmp_m1 / dens_ammsulf) + (tmp_m2 / dens_ammbisulf) +
@@ -703,18 +695,18 @@ void mer07_veh02_wang08_nuc_1box(
     // tmpa = -d(ln(h2so4))/dt by conden to particles   (1/h units)
     // FIXME: BAD CONSTANT
     tmpa = h2so4_uptkrate * 3600.0;
-    tmpa1 = tmpa;
+    // Real tmpa1 = tmpa;
     tmpa = haero::max(tmpa, 0.0);
     // FIXME: BAD CONSTANT
     // tmpb = h2so4 gas diffusivity (m2/s, then m2/h)
     tmpb = 6.7037e-6 * haero::pow(temp_in, 0.75) / cair;
     // m2/s
-    tmpb1 = tmpb;
+    // Real tmpb1 = tmpb;
     // m2/h;
     // FIXME: BAD CONSTANT
     tmpb = tmpb * 3600.0;
     cs_prime_kk = tmpa / (4.0 * pi * tmpb * accom_coef_h2so4);
-    cs_kk = cs_prime_kk * 4.0 * pi * tmpb1;
+    // Real cs_kk = cs_prime_kk * 4.0 * pi * tmpb1;
 
     // "nu" parameter (nm) -- kk2002 eqn 11
     nu_kk = gamma_kk * cs_prime_kk / gr_kk;
@@ -787,7 +779,8 @@ void mer07_veh02_wang08_nuc_1box(
   tmpb = tmpa * freduce;
   // relative difference from qnuma_del
   // FIXME: BAD CONSTANT
-  tmpc = (tmpb - qnuma_del) / haero::max(tmpb, haero::max(qnuma_del, 1.0e-35));
+  // Real tmpc = (tmpb - qnuma_del) / haero::max(tmpb,
+  // haero::max(qnuma_del, 1.0e-35));
 
   // diagnostic output to fort.41
   // (this should be commented-out or deleted in the wrf-chem version)
@@ -798,7 +791,6 @@ void mer07_veh02_wang08_nuc_1box(
   //       icase = icase + 1 if (abs(tmpc).gt.abs(reldiffmax)) then reldiffmax =
   //                   tmpc icase_reldiffmax = icase end if
   //       //       do lun = 41, 51, 10
-  //       // FIXME:
   //       do lun = 6,
   //       6
   //           //          write(lun,'(/)')
@@ -895,7 +887,7 @@ void mer07_veh02_wang08_nuc_1box(
   // #include
   // "../yaml/modal_aero_newnuc/f90_yaml/mer07_veh02_nuc_mosaic_1box_end_yml.f90"
   //         return
-}
+} // end mer07_veh02_wang08_nuc_1box()
 
 KOKKOS_INLINE_FUNCTION
 void newnuc_cluster_growth(Real ratenuclt_bb, Real cnum_h2so4, Real cnum_nh3,

--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -387,6 +387,10 @@ void mer07_veh02_wang08_nuc_1box(
     int &isize_nuc, Real &qnuma_del, Real &qso4a_del, Real &qnh4a_del,
     Real &qh2so4_del, Real &qnh3_del, Real &dens_nh4so4a, Real &dnclusterdt) {
 
+  // NOTE: there are a lot of variables that end up unused since we ignore all
+  //       the writing to file at the bottom. for now, I've preserved all of
+  //       the unused bits as comments *just in case*
+
   // dry-air molar density (mol/m3)
   // Real cair;
   // kk2002 "cs_prime" parameter (1/m2)
@@ -537,12 +541,6 @@ void mer07_veh02_wang08_nuc_1box(
   if ((newnuc_method_flagaa == 1) || (newnuc_method_flagaa == 2)) {
     if (zm_in <= max(pblh_in, 100.0)) {
       so4vol_bb = so4vol_in;
-      // void pbl_nuc_wang2008(Real so4vol, Real pi, int
-      // pbl_nuc_wang2008_user_choice,
-      //                 Real adjust_factor_pbl_ratenucl,
-      //                 int &pbl_nuc_wang2008_actual, Real &ratenucl,
-      //                 Real &rateloge, Real &cnum_tot, Real &cnum_h2so4,
-      //                 Real &cnum_nh3, Real &radius_cluster_nm)
       pbl_nuc_wang2008(so4vol_bb, pi, newnuc_method_flagaa,
                        adjust_factor_pbl_ratenucl,
                        //  out

--- a/src/mam4xx/nucleation.hpp
+++ b/src/mam4xx/nucleation.hpp
@@ -369,96 +369,86 @@ void mer07_veh02_wang08_nuc_1box(
     Real &qh2so4_del, Real &qnh3_del, Real &dens_nh4so4a, Real &dnclusterdt) {
 
   // NOTE: there are a lot of variables that end up unused since we ignore all
-  //       the writing to file at the bottom. for now, I've preserved all of
+  //       the writing to file at the bottom. for now, I've preserved some of
   //       the unused bits as comments *just in case*
+  // NOTE: also, rather than declaring uninitialized values up here, I've done
+  //       so when first used but preserve them here for reference
 
-  // dry-air molar density (mol/m3)
+  // dry-air molar density (mol/m3)--(unused)
   // Real cair;
   // kk2002 "cs_prime" parameter (1/m2)
-  Real cs_prime_kk;
-  // kk2002 "cs" parameter (1/s)
+  // Real cs_prime_kk;
+  // kk2002 "cs" parameter (1/s)--(unused)
   // Real cs_kk;
   // "grown" single-particle dry density (kg/m3)
-  Real dens_part;
+  // Real dens_part;
   // kk2002 final/initial new particle wet diameter (nm)
-  Real dfin_kk, dnuc_kk;
+  // Real dfin_kk, dnuc_kk;
   // critical cluster diameter (m)
-  Real dpdry_clus;
+  // Real dpdry_clus;
   // "grown" single-particle dry diameter (m)
-  Real dpdry_part;
-  // Real tmpa, tmpc, tmpq
-  Real tmpb, tmpe;
-  // Real tmpb1;
-  Real tmp_m1, tmp_m2, tmp_m3, tmp_n1, tmp_n2, tmp_n3;
+  // Real dpdry_part;
   // h2so4 vapor molecular speed (m/s)
-  Real tmp_spd;
-  Real factor_kk;
-  // Real fogas, foso4a, fonh4a, fonuma;
+  // Real tmp_spd;
   // reduction factor applied to nucleation rate
-  Real freduce;
+  // Real freduce;
   // due to limited availability of h2so4 & nh3 gases
-  Real freducea, freduceb;
+  // Real freducea, freduceb;
   // kk2002 "gamma" parameter (nm2*m2/h)
-  Real gamma_kk;
+  // Real gamma_kk;
   // kk2002 "gr" parameter (nm/h)
-  Real gr_kk;
+  // Real gr_kk;
   // (kg dry aerosol)/(mol aerosol so4)
-  Real kgaero_per_moleso4a;
+  // Real kgaero_per_moleso4a;
   // "grown" single-particle dry mass (kg)
-  Real mass_part;
+  // Real mass_part;
   // (mol aerosol nh4)/(mol aerosol so4)
-  Real molenh4a_per_moleso4a;
-  // actual and bounded nh3 (ppt)
-  // Real nh3ppt;
-  // Real nh3ppt_bb;
+  // Real molenh4a_per_moleso4a;
+  // actual and bounded nh3 (ppt)--(unused)
+  // Real nh3ppt, nh3ppt_bb;
   // kk2002 "nu" parameter (nm)
-  Real nu_kk;
+  // Real nu_kk;
   // max production of aerosol nh4 over dtnuc (mol/mol-air)
-  Real qmolnh4a_del_max;
+  // Real qmolnh4a_del_max;
   // max production of aerosol so4 over dtnuc (mol/mol-air)
-  Real qmolso4a_del_max;
+  // Real qmolso4a_del_max;
   // nucleation rate (#/m3/s)
-  Real ratenuclt_bb;
+  // Real ratenuclt_bb;
   // nucleation rate after kk2002 adjustment (#/m3/s)
-  Real ratenuclt_kk;
+  // Real ratenuclt_kk;
   // bounded value of rh_in
-  Real rh_bb;
-  // concentration of h2so4 for nucl. calc., molecules cm-3
+  // Real rh_bb;
+  // concentration of h2so4 for nucl. calc., molecules cm-3--(unused)
   // Real so4vol_in;
   // bounded value of so4vol_in
-  Real so4vol_bb;
+  // Real so4vol_bb;
   // bounded value of temp_in
-  Real temp_bb;
+  // Real temp_bb;
   // critical-cluster dry volume (m3)
-  Real voldry_clus;
+  // Real voldry_clus;
   // "grown" single-particle dry volume (m3)
-  Real voldry_part;
+  // Real voldry_part;
   // grown particle (wet-volume)/(dry-volume)
-  Real wetvol_dryvol;
+  // Real wetvol_dryvol;
   // grown particle (dry-volume-from-so4)/(wet-volume)
-  Real wet_volfrac_so4a;
+  // Real wet_volfrac_so4a;
   // number of h2so4 molecules in the critical nucleus
-  Real cnum_h2so4;
+  // Real cnum_h2so4;
   // total number of molecules in the critical nucleus
-  Real cnum_tot;
+  // Real cnum_tot;
   // the radius of cluster (nm)
-  Real radius_cluster;
+  // Real radius_cluster;
   // number of nh3 molecules in the critical nucleus
-  Real cnum_nh3;
+  // Real cnum_nh3;
   // applied to binary/ternary nucleation rate
-  Real adjust_factor_bin_tern_ratenucl = 1.0;
-  Real adjust_factor_pbl_ratenucl = 1.0;
-
-  // const int icase = 0;
-  // const int icase_reldiffmax = 0;
-  // int lun;
-  int newnuc_method_flagaa2;
+  constexpr Real adjust_factor_bin_tern_ratenucl = 1.0;
+  constexpr Real adjust_factor_pbl_ratenucl = 1.0;
 
   // FIXME: BAD CONSTANTS
-  Real onethird = 1.0 / 3.0;
+  constexpr Real onethird = 1.0 / 3.0;
   // accomodation coef for h2so4 conden
   // FIXME: BAD CONSTANT
-  Real accom_coef_h2so4 = 0.65;
+  constexpr Real accom_coef_h2so4 = 0.65;
 
   // dry densities (kg/m3) molecular weights of aerosol
   // ammsulf, ammbisulf, and sulfacid (from mosaic  dens_electrolyte values)
@@ -467,18 +457,17 @@ void mer07_veh02_wang08_nuc_1box(
   //       Real dens_sulfacid  = 1.841e3
   // use following to match cam3 modal_aero densities
   // FIXME: BAD CONSTANTS
-  Real dens_ammsulf = 1770.0;
-  Real dens_ammbisulf = 1770.0;
-  Real dens_sulfacid = 1770.0;
+  constexpr Real dens_ammsulf = 1770.0;
+  constexpr Real dens_ammbisulf = 1770.0;
+  constexpr Real dens_sulfacid = 1770.0;
 
   // molecular weights (g/mol) of aerosol ammsulf, ammbisulf, and sulfacid
   //    for ammbisulf and sulfacid, use 114 & 96 here rather than 115 & 98
   //    because we don't keep track of aerosol hion mass
   // FIXME: BAD CONSTANTS
-  Real mw_ammsulf = 132.0;
-  Real mw_ammbisulf = 114.0;
-  Real mw_sulfacid = 96.0;
-  // Real reldiffmax = 0.0;
+  constexpr Real mw_ammsulf = 132.0;
+  constexpr Real mw_ammbisulf = 114.0;
+  constexpr Real mw_sulfacid = 96.0;
 
   isize_nuc = 1;
   qnuma_del = 0.0;
@@ -500,14 +489,23 @@ void mer07_veh02_wang08_nuc_1box(
   Real ratenuclt = 1.0e-38;
   Real rateloge = haero::log(ratenuclt);
 
+  Real cnum_h2so4 = 0.0;
+  Real cnum_tot = 0.0;
+  Real radius_cluster = 0.0;
+  // NOTE: This was originally uninitialized at the top of the fortran
+  // subroutine, but that seems weird, so initializing it here
+  // outside of the conditional
+  Real cnum_nh3 = 0.0;
+  // initialize to invalid value
+  int newnuc_method_flagaa2 = -1;
   if ((newnuc_method_flagaa != 2) && (nh3ppt >= 0.1)) {
     newnuc_method_flagaa2 = 1;
   } else {
     // make call to vehkamaki binary parameterization routine
     if (so4vol_in >= 1.0e4) {
-      temp_bb = haero::max(230.15, haero::min(305.15, temp_in));
-      rh_bb = haero::max(1.0e-4, haero::min(1.0, rh_in));
-      so4vol_bb = haero::max(1.0e4, haero::min(1.0e11, so4vol_in));
+      Real temp_bb = haero::max(230.15, haero::min(305.15, temp_in));
+      Real rh_bb = haero::max(1.0e-4, haero::min(1.0, rh_in));
+      Real so4vol_bb = haero::max(1.0e4, haero::min(1.0e11, so4vol_in));
       binary_nuc_vehk2002(temp_bb, rh_bb, so4vol_bb, ratenuclt, rateloge,
                           cnum_h2so4, cnum_tot, radius_cluster);
     }
@@ -515,13 +513,15 @@ void mer07_veh02_wang08_nuc_1box(
     newnuc_method_flagaa2 = 2;
   }
 
+  // FIXME: BAD CONSTANT
   rateloge = rateloge +
              haero::log(haero::max(1.0e-38, adjust_factor_bin_tern_ratenucl));
 
   // do boundary layer nuc
   if ((newnuc_method_flagaa == 1) || (newnuc_method_flagaa == 2)) {
+    // FIXME: BAD CONSTANT
     if (zm_in <= max(pblh_in, 100.0)) {
-      so4vol_bb = so4vol_in;
+      Real so4vol_bb = so4vol_in;
       pbl_nuc_wang2008(so4vol_bb, pi, newnuc_method_flagaa,
                        adjust_factor_pbl_ratenucl,
                        //  out
@@ -536,30 +536,30 @@ void mer07_veh02_wang08_nuc_1box(
   if (rateloge <= -13.82)
     return;
   // REFACTOR NOTE:  if exit above, no yaml / python data written out
-  //       if (ratenuclt .le. 1.0e-6) return
 
   ratenuclt = haero::exp(rateloge);
   // ratenuclt_bb is #/m3/s; ratenuclt is #/cm3/s;
-  ratenuclt_bb = ratenuclt * 1.0e6;
+  Real ratenuclt_bb = ratenuclt * 1.0e6;
   dnclusterdt = ratenuclt_bb;
 
   // wet/dry volume ratio - use simple kohler approx for
   // ammsulf/ammbisulf
   // FIXME: BAD CONSTANTS
   Real tmpa = haero::max(0.10, haero::min(0.95, rh_in));
-  wetvol_dryvol = 1.0 - 0.56 / haero::log(tmpa);
+  Real wetvol_dryvol = 1.0 - 0.56 / haero::log(tmpa);
 
   // determine size bin into which the new particles go
   // (probably it will always be bin #1, but ...)
-  voldry_clus = (haero::max(cnum_h2so4, 1.0) * mw_so4a + cnum_nh3 * mw_nh4a) /
-                (1.0e3 * dens_sulfacid * avogad);
+  Real voldry_clus =
+      (haero::max(cnum_h2so4, 1.0) * mw_so4a + cnum_nh3 * mw_nh4a) /
+      (1.0e3 * dens_sulfacid * avogad);
   // correction when host code sulfate is really ammonium bisulfate/sulfate
   voldry_clus = voldry_clus * (mw_so4a_host / mw_so4a);
-  dpdry_clus = haero::pow(voldry_clus * 6.0 / pi, onethird);
+  Real dpdry_clus = haero::pow(voldry_clus * 6.0 / pi, onethird);
 
   int igrow;
   isize_nuc = 1;
-  dpdry_part = dplom_sect;
+  Real dpdry_part = dplom_sect;
   if (dpdry_clus <= dplom_sect) {
     // need to clusters to larger size
     igrow = 1;
@@ -579,7 +579,7 @@ void mer07_veh02_wang08_nuc_1box(
       }
     }
   }
-  voldry_part = (pi / 6.0) * haero::pow(dpdry_part, 3);
+  Real voldry_part = (pi / 6.0) * haero::pow(dpdry_part, 3);
 
   // determine composition and density of the "grown particles"
   // the grown particles are assumed to be liquid
@@ -587,7 +587,9 @@ void mer07_veh02_wang08_nuc_1box(
   //    so any (nh4/so4) molar ratio between 0 and 2 is allowed
   // assume that the grown particles will have
   //    (nh4/so4 molar ratio) = min( 2, (nh3/h2so4 gas molar ratio) )
-  //
+  Real tmp_n1 = 0.0;
+  Real tmp_n2 = 0.0;
+  Real tmp_n3 = 0.0;
   if (igrow <= 0) {
     // no "growing" so pure sulfuric acid
     tmp_n1 = 0.0;
@@ -609,30 +611,29 @@ void mer07_veh02_wang08_nuc_1box(
     tmp_n3 = 1.0 - tmp_n2;
   }
 
-  tmp_m1 = tmp_n1 * mw_ammsulf;
-  tmp_m2 = tmp_n2 * mw_ammbisulf;
-  tmp_m3 = tmp_n3 * mw_sulfacid;
-  dens_part = (tmp_m1 + tmp_m2 + tmp_m3) /
-              ((tmp_m1 / dens_ammsulf) + (tmp_m2 / dens_ammbisulf) +
-               (tmp_m3 / dens_sulfacid));
+  Real tmp_m1 = tmp_n1 * mw_ammsulf;
+  Real tmp_m2 = tmp_n2 * mw_ammbisulf;
+  Real tmp_m3 = tmp_n3 * mw_sulfacid;
+  Real dens_part = (tmp_m1 + tmp_m2 + tmp_m3) /
+                   ((tmp_m1 / dens_ammsulf) + (tmp_m2 / dens_ammbisulf) +
+                    (tmp_m3 / dens_sulfacid));
   dens_nh4so4a = dens_part;
-  mass_part = voldry_part * dens_part;
+  Real mass_part = voldry_part * dens_part;
   // (mol aerosol nh4)/(mol aerosol so4);
-  molenh4a_per_moleso4a = 2.0 * tmp_n1 + tmp_n2;
+  Real molenh4a_per_moleso4a = 2.0 * tmp_n1 + tmp_n2;
   // (kg dry aerosol)/(mol aerosol so4);
   // FIXME: BAD CONSTANT
-  kgaero_per_moleso4a = 1.0e-3 * (tmp_m1 + tmp_m2 + tmp_m3);
+  Real kgaero_per_moleso4a = 1.0e-3 * (tmp_m1 + tmp_m2 + tmp_m3);
   // correction when host code sulfate is really ammonium bisulfate/sulfate;
   kgaero_per_moleso4a = kgaero_per_moleso4a * (mw_so4a_host / mw_so4a);
 
   // fraction of wet volume due to so4a
   // FIXME: BAD CONSTANTS
-  tmpb = 1.0 + molenh4a_per_moleso4a * 17.0 / 98.0;
-  wet_volfrac_so4a = 1.0 / (wetvol_dryvol * tmpb);
+  Real tmpb = 1.0 + molenh4a_per_moleso4a * 17.0 / 98.0;
+  Real wet_volfrac_so4a = 1.0 / (wetvol_dryvol * tmpb);
 
-  //
   // calc kerminen & kulmala (2002) correction
-  //
+  Real factor_kk = 0.0;
   if (igrow <= 0) {
     factor_kk = 1.0;
   } else {
@@ -640,9 +641,9 @@ void mer07_veh02_wang08_nuc_1box(
     // use kk2002 eqn 21 for h2so4 uptake, and correct for nh3 & h2o uptake
     // h2so4 molecular speed (m/s);
     // FIXME: BAD CONSTANTS
-    tmp_spd = 14.7 * haero::sqrt(temp_in);
-    gr_kk = 3.0e-9 * tmp_spd * mw_sulfacid * so4vol_in /
-            (dens_part * wet_volfrac_so4a);
+    Real tmp_spd = 14.7 * haero::sqrt(temp_in);
+    Real gr_kk = 3.0e-9 * tmp_spd * mw_sulfacid * so4vol_in /
+                 (dens_part * wet_volfrac_so4a);
 
     // "gamma" parameter (nm2/m2/h)
     // use kk2002 eqn 22
@@ -650,17 +651,17 @@ void mer07_veh02_wang08_nuc_1box(
     // dfin_kk = wet diam (nm) of grown particle having dry dia = dpdry_part
     // (m)
     // FIXME: BAD CONSTANT
-    dfin_kk = 1.0e9 * dpdry_part * haero::pow(wetvol_dryvol, onethird);
+    Real dfin_kk = 1.0e9 * dpdry_part * haero::pow(wetvol_dryvol, onethird);
     // dnuc_kk = wet diam (nm) of cluster
-    dnuc_kk = 2.0 * radius_cluster;
+    Real dnuc_kk = 2.0 * radius_cluster;
     dnuc_kk = haero::max(dnuc_kk, 1.0);
     // neglect (dmean/150)**0.048 factor,
     // which should be very close to 1.0 because of small exponent
     // FIXME: BAD CONSTANTS
-    gamma_kk = 0.23 * haero::pow(dnuc_kk, 0.2) *
-               haero::pow(dfin_kk / 3.0, 0.075) *
-               haero::pow(dens_part * 1.0e-3, -0.33) *
-               haero::pow(temp_in / 293.0, -0.75);
+    Real gamma_kk = 0.23 * haero::pow(dnuc_kk, 0.2) *
+                    haero::pow(dfin_kk / 3.0, 0.075) *
+                    haero::pow(dens_part * 1.0e-3, -0.33) *
+                    haero::pow(temp_in / 293.0, -0.75);
 
     // "cs_prime parameter" (1/m2)
     // instead kk2002 eqn 3, use
@@ -679,44 +680,42 @@ void mer07_veh02_wang08_nuc_1box(
     // FIXME: BAD CONSTANT
     // tmpb = h2so4 gas diffusivity (m2/s, then m2/h)
     tmpb = 6.7037e-6 * haero::pow(temp_in, 0.75) / cair;
-    // m2/s
-    // Real tmpb1 = tmpb;
-    // m2/h;
+    // m2/h
     // FIXME: BAD CONSTANT
     tmpb = tmpb * 3600.0;
-    cs_prime_kk = tmpa / (4.0 * pi * tmpb * accom_coef_h2so4);
-    // Real cs_kk = cs_prime_kk * 4.0 * pi * tmpb1;
+    Real cs_prime_kk = tmpa / (4.0 * pi * tmpb * accom_coef_h2so4);
 
     // "nu" parameter (nm) -- kk2002 eqn 11
-    nu_kk = gamma_kk * cs_prime_kk / gr_kk;
+    Real nu_kk = gamma_kk * cs_prime_kk / gr_kk;
     // nucleation rate adjustment factor (--) -- kk2002 eqn 13
     factor_kk = haero::exp((nu_kk / dfin_kk) - (nu_kk / dnuc_kk));
   }
-  ratenuclt_kk = ratenuclt_bb * factor_kk;
+  Real ratenuclt_kk = ratenuclt_bb * factor_kk;
 
   // max production of aerosol dry mass (kg-aero/m3-air)
   tmpa = haero::max(0.0, (ratenuclt_kk * dtnuc * mass_part));
   // max production of aerosol so4 (mol-so4a/mol-air)
-  tmpe = tmpa / (kgaero_per_moleso4a * cair);
+  Real tmpe = tmpa / (kgaero_per_moleso4a * cair);
   // max production of aerosol so4 (mol/mol-air)
   // based on ratenuclt_kk and mass_part
-  qmolso4a_del_max = tmpe;
+  Real qmolso4a_del_max = tmpe;
 
   // check if max production exceeds available h2so4 vapor
-  freducea = 1.0;
+  Real freducea = 1.0;
   if (qmolso4a_del_max > qh2so4_cur) {
     freducea = qh2so4_cur / qmolso4a_del_max;
   }
+  // FIXME: BAD CONSTANT
   // check if max production exceeds available nh3 vapor
-  freduceb = 1.0;
+  Real freduceb = 1.0;
   if (molenh4a_per_moleso4a >= 1.0e-10) {
     // max production of aerosol nh4 (ppm) based on ratenuclt_kk and mass_part
-    qmolnh4a_del_max = qmolso4a_del_max * molenh4a_per_moleso4a;
+    Real qmolnh4a_del_max = qmolso4a_del_max * molenh4a_per_moleso4a;
     if (qmolnh4a_del_max > qnh3_cur) {
       freduceb = qnh3_cur / qmolnh4a_del_max;
     }
   }
-  freduce = haero::min(freducea, freduceb);
+  Real freduce = haero::min(freducea, freduceb);
 
   // if adjusted nucleation rate is less than 1e-12 #/m3/s ~= 0.1 #/cm3/day,
   // exit with new particle formation = 0
@@ -756,116 +755,6 @@ void mer07_veh02_wang08_nuc_1box(
   tmpa = haero::max(0.0, ratenuclt_kk * dtnuc / cair);
   // adjusted production of aerosol number (#/mol-air)
   tmpb = tmpa * freduce;
-  // relative difference from qnuma_del
-  // FIXME: BAD CONSTANT
-  // Real tmpc = (tmpb - qnuma_del) / haero::max(tmpb,
-  // haero::max(qnuma_del, 1.0e-35));
-
-  // diagnostic output to fort.41
-  // (this should be commented-out or deleted in the wrf-chem version)
-  //
-  // if (ldiagaa > 0)
-  //   // do following for diagnostic output if ldiagaa > 0
-
-  //       icase = icase + 1 if (abs(tmpc).gt.abs(reldiffmax)) then reldiffmax =
-  //                   tmpc icase_reldiffmax = icase end if
-  //       //       do lun = 41, 51, 10
-  //       do lun = 6,
-  //       6
-  //           //          write(lun,'(/)')
-  //           write(lun, '(a,2i9,1p,e10.2)') &
-  //           'vehkam bin-nuc icase, icase_rdmax =',
-  //       &icase, icase_reldiffmax,
-  //       reldiffmax if (freduceb.lt.freducea)
-  //           then if (abs(freducea - freduceb).gt.&
-  //                    3.0e-7 * haero::max(freduceb, freducea))
-  //               write(lun, '(a,1p,2e15.7)') &;
-  // 'freducea, b =', freducea, freduceb end if end do
-
-  // // output factors so that output matches that of ternucl03
-  // //       fogas  = 1.0e6                     // convert mol/mol-air to ppm
-  // //       foso4a = 1.0e9*mw_so4a/mw_air      // convert mol-so4a/mol-air to
-  // ug/kg-air
-  // //       fonh4a = 1.0e9*mw_nh4a/mw_air      // convert mol-nh4a/mol-air to
-  // ug/kg-air
-  // //       fonuma = 1.0e3/mw_air              // convert #/mol-air to
-  // #/kg-air
-  //         fogas  = 1.0;
-  //         foso4a = 1.0;
-  //         fonh4a = 1.0;
-  //         fonuma = 1.0;
-
-  // //       do lun = 41, 51, 10
-  //         do lun = 6, 6
-
-  //         write(lun,'(a,2i5)') 'newnuc_method_flagaa/aa2',   &
-  //            newnuc_method_flagaa, newnuc_method_flagaa2
-
-  //         write(lun,9210)
-  //         write(lun,9201) temp_in, rh_in,   &
-  //            ratenuclt, 2.0*radius_cluster*1.0e-7, dpdry_part*1.0e2,   &;
-  //            voldry_part*1.0e6, float(igrow);
-  //         write(lun,9215)
-  //         write(lun,9201)   &
-  //            qh2so4_avg*fogas, 0.0,  &;
-  //            qh2so4_cur*fogas, qnh3_cur*fogas,  &
-  //            qh2so4_del*fogas, qnh3_del*fogas,  &
-  //            qso4a_del*foso4a, qnh4a_del*fonh4a
-
-  //         write(lun,9220)
-  //         write(lun,9201)   &
-  //            dtnuc, dens_nh4so4a*1.0e-3,   &;
-  //            (qnh3_cur/qh2so4_cur), molenh4a_per_moleso4a,   &
-  //            qnuma_del*fonuma, tmpb*fonuma, tmpc, freduce
-
-  //         end do
-
-  // //       lun = 51
-  //         lun = 6
-  //         write(lun,9230)
-  //         write(lun,9201)   &
-  //            press_in, cair*1.0e-6, so4vol_in,   &;
-  //            wet_volfrac_so4a, wetvol_dryvol, dens_part*1.0e-3;
-
-  //         if (igrow > 0) then
-  //         write(lun,9240)
-  //         write(lun,9201)   &
-  //            tmp_spd, gr_kk, dnuc_kk, dfin_kk,   &
-  //            gamma_kk, tmpa1, tmpb1, cs_kk
-
-  //         write(lun,9250)
-  //         write(lun,9201)   &
-  //            cs_prime_kk, nu_kk, factor_kk, ratenuclt,   &
-  //            ratenuclt_kk*1.0e-6;
-  //         end if
-
-  // 9201    format ( 1p, 40e10.2  )
-  // 9210    format (   &
-  //         '      temp        rh',   &
-  //         '   ratenuc  dia_clus ddry_part',   &
-  //         ' vdry_part     igrow' )
-  // 9215    format (   &
-  //         '  h2so4avg  h2so4pre',   &
-  //         '  h2so4cur   nh3_cur',   &
-  //         '  h2so4del   nh3_del',   &
-  //         '  so4a_del  nh4a_del' )
-  // 9220    format (    &
-  //         '     dtnuc    dens_a   nh/so g   nh/so a',   &
-  //         '  numa_del  numa_dl2   reldiff   freduce' )
-  // 9230    format (   &
-  //         '  press_in      cair so4_volin',   &
-  //         ' wet_volfr wetv_dryv dens_part' )
-  // 9240    format (   &
-  //         '   tmp_spd     gr_kk   dnuc_kk   dfin_kk',   &
-  //         '  gamma_kk     tmpa1     tmpb1     cs_kk' )
-  // 9250    format (   &
-  //         ' cs_pri_kk     nu_kk factor_kk ratenuclt',   &
-  //         ' ratenu_kk' )
-
-  //         endif    //  branch if diagnostic output if ldiagaa > 0
-  // #include
-  // "../yaml/modal_aero_newnuc/f90_yaml/mer07_veh02_nuc_mosaic_1box_end_yml.f90"
-  //         return
 } // end mer07_veh02_wang08_nuc_1box()
 
 KOKKOS_INLINE_FUNCTION

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -45,8 +45,8 @@ EkatCreateUnitTest(mam4_aging_unit_tests mam4_aging_unit_tests.cpp
   LIBS mam4xx_tests ${HAERO_LIBRARIES} EXCLUDE_TEST_SESSION)
 EkatCreateUnitTest(mam4_hetfrz_unit_tests mam4_hetfrz_unit_tests.cpp
   LIBS mam4xx_tests ${HAERO_LIBRARIES} EXCLUDE_TEST_SESSION)
-EkatCreateUnitTest(mam4_amicphys_1gridcell_tests mam4_amicphys_1gridcell.cpp
-  LIBS mam4xx_tests ${HAERO_LIBRARIES} EXCLUDE_TEST_SESSION)
+# EkatCreateUnitTest(mam4_amicphys_1gridcell_tests mam4_amicphys_1gridcell.cpp
+#   LIBS mam4xx_tests ${HAERO_LIBRARIES} EXCLUDE_TEST_SESSION)
 EkatCreateUnitTest(mam4_nucleate_ice_unit_tests mam4_nucleate_ice_unit_tests.cpp
   LIBS mam4xx_tests ${HAERO_LIBRARIES} EXCLUDE_TEST_SESSION)
 EkatCreateUnitTest(mam4_wet_deposition_unit_tests mam4_wet_deposition_unit_tests.cpp
@@ -67,7 +67,7 @@ if (NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel") #The Intel compiler always em
   target_compile_options(mam4_coagulation_unit_tests PRIVATE)
   target_compile_options(mam4_calcsize_unit_tests PRIVATE)
   target_compile_options(mam4_convproc_unit_tests PRIVATE)
-  target_compile_options(mam4_amicphys_1gridcell_tests PRIVATE)
+  # target_compile_options(mam4_amicphys_1gridcell_tests PRIVATE)
   target_compile_options(mam4_rename_unit_tests PRIVATE)
   target_compile_options(mam4_aging_unit_tests PRIVATE)
   target_compile_options(mam4_hetfrz_unit_tests PRIVATE)

--- a/src/validation/nucleation/CMakeLists.txt
+++ b/src/validation/nucleation/CMakeLists.txt
@@ -74,52 +74,52 @@ foreach (input
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
 endforeach()
 
-# # additional tests added for integration
-# set(TestLabel "nuc_tests_new")
+# additional tests added for integration
+set(TestLabel "nuc_tests_new")
 
-# set(NUCLEATION_VALIDATION_SCRIPTS_DIR ${MAM_X_VALIDATION_DIR}/scripts)
+set(NUCLEATION_VALIDATION_SCRIPTS_DIR ${MAM_X_VALIDATION_DIR}/scripts)
 
-# # Copy some Python scripts from mam_x_validation to our binary directory.
-# foreach(script
-#         compare_mam4xx_mam4.py)
-#   configure_file(
-#     ${NUCLEATION_VALIDATION_SCRIPTS_DIR}/${script}
-#     ${CMAKE_CURRENT_BINARY_DIR}/${script}
-#     COPYONLY
-#   )
-# endforeach()
+# Copy some Python scripts from mam_x_validation to our binary directory.
+foreach(script
+        compare_mam4xx_mam4.py)
+  configure_file(
+    ${NUCLEATION_VALIDATION_SCRIPTS_DIR}/${script}
+    ${CMAKE_CURRENT_BINARY_DIR}/${script}
+    COPYONLY
+  )
+endforeach()
 
-# # Run the driver in several configurations to produce datasets.
-# set(TEST_LIST
-#     binary_nuc_vehk2002
-#     pbl_nuc_wang2008
-#     mer07_veh02_nuc_mosaic_1box
-#     )
+# Run the driver in several configurations to produce datasets.
+set(TEST_LIST
+    binary_nuc_vehk2002
+    pbl_nuc_wang2008
+    mer07_veh02_nuc_mosaic_1box
+    )
 
-# set(DEFAULT_TOL 2e-10)
+set(DEFAULT_TOL 2e-10)
 
-# set(ERROR_THRESHOLDS
-#     ${DEFAULT_TOL} # binary_nuc_vehk2002
-#     ${DEFAULT_TOL} # pbl_nuc_wang2008
-#     ${DEFAULT_TOL} # mer07_veh02_nuc_mosaic_1box
-#    )
+set(ERROR_THRESHOLDS
+    ${DEFAULT_TOL} # binary_nuc_vehk2002
+    ${DEFAULT_TOL} # pbl_nuc_wang2008
+    ${DEFAULT_TOL} # mer07_veh02_nuc_mosaic_1box
+   )
 
-# foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
-#   # copy the baseline file into place.
-#   configure_file(
-#     ${NUC_VALIDATION_DIR}/mam_${input}.py
-#     ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
-#     COPYONLY
-#   )
+foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
+  # copy the baseline file into place.
+  configure_file(
+    ${NUC_VALIDATION_DIR}/mam_${input}.py
+    ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
+    COPYONLY
+  )
 
-#   # add a test to run the skywalker driver
-#   add_test(run_${input} nucleation_driver ${NUC_VALIDATION_DIR}/${input}.yaml)
-#   set_tests_properties(run_${input} PROPERTIES LABELS "${TestLabel}")
+  # add a test to run the skywalker driver
+  add_test(run_${input} nucleation_driver ${NUC_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS "${TestLabel}")
 
-#   # add a test to validate mam4xx's results against the baseline.
-#   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
-#   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
-#   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
-#   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
-#   set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
-# endforeach()
+  # add a test to validate mam4xx's results against the baseline.
+  # Select a threshold error slightly bigger than the largest relative error for the threshold error.
+  # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
+  add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
+endforeach()

--- a/src/validation/nucleation/CMakeLists.txt
+++ b/src/validation/nucleation/CMakeLists.txt
@@ -7,7 +7,10 @@ include_directories(${PROJECT_BINARY_DIR}/validation)
 # We use a single driver for all nucleation-related parameterizations.
 add_executable(nucleation_driver nucleation_driver.cpp
                mer07_veh02_wang08_nuc_1box.cpp
-               newnuc_cluster_growth.cpp)
+               newnuc_cluster_growth.cpp
+               binary_nuc_vehk2002.cpp
+               pbl_nuc_wang2008.cpp
+               mer07_veh02_nuc_mosaic_1box.cpp)
 target_link_libraries(nucleation_driver skywalker;validation;${HAERO_LIBRARIES})
 
 # Copy some Python scripts from mam_x_validation to our binary directory.
@@ -71,3 +74,52 @@ foreach (input
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
 endforeach()
 
+# additional tests added for integration
+set(TestLabel "nuc_tests_new")
+
+set(NUCLEATION_VALIDATION_SCRIPTS_DIR ${MAM_X_VALIDATION_DIR}/scripts)
+
+# Copy some Python scripts from mam_x_validation to our binary directory.
+foreach(script
+        compare_mam4xx_mam4.py)
+  configure_file(
+    ${NUCLEATION_VALIDATION_SCRIPTS_DIR}/${script}
+    ${CMAKE_CURRENT_BINARY_DIR}/${script}
+    COPYONLY
+  )
+endforeach()
+
+# Run the driver in several configurations to produce datasets.
+set(TEST_LIST
+    binary_nuc_vehk2002
+    pbl_nuc_wang2008
+    mer07_veh02_nuc_mosaic_1box
+    )
+
+set(DEFAULT_TOL 2e-10)
+
+set(ERROR_THRESHOLDS
+    ${DEFAULT_TOL} # binary_nuc_vehk2002
+    ${DEFAULT_TOL} # pbl_nuc_wang2008
+    ${DEFAULT_TOL} # mer07_veh02_nuc_mosaic_1box
+   )
+
+foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
+  # copy the baseline file into place.
+  configure_file(
+    ${NUC_VALIDATION_DIR}/mam_${input}.py
+    ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
+    COPYONLY
+  )
+
+  # add a test to run the skywalker driver
+  add_test(run_${input} nucleation_driver ${NUC_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS "${TestLabel}")
+
+  # add a test to validate mam4xx's results against the baseline.
+  # Select a threshold error slightly bigger than the largest relative error for the threshold error.
+  # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
+  add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
+endforeach()

--- a/src/validation/nucleation/CMakeLists.txt
+++ b/src/validation/nucleation/CMakeLists.txt
@@ -99,7 +99,7 @@ set(TEST_LIST
 set(DEFAULT_TOL 2e-10)
 
 set(ERROR_THRESHOLDS
-    ${DEFAULT_TOL} # binary_nuc_vehk2002
+    3.5e-10 # binary_nuc_vehk2002
     ${DEFAULT_TOL} # pbl_nuc_wang2008
     ${DEFAULT_TOL} # mer07_veh02_nuc_mosaic_1box
    )

--- a/src/validation/nucleation/CMakeLists.txt
+++ b/src/validation/nucleation/CMakeLists.txt
@@ -96,12 +96,10 @@ set(TEST_LIST
     mer07_veh02_nuc_mosaic_1box
     )
 
-set(DEFAULT_TOL 2e-10)
-
 set(ERROR_THRESHOLDS
     3.5e-10 # binary_nuc_vehk2002
-    ${DEFAULT_TOL} # pbl_nuc_wang2008
-    ${DEFAULT_TOL} # mer07_veh02_nuc_mosaic_1box
+    2.0e-10 # pbl_nuc_wang2008
+    2.0e-11 # mer07_veh02_nuc_mosaic_1box
    )
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)

--- a/src/validation/nucleation/CMakeLists.txt
+++ b/src/validation/nucleation/CMakeLists.txt
@@ -74,52 +74,52 @@ foreach (input
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
 endforeach()
 
-# additional tests added for integration
-set(TestLabel "nuc_tests_new")
+# # additional tests added for integration
+# set(TestLabel "nuc_tests_new")
 
-set(NUCLEATION_VALIDATION_SCRIPTS_DIR ${MAM_X_VALIDATION_DIR}/scripts)
+# set(NUCLEATION_VALIDATION_SCRIPTS_DIR ${MAM_X_VALIDATION_DIR}/scripts)
 
-# Copy some Python scripts from mam_x_validation to our binary directory.
-foreach(script
-        compare_mam4xx_mam4.py)
-  configure_file(
-    ${NUCLEATION_VALIDATION_SCRIPTS_DIR}/${script}
-    ${CMAKE_CURRENT_BINARY_DIR}/${script}
-    COPYONLY
-  )
-endforeach()
+# # Copy some Python scripts from mam_x_validation to our binary directory.
+# foreach(script
+#         compare_mam4xx_mam4.py)
+#   configure_file(
+#     ${NUCLEATION_VALIDATION_SCRIPTS_DIR}/${script}
+#     ${CMAKE_CURRENT_BINARY_DIR}/${script}
+#     COPYONLY
+#   )
+# endforeach()
 
-# Run the driver in several configurations to produce datasets.
-set(TEST_LIST
-    binary_nuc_vehk2002
-    pbl_nuc_wang2008
-    mer07_veh02_nuc_mosaic_1box
-    )
+# # Run the driver in several configurations to produce datasets.
+# set(TEST_LIST
+#     binary_nuc_vehk2002
+#     pbl_nuc_wang2008
+#     mer07_veh02_nuc_mosaic_1box
+#     )
 
-set(DEFAULT_TOL 2e-10)
+# set(DEFAULT_TOL 2e-10)
 
-set(ERROR_THRESHOLDS
-    ${DEFAULT_TOL} # binary_nuc_vehk2002
-    ${DEFAULT_TOL} # pbl_nuc_wang2008
-    ${DEFAULT_TOL} # mer07_veh02_nuc_mosaic_1box
-   )
+# set(ERROR_THRESHOLDS
+#     ${DEFAULT_TOL} # binary_nuc_vehk2002
+#     ${DEFAULT_TOL} # pbl_nuc_wang2008
+#     ${DEFAULT_TOL} # mer07_veh02_nuc_mosaic_1box
+#    )
 
-foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
-  # copy the baseline file into place.
-  configure_file(
-    ${NUC_VALIDATION_DIR}/mam_${input}.py
-    ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
-    COPYONLY
-  )
+# foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
+#   # copy the baseline file into place.
+#   configure_file(
+#     ${NUC_VALIDATION_DIR}/mam_${input}.py
+#     ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
+#     COPYONLY
+#   )
 
-  # add a test to run the skywalker driver
-  add_test(run_${input} nucleation_driver ${NUC_VALIDATION_DIR}/${input}.yaml)
-  set_tests_properties(run_${input} PROPERTIES LABELS "${TestLabel}")
+#   # add a test to run the skywalker driver
+#   add_test(run_${input} nucleation_driver ${NUC_VALIDATION_DIR}/${input}.yaml)
+#   set_tests_properties(run_${input} PROPERTIES LABELS "${TestLabel}")
 
-  # add a test to validate mam4xx's results against the baseline.
-  # Select a threshold error slightly bigger than the largest relative error for the threshold error.
-  # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
-  add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
-  set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
-  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
-endforeach()
+#   # add a test to validate mam4xx's results against the baseline.
+#   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
+#   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
+#   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+#   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+#   set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
+# endforeach()

--- a/src/validation/nucleation/binary_nuc_vehk2002.cpp
+++ b/src/validation/nucleation/binary_nuc_vehk2002.cpp
@@ -1,0 +1,33 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <mam4xx/nucleation.hpp>
+
+// #include <haero/constants.hpp>
+// #include <mam4xx/mam4_types.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+using namespace skywalker;
+using namespace mam4;
+using namespace haero;
+void binary_nuc_vehk2002(Ensemble *ensemble) {
+  ensemble->process([=](const Input &input, Output &output) {
+    // Ensemble parameters
+    // Declare array of strings for input names
+    std::string input_arrays[] = {"life"};
+
+    // Iterate over input_arrays and error if not in input
+    for (std::string name : input_arrays) {
+      if (!input.has_array(name.c_str())) {
+        std::cerr << "Required name for array: " << name << std::endl;
+        exit(1);
+      }
+    }
+
+    const Real life = input.get_array("life")[0];
+    output.set("ans", life);
+  });
+}

--- a/src/validation/nucleation/binary_nuc_vehk2002.cpp
+++ b/src/validation/nucleation/binary_nuc_vehk2002.cpp
@@ -5,8 +5,6 @@
 
 #include <mam4xx/nucleation.hpp>
 
-// #include <haero/constants.hpp>
-// #include <mam4xx/mam4_types.hpp>
 #include <skywalker.hpp>
 #include <validation.hpp>
 

--- a/src/validation/nucleation/binary_nuc_vehk2002.cpp
+++ b/src/validation/nucleation/binary_nuc_vehk2002.cpp
@@ -17,9 +17,7 @@ void binary_nuc_vehk2002(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
     // Ensemble parameters
     // Declare array of strings for input names
-    std::string input_arrays[] = {"life",       "temp",     "rh",
-                                  "so4vol",     "ratenucl", "rateloge",
-                                  "cnum_h2so4", "cnum_tot", "radius_cluster"};
+    std::string input_arrays[] = {"temp", "rh", "so4vol"};
 
     // Iterate over input_arrays and error if not in input
     for (std::string name : input_arrays) {
@@ -29,26 +27,22 @@ void binary_nuc_vehk2002(Ensemble *ensemble) {
       }
     }
 
-    const Real life = input.get_array("life")[0];
+    const Real temp = input.get_array("temp")[0];
+    const Real rh = input.get_array("rh")[0];
+    const Real so4vol = input.get_array("so4vol")[0];
+    Real ratenucl;
+    Real rateloge;
+    Real cnum_h2so4;
+    Real cnum_tot;
+    Real radius_cluster;
 
-    // const Real temp = input.get_array("temp")[0];
-    // const Real rh = input.get_array("rh")[0];
-    // const Real so4vol = input.get_array("so4vol")[0];
-    // Real ratenucl = input.get_array("ratenucl")[0];
-    // Real rateloge = input.get_array("rateloge")[0];
-    // Real cnum_h2so4 = input.get_array("cnum_h2so4")[0];
-    // Real cnum_tot = input.get_array("cnum_tot")[0];
-    // Real radius_cluster = input.get_array("radius_cluster")[0];
+    nucleation::binary_nuc_vehk2002(temp, rh, so4vol, ratenucl, rateloge,
+                                       cnum_h2so4, cnum_tot, radius_cluster);
 
-    // nucleation::binary_nuc_vehk2002(temp, rh, so4vol, ratenucl, rateloge,
-                                      //  cnum_h2so4, cnum_tot, radius_cluster)
-
-    output.set("ans", life);
-
-    // output.set("ratenucl", ratenucl);
-    // output.set("rateloge", rateloge);
-    // output.set("cnum_h2so4", cnum_h2so4);
-    // output.set("cnum_tot", cnum_tot);
-    // output.set("radius_cluster", radius_cluster);
+    output.set("ratenucl", ratenucl);
+    output.set("rateloge", rateloge);
+    output.set("cnum_h2so4", cnum_h2so4);
+    output.set("cnum_tot", cnum_tot);
+    output.set("radius_cluster", radius_cluster);
   });
 }

--- a/src/validation/nucleation/binary_nuc_vehk2002.cpp
+++ b/src/validation/nucleation/binary_nuc_vehk2002.cpp
@@ -37,7 +37,7 @@ void binary_nuc_vehk2002(Ensemble *ensemble) {
     Real radius_cluster;
 
     nucleation::binary_nuc_vehk2002(temp, rh, so4vol, ratenucl, rateloge,
-                                       cnum_h2so4, cnum_tot, radius_cluster);
+                                    cnum_h2so4, cnum_tot, radius_cluster);
 
     output.set("ratenucl", ratenucl);
     output.set("rateloge", rateloge);

--- a/src/validation/nucleation/binary_nuc_vehk2002.cpp
+++ b/src/validation/nucleation/binary_nuc_vehk2002.cpp
@@ -17,7 +17,9 @@ void binary_nuc_vehk2002(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
     // Ensemble parameters
     // Declare array of strings for input names
-    std::string input_arrays[] = {"life"};
+    std::string input_arrays[] = {"life",       "temp",     "rh",
+                                  "so4vol",     "ratenucl", "rateloge",
+                                  "cnum_h2so4", "cnum_tot", "radius_cluster"};
 
     // Iterate over input_arrays and error if not in input
     for (std::string name : input_arrays) {
@@ -28,6 +30,25 @@ void binary_nuc_vehk2002(Ensemble *ensemble) {
     }
 
     const Real life = input.get_array("life")[0];
+
+    // const Real temp = input.get_array("temp")[0];
+    // const Real rh = input.get_array("rh")[0];
+    // const Real so4vol = input.get_array("so4vol")[0];
+    // Real ratenucl = input.get_array("ratenucl")[0];
+    // Real rateloge = input.get_array("rateloge")[0];
+    // Real cnum_h2so4 = input.get_array("cnum_h2so4")[0];
+    // Real cnum_tot = input.get_array("cnum_tot")[0];
+    // Real radius_cluster = input.get_array("radius_cluster")[0];
+
+    // nucleation::binary_nuc_vehk2002(temp, rh, so4vol, ratenucl, rateloge,
+                                      //  cnum_h2so4, cnum_tot, radius_cluster)
+
     output.set("ans", life);
+
+    // output.set("ratenucl", ratenucl);
+    // output.set("rateloge", rateloge);
+    // output.set("cnum_h2so4", cnum_h2so4);
+    // output.set("cnum_tot", cnum_tot);
+    // output.set("radius_cluster", radius_cluster);
   });
 }

--- a/src/validation/nucleation/mer07_veh02_nuc_mosaic_1box.cpp
+++ b/src/validation/nucleation/mer07_veh02_nuc_mosaic_1box.cpp
@@ -21,9 +21,8 @@ void mer07_veh02_nuc_mosaic_1box(Ensemble *ensemble) {
         "dtnuc",    "temp_in",        "rh_in",        "press_in",
         "zm_in",    "pblh_in",        "qh2so4_cur",   "qh2so4_avg",
         "qnh3_cur", "h2so4_uptkrate", "mw_so4a_host", "newnuc_method_flagaa",
-        "nsize",    "maxd_asize",     "dplom_sect",   "dphim_sect",
-        "ldiagaa",  "rgas",           "avogad",       "mw_so4a",
-        "mw_nh4a"};
+        "nsize",    "dplom_sect",     "dphim_sect",   "ldiagaa",
+        "rgas",     "avogad",         "mw_so4a",      "mw_nh4a"};
 
     // Iterate over input_arrays and error if not in input
     for (std::string name : input_arrays) {
@@ -33,28 +32,61 @@ void mer07_veh02_nuc_mosaic_1box(Ensemble *ensemble) {
       }
     }
 
-    // dtnuc
-    // temp_in
-    // rh_in
-    // press_in
-    // zm_in
-    // pblh_in
-    // qh2so4_cur
-    // qh2so4_avg
-    // qnh3_cur
-    // h2so4_uptkrate
-    // mw_so4a_host
-    // newnuc_method_flagaa
-    // nsize
-    // maxd_asize
-    // dplom_sect
-    // dphim_sect
-    // ldiagaa
-    // rgas
-    // avogad
-    // mw_so4a
-    // mw_nh4a
+    const int newnuc_method_flagaa_ =
+        input.get_array("newnuc_method_flagaa")[0];
+    const Real dtnuc_ = input.get_array("dtnuc")[0];
+    const Real temp_in_ = input.get_array("temp_in")[0];
+    const Real rh_in_ = input.get_array("rh_in")[0];
+    const Real press_in_ = input.get_array("press_in")[0];
+    const Real zm_in_ = input.get_array("zm_in")[0];
+    const Real pblh_in_ = input.get_array("pblh_in")[0];
+    const Real qh2so4_cur_ = input.get_array("qh2so4_cur")[0];
+    const Real qh2so4_avg_ = input.get_array("qh2so4_avg")[0];
+    const Real qnh3_cur_ = input.get_array("qnh3_cur")[0];
+    const Real h2so4_uptkrate_ = input.get_array("h2so4_uptkrate")[0];
+    const Real mw_so4a_host_ = input.get_array("mw_so4a_host")[0];
+    const int nsize_ = input.get_array("nsize")[0];
+    const Real dplom_sect_ = input.get_array("dplom_sect")[0];
+    const Real dphim_sect_ = input.get_array("dphim_sect")[0];
+    const int ldiagaa_ = input.get_array("ldiagaa")[0];
+    const Real rgas_ = input.get_array("rgas")[0];
+    const Real avogad_ = input.get_array("avogad")[0];
+    const Real mw_nh4a_ = input.get_array("mw_nh4a")[0];
+    const Real mw_so4a_ = input.get_array("mw_so4a")[0];
+    const Real pi = haero::Constants::pi;
 
+    int newnuc_method_flagaa;
+    if (newnuc_method_flagaa_ == 11) {
+      newnuc_method_flagaa = 1;
+    } else if (newnuc_method_flagaa_ == 12) {
+      newnuc_method_flagaa = 2;
+    } else {
+      std::cerr << "Undefined value for parameter: newnuc_method_flagaa"
+                << std::endl;
+    }
 
+    int isize_nuc;
+    Real qnuma_del;
+    Real qso4a_del;
+    Real qnh4a_del;
+    Real qh2so4_del;
+    Real qnh3_del;
+    Real dens_nh4so4a;
+    Real dnclusterdt;
+
+    nucleation::mer07_veh02_wang08_nuc_1box(
+        newnuc_method_flagaa, dtnuc_, temp_in_, rh_in_, press_in_, zm_in_,
+        pblh_in_, qh2so4_cur_, qh2so4_avg_, qnh3_cur_, h2so4_uptkrate_,
+        mw_so4a_host_, nsize_, dplom_sect_, dphim_sect_, ldiagaa_, rgas_,
+        avogad_, mw_nh4a_, mw_so4a_, pi, isize_nuc, qnuma_del, qso4a_del,
+        qnh4a_del, qh2so4_del, qnh3_del, dens_nh4so4a, dnclusterdt);
+
+    output.set("isize_nuc", isize_nuc);
+    output.set("qnuma_del", qnuma_del);
+    output.set("qso4a_del", qso4a_del);
+    output.set("qnh4a_del", qnh4a_del);
+    output.set("qh2so4_del", qh2so4_del);
+    output.set("dens_nh4so4a", dens_nh4so4a);
+    output.set("dnclusterdt", dnclusterdt);
   });
 }

--- a/src/validation/nucleation/mer07_veh02_nuc_mosaic_1box.cpp
+++ b/src/validation/nucleation/mer07_veh02_nuc_mosaic_1box.cpp
@@ -19,8 +19,8 @@ void mer07_veh02_nuc_mosaic_1box(Ensemble *ensemble) {
         "dtnuc",    "temp_in",        "rh_in",        "press_in",
         "zm_in",    "pblh_in",        "qh2so4_cur",   "qh2so4_avg",
         "qnh3_cur", "h2so4_uptkrate", "mw_so4a_host", "newnuc_method_flagaa",
-        "nsize",    "dplom_sect",     "dphim_sect",   "ldiagaa",
-        "rgas",     "avogad",         "mw_so4a",      "mw_nh4a"};
+        "nsize",    "dplom_sect",     "dphim_sect",   "rgas",
+        "avogad",   "mw_so4a",        "mw_nh4a"};
 
     // Iterate over input_arrays and error if not in input
     for (std::string name : input_arrays) {
@@ -46,7 +46,6 @@ void mer07_veh02_nuc_mosaic_1box(Ensemble *ensemble) {
     const int nsize_ = input.get_array("nsize")[0];
     const Real dplom_sect_ = input.get_array("dplom_sect")[0];
     const Real dphim_sect_ = input.get_array("dphim_sect")[0];
-    const int ldiagaa_ = input.get_array("ldiagaa")[0];
     const Real rgas_ = input.get_array("rgas")[0];
     const Real avogad_ = input.get_array("avogad")[0];
     const Real mw_nh4a_ = input.get_array("mw_nh4a")[0];
@@ -62,12 +61,12 @@ void mer07_veh02_nuc_mosaic_1box(Ensemble *ensemble) {
     Real dens_nh4so4a;
     Real dnclusterdt;
 
-    nucleation::mer07_veh02_wang08_nuc_1box(
+    nucleation::mer07_veh02_nuc_mosaic_1box(
         newnuc_method_flagaa_, dtnuc_, temp_in_, rh_in_, press_in_, zm_in_,
         pblh_in_, qh2so4_cur_, qh2so4_avg_, qnh3_cur_, h2so4_uptkrate_,
-        mw_so4a_host_, nsize_, dplom_sect_, dphim_sect_, ldiagaa_, rgas_,
-        avogad_, mw_nh4a_, mw_so4a_, pi, isize_nuc, qnuma_del, qso4a_del,
-        qnh4a_del, qh2so4_del, qnh3_del, dens_nh4so4a, dnclusterdt);
+        mw_so4a_host_, nsize_, dplom_sect_, dphim_sect_, rgas_, avogad_,
+        mw_nh4a_, mw_so4a_, pi, isize_nuc, qnuma_del, qso4a_del, qnh4a_del,
+        qh2so4_del, qnh3_del, dens_nh4so4a, dnclusterdt);
 
     output.set("isize_nuc", isize_nuc);
     output.set("qnuma_del", qnuma_del);

--- a/src/validation/nucleation/mer07_veh02_nuc_mosaic_1box.cpp
+++ b/src/validation/nucleation/mer07_veh02_nuc_mosaic_1box.cpp
@@ -17,7 +17,13 @@ void mer07_veh02_nuc_mosaic_1box(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
     // Ensemble parameters
     // Declare array of strings for input names
-    std::string input_arrays[] = {"life"};
+    std::string input_arrays[] = {
+        "dtnuc",    "temp_in",        "rh_in",        "press_in",
+        "zm_in",    "pblh_in",        "qh2so4_cur",   "qh2so4_avg",
+        "qnh3_cur", "h2so4_uptkrate", "mw_so4a_host", "newnuc_method_flagaa",
+        "nsize",    "maxd_asize",     "dplom_sect",   "dphim_sect",
+        "ldiagaa",  "rgas",           "avogad",       "mw_so4a",
+        "mw_nh4a"};
 
     // Iterate over input_arrays and error if not in input
     for (std::string name : input_arrays) {
@@ -27,7 +33,28 @@ void mer07_veh02_nuc_mosaic_1box(Ensemble *ensemble) {
       }
     }
 
-    const Real life = input.get_array("life")[0];
-    output.set("ans", life);
+    // dtnuc
+    // temp_in
+    // rh_in
+    // press_in
+    // zm_in
+    // pblh_in
+    // qh2so4_cur
+    // qh2so4_avg
+    // qnh3_cur
+    // h2so4_uptkrate
+    // mw_so4a_host
+    // newnuc_method_flagaa
+    // nsize
+    // maxd_asize
+    // dplom_sect
+    // dphim_sect
+    // ldiagaa
+    // rgas
+    // avogad
+    // mw_so4a
+    // mw_nh4a
+
+
   });
 }

--- a/src/validation/nucleation/mer07_veh02_nuc_mosaic_1box.cpp
+++ b/src/validation/nucleation/mer07_veh02_nuc_mosaic_1box.cpp
@@ -1,0 +1,33 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <mam4xx/nucleation.hpp>
+
+// #include <haero/constants.hpp>
+// #include <mam4xx/mam4_types.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+using namespace skywalker;
+using namespace mam4;
+using namespace haero;
+void mer07_veh02_nuc_mosaic_1box(Ensemble *ensemble) {
+  ensemble->process([=](const Input &input, Output &output) {
+    // Ensemble parameters
+    // Declare array of strings for input names
+    std::string input_arrays[] = {"life"};
+
+    // Iterate over input_arrays and error if not in input
+    for (std::string name : input_arrays) {
+      if (!input.has_array(name.c_str())) {
+        std::cerr << "Required name for array: " << name << std::endl;
+        exit(1);
+      }
+    }
+
+    const Real life = input.get_array("life")[0];
+    output.set("ans", life);
+  });
+}

--- a/src/validation/nucleation/mer07_veh02_nuc_mosaic_1box.cpp
+++ b/src/validation/nucleation/mer07_veh02_nuc_mosaic_1box.cpp
@@ -5,8 +5,6 @@
 
 #include <mam4xx/nucleation.hpp>
 
-// #include <haero/constants.hpp>
-// #include <mam4xx/mam4_types.hpp>
 #include <skywalker.hpp>
 #include <validation.hpp>
 
@@ -55,16 +53,6 @@ void mer07_veh02_nuc_mosaic_1box(Ensemble *ensemble) {
     const Real mw_so4a_ = input.get_array("mw_so4a")[0];
     const Real pi = haero::Constants::pi;
 
-    int newnuc_method_flagaa;
-    if (newnuc_method_flagaa_ == 11) {
-      newnuc_method_flagaa = 1;
-    } else if (newnuc_method_flagaa_ == 12) {
-      newnuc_method_flagaa = 2;
-    } else {
-      std::cerr << "Undefined value for parameter: newnuc_method_flagaa"
-                << std::endl;
-    }
-
     int isize_nuc;
     Real qnuma_del;
     Real qso4a_del;
@@ -75,7 +63,7 @@ void mer07_veh02_nuc_mosaic_1box(Ensemble *ensemble) {
     Real dnclusterdt;
 
     nucleation::mer07_veh02_wang08_nuc_1box(
-        newnuc_method_flagaa, dtnuc_, temp_in_, rh_in_, press_in_, zm_in_,
+        newnuc_method_flagaa_, dtnuc_, temp_in_, rh_in_, press_in_, zm_in_,
         pblh_in_, qh2so4_cur_, qh2so4_avg_, qnh3_cur_, h2so4_uptkrate_,
         mw_so4a_host_, nsize_, dplom_sect_, dphim_sect_, ldiagaa_, rgas_,
         avogad_, mw_nh4a_, mw_so4a_, pi, isize_nuc, qnuma_del, qso4a_del,

--- a/src/validation/nucleation/nucleation_driver.cpp
+++ b/src/validation/nucleation/nucleation_driver.cpp
@@ -27,6 +27,9 @@ using namespace mam4;
 // Parameterizations used by the nucleation process.
 void mer07_veh02_wang08_nuc_1box(Ensemble *ensemble);
 void newnuc_cluster_growth(Ensemble *ensemble);
+void binary_nuc_vehk2002(Ensemble *ensemble);
+void pbl_nuc_wang2008(Ensemble *ensemble);
+void mer07_veh02_nuc_mosaic_1box(Ensemble *ensemble);
 
 int main(int argc, char **argv) {
   if (argc == 1) {
@@ -55,6 +58,12 @@ int main(int argc, char **argv) {
       mer07_veh02_wang08_nuc_1box(ensemble);
     } else if (func_name == "newnuc_cluster_growth") {
       newnuc_cluster_growth(ensemble);
+    } else if (func_name == "binary_nuc_vehk2002") {
+      binary_nuc_vehk2002(ensemble);
+    } else if (func_name == "pbl_nuc_wang2008") {
+      pbl_nuc_wang2008(ensemble);
+    } else if (func_name == "mer07_veh02_nuc_mosaic_1box") {
+      mer07_veh02_nuc_mosaic_1box(ensemble);
     }
   } catch (std::exception &e) {
     std::cerr << argv[0] << ": Error: " << e.what() << std::endl;

--- a/src/validation/nucleation/pbl_nuc_wang2008.cpp
+++ b/src/validation/nucleation/pbl_nuc_wang2008.cpp
@@ -63,7 +63,6 @@ void pbl_nuc_wang2008(Ensemble *ensemble) {
         adjust_factor_pbl_ratenucl_, pbl_nuc_wang2008_actual_, ratenucl_,
         rateloge_, cnum_tot_, cnum_h2so4_, cnum_nh3_, radius_cluster_nm_);
 
-
     int pbl_nuc_wang2008_actual_out;
     if (pbl_nuc_wang2008_actual_ == 1) {
       pbl_nuc_wang2008_actual_out = 11;

--- a/src/validation/nucleation/pbl_nuc_wang2008.cpp
+++ b/src/validation/nucleation/pbl_nuc_wang2008.cpp
@@ -1,0 +1,63 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <mam4xx/nucleation.hpp>
+
+#include <haero/constants.hpp>
+// #include <mam4xx/mam4_types.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+using namespace skywalker;
+using namespace mam4;
+using namespace haero;
+void pbl_nuc_wang2008(Ensemble *ensemble) {
+  ensemble->process([=](const Input &input, Output &output) {
+    // Ensemble parameters
+    // Declare array of strings for input names
+    std::string input_arrays[] = {"life",     "pbl_nuc_wang2008_actual",
+                                  "ratenucl", "rateloge",
+                                  "cnum_tot", "cnum_h2so4",
+                                  "cnum_nh3", "radius_cluster_nm"};
+
+    // Iterate over input_arrays and error if not in input
+    for (std::string name : input_arrays) {
+      if (!input.has_array(name.c_str())) {
+        std::cerr << "Required name for array: " << name << std::endl;
+        exit(1);
+      }
+    }
+
+    const Real life_ = input.get_array("life")[0];
+
+    const Real so4vol_ = input.get_array("so4vol")[0];
+    constexpr int pi_ = haero::pi;
+    const int pbl_nuc_wang2008_user_choice_ =
+        input.get_array("pbl_nuc_wang2008_user_choice")[0];
+    int pbl_nuc_wang2008_actual_ =
+        input.get_array("pbl_nuc_wang2008_actual")[0];
+    Real ratenucl_ = input.get_array("ratenucl")[0];
+    Real rateloge_ = input.get_array("rateloge")[0];
+    Real cnum_tot_ = input.get_array("cnum_tot")[0];
+    Real cnum_h2so4_ = input.get_array("cnum_h2so4")[0];
+    Real cnum_nh3_ = input.get_array("cnum_nh3")[0];
+    Real radius_cluster_nm_ = input.get_array("radius_cluster_nm")[0];
+
+    nucleation::pbl_nuc_wang2008(
+        so4vol_, pi_, pbl_nuc_wang2008_user_choice_,
+        adjust_factor_pbl_ratenucl_, pbl_nuc_wang2008_actual_, ratenucl_,
+        rateloge_, cnum_tot_, cnum_h2so4_, cnum_nh3_, radius_cluster_nm_);
+
+    output.set("ans", life);
+
+    output.set("pbl_nuc_wang2008_actual", pbl_nuc_wang2008_actual_out);
+    output.set("ratenucl", ratenucl_out);
+    output.set("rateloge", rateloge_out);
+    output.set("cnum_tot", cnum_tot_out);
+    output.set("cnum_h2so4", cnum_h2so4_out);
+    output.set("cnum_nh3", cnum_nh3_out);
+    output.set("radius_cluster_nm", radius_cluster_nm_out);
+  });
+}

--- a/src/validation/nucleation/pbl_nuc_wang2008.cpp
+++ b/src/validation/nucleation/pbl_nuc_wang2008.cpp
@@ -30,34 +30,34 @@ void pbl_nuc_wang2008(Ensemble *ensemble) {
       }
     }
 
-    const Real life_ = input.get_array("life")[0];
+    const Real life_ = input.get_array("")[0];
 
-    const Real so4vol_ = input.get_array("so4vol")[0];
-    constexpr int pi_ = haero::pi;
-    const int pbl_nuc_wang2008_user_choice_ =
-        input.get_array("pbl_nuc_wang2008_user_choice")[0];
-    int pbl_nuc_wang2008_actual_ =
-        input.get_array("pbl_nuc_wang2008_actual")[0];
-    Real ratenucl_ = input.get_array("ratenucl")[0];
-    Real rateloge_ = input.get_array("rateloge")[0];
-    Real cnum_tot_ = input.get_array("cnum_tot")[0];
-    Real cnum_h2so4_ = input.get_array("cnum_h2so4")[0];
-    Real cnum_nh3_ = input.get_array("cnum_nh3")[0];
-    Real radius_cluster_nm_ = input.get_array("radius_cluster_nm")[0];
+    // const Real so4vol_ = input.get_array("so4vol")[0];
+    // constexpr int pi_ = haero::pi;
+    // const int pbl_nuc_wang2008_user_choice_ =
+    //     input.get_array("pbl_nuc_wang2008_user_choice")[0];
+    // int pbl_nuc_wang2008_actual_ =
+    //     input.get_array("pbl_nuc_wang2008_actual")[0];
+    // Real ratenucl_ = input.get_array("ratenucl")[0];
+    // Real rateloge_ = input.get_array("rateloge")[0];
+    // Real cnum_tot_ = input.get_array("cnum_tot")[0];
+    // Real cnum_h2so4_ = input.get_array("cnum_h2so4")[0];
+    // Real cnum_nh3_ = input.get_array("cnum_nh3")[0];
+    // Real radius_cluster_nm_ = input.get_array("radius_cluster_nm")[0];
 
-    nucleation::pbl_nuc_wang2008(
-        so4vol_, pi_, pbl_nuc_wang2008_user_choice_,
-        adjust_factor_pbl_ratenucl_, pbl_nuc_wang2008_actual_, ratenucl_,
-        rateloge_, cnum_tot_, cnum_h2so4_, cnum_nh3_, radius_cluster_nm_);
+    // nucleation::pbl_nuc_wang2008(
+    //     so4vol_, pi_, pbl_nuc_wang2008_user_choice_,
+    //     adjust_factor_pbl_ratenucl_, pbl_nuc_wang2008_actual_, ratenucl_,
+    //     rateloge_, cnum_tot_, cnum_h2so4_, cnum_nh3_, radius_cluster_nm_);
 
     output.set("ans", life);
 
-    output.set("pbl_nuc_wang2008_actual", pbl_nuc_wang2008_actual_out);
-    output.set("ratenucl", ratenucl_out);
-    output.set("rateloge", rateloge_out);
-    output.set("cnum_tot", cnum_tot_out);
-    output.set("cnum_h2so4", cnum_h2so4_out);
-    output.set("cnum_nh3", cnum_nh3_out);
-    output.set("radius_cluster_nm", radius_cluster_nm_out);
+    // output.set("pbl_nuc_wang2008_actual", pbl_nuc_wang2008_actual_out);
+    // output.set("ratenucl", ratenucl_out);
+    // output.set("rateloge", rateloge_out);
+    // output.set("cnum_tot", cnum_tot_out);
+    // output.set("cnum_h2so4", cnum_h2so4_out);
+    // output.set("cnum_nh3", cnum_nh3_out);
+    // output.set("radius_cluster_nm", radius_cluster_nm_out);
   });
 }

--- a/src/validation/nucleation/pbl_nuc_wang2008.cpp
+++ b/src/validation/nucleation/pbl_nuc_wang2008.cpp
@@ -17,10 +17,15 @@ void pbl_nuc_wang2008(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
     // Ensemble parameters
     // Declare array of strings for input names
-    std::string input_arrays[] = {"life",     "pbl_nuc_wang2008_actual",
-                                  "ratenucl", "rateloge",
-                                  "cnum_tot", "cnum_h2so4",
-                                  "cnum_nh3", "radius_cluster_nm"};
+    std::string input_arrays[] = {"so4vol",
+                                  "newnuc_method_flagaa",
+                                  "newnuc_method_flagaa2",
+                                  "ratenucl",
+                                  "rateloge",
+                                  "cnum_tot",
+                                  "cnum_h2so4",
+                                  "cnum_nh3",
+                                  "radius_cluster"};
 
     // Iterate over input_arrays and error if not in input
     for (std::string name : input_arrays) {
@@ -30,27 +35,52 @@ void pbl_nuc_wang2008(Ensemble *ensemble) {
       }
     }
 
-    const Real life_ = input.get_array("")[0];
+    const Real adjust_factor_pbl_ratenucl_ = 1.0;
 
-    // const Real so4vol_ = input.get_array("so4vol")[0];
-    // constexpr int pi_ = haero::pi;
-    // const int pbl_nuc_wang2008_user_choice_ =
-    //     input.get_array("pbl_nuc_wang2008_user_choice")[0];
-    // int pbl_nuc_wang2008_actual_ =
-    //     input.get_array("pbl_nuc_wang2008_actual")[0];
-    // Real ratenucl_ = input.get_array("ratenucl")[0];
-    // Real rateloge_ = input.get_array("rateloge")[0];
-    // Real cnum_tot_ = input.get_array("cnum_tot")[0];
-    // Real cnum_h2so4_ = input.get_array("cnum_h2so4")[0];
-    // Real cnum_nh3_ = input.get_array("cnum_nh3")[0];
-    // Real radius_cluster_nm_ = input.get_array("radius_cluster_nm")[0];
+    const Real so4vol_ = input.get_array("so4vol")[0];
+    const int newnuc_method_flagaa_ =
+        input.get_array("newnuc_method_flagaa")[0];
+    int pbl_nuc_wang2008_actual_ = input.get_array("newnuc_method_flagaa2")[0];
+    Real ratenucl_ = input.get_array("ratenucl")[0];
+    Real rateloge_ = input.get_array("rateloge")[0];
+    Real cnum_tot_ = input.get_array("cnum_tot")[0];
+    Real cnum_h2so4_ = input.get_array("cnum_h2so4")[0];
+    Real cnum_nh3_ = input.get_array("cnum_nh3")[0];
+    Real radius_cluster_nm_ = input.get_array("radius_cluster")[0];
 
-    // nucleation::pbl_nuc_wang2008(
-    //     so4vol_, pi_, pbl_nuc_wang2008_user_choice_,
-    //     adjust_factor_pbl_ratenucl_, pbl_nuc_wang2008_actual_, ratenucl_,
-    //     rateloge_, cnum_tot_, cnum_h2so4_, cnum_nh3_, radius_cluster_nm_);
+    int pbl_nuc_wang2008_user_choice;
+    if (newnuc_method_flagaa_ == 11) {
+      pbl_nuc_wang2008_user_choice = 1;
+    } else if (newnuc_method_flagaa_ == 12) {
+      pbl_nuc_wang2008_user_choice = 2;
+    } else {
+      std::cerr << "Undefined value for parameter: newnuc_method_flagaa"
+                << std::endl;
+    }
 
-    output.set("ans", life);
+    nucleation::pbl_nuc_wang2008(
+        so4vol_, haero::Constants::pi, pbl_nuc_wang2008_user_choice,
+        adjust_factor_pbl_ratenucl_, pbl_nuc_wang2008_actual_, ratenucl_,
+        rateloge_, cnum_tot_, cnum_h2so4_, cnum_nh3_, radius_cluster_nm_);
+
+
+    int pbl_nuc_wang2008_actual_out;
+    if (pbl_nuc_wang2008_actual_ == 1) {
+      pbl_nuc_wang2008_actual_out = 11;
+    } else if (pbl_nuc_wang2008_actual_ == 2) {
+      pbl_nuc_wang2008_actual_out = 12;
+    } else {
+      std::cerr << "Undefined value for output: pbl_nuc_wang2008_actual"
+                << std::endl;
+    }
+
+    output.set("newnuc_method_flagaa2", pbl_nuc_wang2008_actual_out);
+    output.set("ratenucl", ratenucl_);
+    output.set("rateloge", rateloge_);
+    output.set("cnum_tot", cnum_tot_);
+    output.set("cnum_h2so4", cnum_h2so4_);
+    output.set("cnum_nh3", cnum_nh3_);
+    output.set("radius_cluster", radius_cluster_nm_);
 
     // output.set("pbl_nuc_wang2008_actual", pbl_nuc_wang2008_actual_out);
     // output.set("ratenucl", ratenucl_out);

--- a/src/validation/nucleation/pbl_nuc_wang2008.cpp
+++ b/src/validation/nucleation/pbl_nuc_wang2008.cpp
@@ -6,7 +6,6 @@
 #include <mam4xx/nucleation.hpp>
 
 #include <haero/constants.hpp>
-// #include <mam4xx/mam4_types.hpp>
 #include <skywalker.hpp>
 #include <validation.hpp>
 
@@ -38,7 +37,7 @@ void pbl_nuc_wang2008(Ensemble *ensemble) {
     const Real adjust_factor_pbl_ratenucl_ = 1.0;
 
     const Real so4vol_ = input.get_array("so4vol")[0];
-    const int newnuc_method_flagaa_ =
+    const int pbl_nuc_wang2008_user_choice_ =
         input.get_array("newnuc_method_flagaa")[0];
     int pbl_nuc_wang2008_actual_ = input.get_array("newnuc_method_flagaa2")[0];
     Real ratenucl_ = input.get_array("ratenucl")[0];
@@ -48,45 +47,17 @@ void pbl_nuc_wang2008(Ensemble *ensemble) {
     Real cnum_nh3_ = input.get_array("cnum_nh3")[0];
     Real radius_cluster_nm_ = input.get_array("radius_cluster")[0];
 
-    int pbl_nuc_wang2008_user_choice;
-    if (newnuc_method_flagaa_ == 11) {
-      pbl_nuc_wang2008_user_choice = 1;
-    } else if (newnuc_method_flagaa_ == 12) {
-      pbl_nuc_wang2008_user_choice = 2;
-    } else {
-      std::cerr << "Undefined value for parameter: newnuc_method_flagaa"
-                << std::endl;
-    }
-
     nucleation::pbl_nuc_wang2008(
-        so4vol_, haero::Constants::pi, pbl_nuc_wang2008_user_choice,
+        so4vol_, haero::Constants::pi, pbl_nuc_wang2008_user_choice_,
         adjust_factor_pbl_ratenucl_, pbl_nuc_wang2008_actual_, ratenucl_,
         rateloge_, cnum_tot_, cnum_h2so4_, cnum_nh3_, radius_cluster_nm_);
 
-    int pbl_nuc_wang2008_actual_out;
-    if (pbl_nuc_wang2008_actual_ == 1) {
-      pbl_nuc_wang2008_actual_out = 11;
-    } else if (pbl_nuc_wang2008_actual_ == 2) {
-      pbl_nuc_wang2008_actual_out = 12;
-    } else {
-      std::cerr << "Undefined value for output: pbl_nuc_wang2008_actual"
-                << std::endl;
-    }
-
-    output.set("newnuc_method_flagaa2", pbl_nuc_wang2008_actual_out);
+    output.set("newnuc_method_flagaa2", pbl_nuc_wang2008_actual_);
     output.set("ratenucl", ratenucl_);
     output.set("rateloge", rateloge_);
     output.set("cnum_tot", cnum_tot_);
     output.set("cnum_h2so4", cnum_h2so4_);
     output.set("cnum_nh3", cnum_nh3_);
     output.set("radius_cluster", radius_cluster_nm_);
-
-    // output.set("pbl_nuc_wang2008_actual", pbl_nuc_wang2008_actual_out);
-    // output.set("ratenucl", ratenucl_out);
-    // output.set("rateloge", rateloge_out);
-    // output.set("cnum_tot", cnum_tot_out);
-    // output.set("cnum_h2so4", cnum_h2so4_out);
-    // output.set("cnum_nh3", cnum_nh3_out);
-    // output.set("radius_cluster_nm", radius_cluster_nm_out);
   });
 }


### PR DESCRIPTION
This PR ports `mer07_veh02_nuc_mosaic_1box()` as the version coming from the MAM refactor repo--in contrast to the box-model version that was already present. A validation test is added for this function, as well as for `binary_nuc_vehk2002()` and `pbl_nuc_wang2008()`. 