### PR TITLE
Changes return type of linoz srf sink function from void to Real

### DIFF
--- a/src/mam4xx/lin_strat_chem.hpp
+++ b/src/mam4xx/lin_strat_chem.hpp
@@ -259,7 +259,7 @@ void lin_strat_chem_solve(
 } // lin_strat_chem_solve
 
 KOKKOS_INLINE_FUNCTION
-void lin_strat_sfcsink_kk(const Real delta_t, const Real pdel, // in
+Real lin_strat_sfcsink_kk(const Real delta_t, const Real pdel, // in
                           Real &o3l_vmr, const Real o3_sfc, const Real o3_tau,
                           Real &do3mass) {
   constexpr Real one = 1.0;
@@ -278,6 +278,7 @@ void lin_strat_sfcsink_kk(const Real delta_t, const Real pdel, // in
   o3l_vmr = o3l_old + do3;
   do3mass += do3 * mass * mwo3 / mwdry; // loss in kg/m2 summed over boundary
                                         // layers within one time step
+  return o3l_vmr;
 }
 
 KOKKOS_INLINE_FUNCTION
@@ -294,8 +295,8 @@ void lin_strat_sfcsink(const Real delta_t, const ColumnView &pdel, // in
 
   Real do3mass_icol = 0;
   for (int kk = pver - 1; kk > pver - o3_lbl - 1; --kk) {
-    lin_strat_sfcsink_kk(delta_t, pdel(kk), o3l_vmr(kk), o3_sfc, o3_tau,
-                         do3mass_icol);
+    o3l_vmr(kk) = lin_strat_sfcsink_kk(delta_t, pdel(kk), o3l_vmr(kk), o3_sfc,
+                                       o3_tau, do3mass_icol);
   }
 
   // Two parameters are applied to Linoz O3 for surface sink, O3l is not coupled

--- a/src/mam4xx/lin_strat_chem.hpp
+++ b/src/mam4xx/lin_strat_chem.hpp
@@ -260,7 +260,7 @@ void lin_strat_chem_solve(
 
 KOKKOS_INLINE_FUNCTION
 Real lin_strat_sfcsink_kk(const Real delta_t, const Real pdel, // in
-                          Real &o3l_vmr_in, const Real o3_sfc,
+                          const Real o3l_vmr_in, const Real o3_sfc,
                           const Real o3_tau, Real &do3mass) {
   constexpr Real one = 1.0;
   // BAD CONSTANT

--- a/src/mam4xx/lin_strat_chem.hpp
+++ b/src/mam4xx/lin_strat_chem.hpp
@@ -260,7 +260,7 @@ void lin_strat_chem_solve(
 
 KOKKOS_INLINE_FUNCTION
 Real lin_strat_sfcsink_kk(const Real delta_t, const Real pdel, // in
-                          Real &o3l_vmr, const Real o3_sfc, const Real o3_tau,
+                          Real &o3l_vmr_in, const Real o3_sfc, const Real o3_tau,
                           Real &do3mass) {
   constexpr Real one = 1.0;
   // BAD CONSTANT
@@ -273,9 +273,9 @@ Real lin_strat_sfcsink_kk(const Real delta_t, const Real pdel, // in
       (one - haero::exp(-delta_t / o3_tau));     // !compute time scale factor
                                                  //
   const Real mass = pdel * rgrav;                //   air mass in kg/m2
-  const Real o3l_old = o3l_vmr;                  // vmr
+  const Real o3l_old = o3l_vmr_in;                  // vmr
   const Real do3 = (o3_sfc - o3l_old) * efactor; // vmr
-  o3l_vmr = o3l_old + do3;
+  const Real o3l_vmr = o3l_old + do3;
   do3mass += do3 * mass * mwo3 / mwdry; // loss in kg/m2 summed over boundary
                                         // layers within one time step
   return o3l_vmr;

--- a/src/mam4xx/lin_strat_chem.hpp
+++ b/src/mam4xx/lin_strat_chem.hpp
@@ -260,8 +260,8 @@ void lin_strat_chem_solve(
 
 KOKKOS_INLINE_FUNCTION
 Real lin_strat_sfcsink_kk(const Real delta_t, const Real pdel, // in
-                          Real &o3l_vmr_in, const Real o3_sfc, const Real o3_tau,
-                          Real &do3mass) {
+                          Real &o3l_vmr_in, const Real o3_sfc,
+                          const Real o3_tau, Real &do3mass) {
   constexpr Real one = 1.0;
   // BAD CONSTANT
   constexpr Real mwo3 = 48.; // molecular weight O3
@@ -273,7 +273,7 @@ Real lin_strat_sfcsink_kk(const Real delta_t, const Real pdel, // in
       (one - haero::exp(-delta_t / o3_tau));     // !compute time scale factor
                                                  //
   const Real mass = pdel * rgrav;                //   air mass in kg/m2
-  const Real o3l_old = o3l_vmr_in;                  // vmr
+  const Real o3l_old = o3l_vmr_in;               // vmr
   const Real do3 = (o3_sfc - o3l_old) * efactor; // vmr
   const Real o3l_vmr = o3l_old + do3;
   do3mass += do3 * mass * mwo3 / mwdry; // loss in kg/m2 summed over boundary


### PR DESCRIPTION
The return type is changed so that the function's output is easy to see.