### PR TITLE
Changes needed for microphysics branch

### DIFF
--- a/src/mam4xx/gas_chem.hpp
+++ b/src/mam4xx/gas_chem.hpp
@@ -243,7 +243,7 @@ void newton_raphson_iter(const Real dti, const Real lin_jac[nzcnt],
 KOKKOS_INLINE_FUNCTION
 void imp_sol(Real base_sol[gas_pcnst], // inout - species mixing ratios [vmr]
              const Real reaction_rates[rxntot], const Real het_rates[gas_pcnst],
-             const Real extfrc[extcnt], Real &delt,
+             const Real extfrc[extcnt], const Real &delt,
              const int permute_4[gas_pcnst], const int clsmap_4[gas_pcnst],
              const bool factor[itermax], Real epsilon[clscnt4],
              Real prod_out[clscnt4], Real loss_out[clscnt4]) {

--- a/src/mam4xx/gas_chem_mechanism.hpp
+++ b/src/mam4xx/gas_chem_mechanism.hpp
@@ -54,7 +54,7 @@ void set_rates(Real rxt_rates[rxntot], Real sol[gas_pcnst]) {
 } // set_rates
 
 KOKKOS_INLINE_FUNCTION
-void adjrxt(Real rate[rxntot], Real inv[nfs], Real m) {
+void adjrxt(Real rate[rxntot], const Real inv[nfs], const Real m) {
   rate[2] *= inv[4];
   rate[3] *= inv[4];
   rate[4] *= inv[4];


### PR DESCRIPTION
A few more changes are needed for the microphysics branch under EAMxx, which is currently pointing to this branch for the MAM4xx submodule.