### PR TITLE
Implementing the find_season_index routine

### DIFF
--- a/src/mam4xx/mo_drydep.hpp
+++ b/src/mam4xx/mo_drydep.hpp
@@ -26,7 +26,7 @@ constexpr Real rair = 287.04;
 constexpr Real grav = 9.81;
 constexpr Real karman = 0.4;   // from shr_const_mod.F90
 constexpr Real tmelt = 273.15; // from shr_const_mod.F90 via physconst.F90
-constexpr Real r2d = 180.0 / haero::Constants::pi; // degrees to radians
+constexpr Real r2d = 180.0 / haero::Constants::pi; // radians to degrees
 // nddvels is equal to number of species in dry deposition list for gases.
 constexpr int nddvels = mam4::seq_drydep::n_drydep;
 

--- a/src/mam4xx/mo_drydep.hpp
+++ b/src/mam4xx/mo_drydep.hpp
@@ -44,26 +44,25 @@ constexpr int nddvels = mam4::seq_drydep::n_drydep;
  */
 
 using View1D = DeviceType::view_1d<Real>;
+using View1DInt = DeviceType::view_1d<int>;
 using View2DInt = DeviceType::view_2d<int>;
 using View3DInt = DeviceType::view_3d<int>;
 
 KOKKOS_INLINE_FUNCTION
-void find_season_index(const int plon, const View1D &clat,
+void find_season_index(const Real clat_j,
                        const View1D &lat_lai, const int nlat_lai,
                        const View3DInt &wk_lai,
-                       const View2DInt &index_season_lai) {
+                       const View1DInt &index_season_lai) {
 
   // Comment from Fortran code.
   /*For unstructured grids plon is the 1d horizontal grid size and plat=1
   ! So this code averages at the latitude of each grid point - not an ideal
   solution*/
-
-  for (int j = 0; j < plon; ++j) {
     // BAD CONSTANT
     Real diff_min = 10.0;
     int pos_min = -99;
     const Real target_lat =
-        clat(j) * r2d; // Using operator() for element access
+        clat_j * r2d; // Using operator() for element access
 
     for (int i = 0; i < nlat_lai; ++i) {
       Real current_diff = haero::abs(
@@ -99,9 +98,8 @@ void find_season_index(const int plon, const View1D &clat,
         }
       }
 
-      index_season_lai(j, m) = k_max; //
+      index_season_lai(m) = k_max; //
     }                                 // m
-  }                                   // j
 } // findSeasonIndex
 
 KOKKOS_INLINE_FUNCTION

--- a/src/mam4xx/mo_drydep.hpp
+++ b/src/mam4xx/mo_drydep.hpp
@@ -49,57 +49,54 @@ using View2DInt = DeviceType::view_2d<int>;
 using View3DInt = DeviceType::view_3d<int>;
 
 KOKKOS_INLINE_FUNCTION
-void find_season_index(const Real clat_j,
-                       const View1D &lat_lai, const int nlat_lai,
-                       const View3DInt &wk_lai,
+void find_season_index(const Real clat_j, const View1D &lat_lai,
+                       const int nlat_lai, const View3DInt &wk_lai,
                        const View1DInt &index_season_lai) {
 
   // Comment from Fortran code.
   /*For unstructured grids plon is the 1d horizontal grid size and plat=1
   ! So this code averages at the latitude of each grid point - not an ideal
   solution*/
-    // BAD CONSTANT
-    Real diff_min = 10.0;
-    int pos_min = -99;
-    const Real target_lat =
-        clat_j * r2d; // Using operator() for element access
+  // BAD CONSTANT
+  Real diff_min = 10.0;
+  int pos_min = -99;
+  const Real target_lat = clat_j * r2d; // Using operator() for element access
 
-    for (int i = 0; i < nlat_lai; ++i) {
-      Real current_diff = haero::abs(
-          lat_lai(i) - target_lat); // Using operator() for element access
-      if (current_diff < diff_min) {
-        diff_min = current_diff;
-        pos_min = i;
-      }
-    } // i
+  for (int i = 0; i < nlat_lai; ++i) {
+    Real current_diff = haero::abs(
+        lat_lai(i) - target_lat); // Using operator() for element access
+    if (current_diff < diff_min) {
+      diff_min = current_diff;
+      pos_min = i;
+    }
+  } // i
 
-    EKAT_KERNEL_ASSERT_MSG(pos_min > 0,
-                           "Error: dvel_inti: cannot find index.\n");
-    /* specify the season as the most frequent in the 11 vegetation classes
-   ! this was done to remove a banding problem in dvel (JFL Oct 04)*/
-    // BAD CONSTANT
-    for (int m = 0; m < 12; ++m) {
-      int num_seas[5] = {0, 0, 0, 0, 0};
-      for (int l = 0; l < 11; ++l) {
-        for (int k = 0; k < 5; ++k) {
-          if (wk_lai(pos_min, l, m) == k + 1) {
-            num_seas[k]++;
-            break; // Exit the innermost loop
-          }
-        }
-      }
-
-      int num_max = -1;
-      int k_max = 0;
+  EKAT_KERNEL_ASSERT_MSG(pos_min > 0, "Error: dvel_inti: cannot find index.\n");
+  /* specify the season as the most frequent in the 11 vegetation classes
+ ! this was done to remove a banding problem in dvel (JFL Oct 04)*/
+  // BAD CONSTANT
+  for (int m = 0; m < 12; ++m) {
+    int num_seas[5] = {0, 0, 0, 0, 0};
+    for (int l = 0; l < 11; ++l) {
       for (int k = 0; k < 5; ++k) {
-        if (num_seas[k] > num_max) {
-          num_max = num_seas[k];
-          k_max = k; //
+        if (wk_lai(pos_min, l, m) == k + 1) {
+          num_seas[k]++;
+          break; // Exit the innermost loop
         }
       }
+    }
 
-      index_season_lai(m) = k_max; //
-    }                                 // m
+    int num_max = -1;
+    int k_max = 0;
+    for (int k = 0; k < 5; ++k) {
+      if (num_seas[k] > num_max) {
+        num_max = num_seas[k];
+        k_max = k; //
+      }
+    }
+
+    index_season_lai(m) = k_max; //
+  }                              // m
 } // findSeasonIndex
 
 KOKKOS_INLINE_FUNCTION

--- a/src/mam4xx/mo_drydep.hpp
+++ b/src/mam4xx/mo_drydep.hpp
@@ -74,7 +74,7 @@ void find_season_index(const int plon, const View1D &clat,
       }
     } // i
 
-    EKAT_KERNEL_ASSERT_MSG(pos_min < 0,
+    EKAT_KERNEL_ASSERT_MSG(pos_min > 0,
                            "Error: dvel_inti: cannot find index.\n");
     /* specify the season as the most frequent in the 11 vegetation classes
    ! this was done to remove a banding problem in dvel (JFL Oct 04)*/

--- a/src/mam4xx/mo_drydep.hpp
+++ b/src/mam4xx/mo_drydep.hpp
@@ -48,9 +48,10 @@ using View2DInt = DeviceType::view_2d<int>;
 using View3DInt = DeviceType::view_3d<int>;
 
 KOKKOS_INLINE_FUNCTION
-void find_season_index(const int plon, const View1D &clat, const View1D &lat_lai,
-                     const int nlat_lai, const View3DInt &wk_lai,
-                     const View2DInt &index_season_lai) {
+void find_season_index(const int plon, const View1D &clat,
+                       const View1D &lat_lai, const int nlat_lai,
+                       const View3DInt &wk_lai,
+                       const View2DInt &index_season_lai) {
 
   // Comment from Fortran code.
   /*For unstructured grids plon is the 1d horizontal grid size and plat=1
@@ -98,7 +99,7 @@ void find_season_index(const int plon, const View1D &clat, const View1D &lat_lai
         }
       }
 
-      index_season_lai(j, m) = k_max; // Using operator() for setting values
+      index_season_lai(j, m) = k_max; //
     }                                 // m
   }                                   // j
 } // findSeasonIndex

--- a/src/validation/mo_drydep/CMakeLists.txt
+++ b/src/validation/mo_drydep/CMakeLists.txt
@@ -63,7 +63,7 @@ set(ERROR_THRESHOLDS
     ${DEFAULT_TOL} # calculate_uustar
     1e-9           # drydep_xactive
     ${DEFAULT_TOL} # calculate_gas_drydep_vlc_and_flux
-    ${DEFAULT_TOL} # drydep_inti_xactive_ts_0
+    0 # drydep_inti_xactive_ts_0
    )
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)

--- a/src/validation/mo_drydep/CMakeLists.txt
+++ b/src/validation/mo_drydep/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(mo_drydep_driver
                calculate_uustar.cpp
                drydep_xactive.cpp
                calculate_gas_drydep_vlc_and_flux.cpp
+               find_season_index.cpp
                )
 
 target_link_libraries(mo_drydep_driver skywalker;validation;${HAERO_LIBRARIES})
@@ -44,7 +45,8 @@ set(TEST_LIST
     calculate_ustar
     calculate_uustar
     drydep_xactive
-    calculate_gas_drydep_vlc_and_flux 
+    calculate_gas_drydep_vlc_and_flux
+    drydep_inti_xactive_ts_0
     )
 
 set(DEFAULT_TOL 1e-10)
@@ -61,6 +63,7 @@ set(ERROR_THRESHOLDS
     ${DEFAULT_TOL} # calculate_uustar
     1e-9           # drydep_xactive
     ${DEFAULT_TOL} # calculate_gas_drydep_vlc_and_flux
+    ${DEFAULT_TOL} # drydep_inti_xactive_ts_0
    )
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
@@ -104,5 +107,3 @@ set_tests_properties(run_${m4stand_compare} PROPERTIES LABELS ${TestLabels})
 add_test(validate_${m4stand_compare} python3 compare_mam4xx_mam4.py mam4xx_${m4stand_compare}.py m4stand_${m4stand_compare}.py True ${DEFAULT_TOL})
 set_tests_properties(run_${m4stand_compare} PROPERTIES LABELS "${TestLabels};compared2standalone")
 set_tests_properties(validate_${m4stand_compare} PROPERTIES LABELS "${TestLabels};compared2standalone")
-
-

--- a/src/validation/mo_drydep/find_season_index.cpp
+++ b/src/validation/mo_drydep/find_season_index.cpp
@@ -44,11 +44,11 @@ void find_season_index(Ensemble *ensemble) {
       }
     }
 
-    constexpr Real r2d = 180.0 / Constants::pi; // degrees to radians
+    constexpr Real r2d = 180.0 / Constants::pi; // radians to degrees
 
     View2DIntHost index_season_lai("index_season_lai", plon, 12);
 
-    // convert to radians
+    // convert to degrees
     for (int j = 0; j < plon; ++j) {
       clat(j) *= r2d;
     }

--- a/src/validation/mo_drydep/find_season_index.cpp
+++ b/src/validation/mo_drydep/find_season_index.cpp
@@ -1,0 +1,64 @@
+// mam4xx: Copyright (c) 2022,
+// Battelle Memorial Institute and
+// National Technology & Engineering Solutions of Sandia, LLC (NTESS)
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <mam4xx/mam4.hpp>
+#include <skywalker.hpp>
+#include <validation.hpp>
+
+using namespace skywalker;
+using namespace mam4;
+using namespace haero;
+
+void find_season_index(Ensemble *ensemble) {
+  ensemble->process([=](const Input &input, Output &output) {
+    // Assuming you have a way to get these from your input
+    using View2DInt = typename DeviceType::view_2d<int>;
+    using View3DInt = typename DeviceType::view_3d<int>;
+    using View1DHost = typename HostType::view_1d<Real>;
+    using View1D = typename DeviceType::view_1d<Real>;
+
+    auto clat_db = input.get_array("clat");
+    auto lat_lai_db = input.get_array("lat_lai");
+    auto wk_lai_db = input.get_array("wk_lai");
+
+    const int plon = clat_db.size();
+    View1D clat("clat", plon);
+    auto clat_host = View1DHost((Real *)clat_db.data(),plon );
+    Kokkos::deep_copy(clat, clat_host);
+
+    const int nlat_lai = lat_lai_db.size();
+    View1D lat_lai("lat_lai", nlat_lai);
+    auto lat_lai_host = View1DHost((Real *)lat_lai_db.data(),nlat_lai );
+    Kokkos::deep_copy(lat_lai, lat_lai_host);
+
+    const int npft_lai = 11;
+
+    View3DInt wk_lai("wk_lai",nlat_lai, npft_lai, 12 );
+    validation::convert_1d_vector_to_3d_view_int_device(wk_lai_db, wk_lai);
+
+    View2DInt index_season_lai("index_season_lai", plon, 12);
+    auto team_policy = ThreadTeamPolicy(plon, Kokkos::AUTO);
+    Kokkos::parallel_for(
+        team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
+      const int j = team.league_rank();
+      const auto index_season_lai_at_j = ekat::subview(index_season_lai,j);
+      mo_drydep::find_season_index(clat(j), lat_lai, nlat_lai, wk_lai, index_season_lai_at_j);
+
+    team.team_barrier();
+    // c++ to Fortran; only for validation.
+    Kokkos::parallel_for(
+      Kokkos::TeamVectorRange(team, index_season_lai_at_j.extent(0)), [&](int i) {
+              index_season_lai_at_j(i)=index_season_lai_at_j(i)+1;
+    });
+
+
+    });
+
+    std::vector<Real> index_season_lai_out(plon*12, 0.0);
+    mam4::validation::convert_2d_view_int_device_to_1d_vector(index_season_lai,
+                                                          index_season_lai_out);
+    output.set("index_season_lai", index_season_lai_out);
+  });
+}

--- a/src/validation/mo_drydep/find_season_index.cpp
+++ b/src/validation/mo_drydep/find_season_index.cpp
@@ -48,13 +48,17 @@ void find_season_index(Ensemble *ensemble) {
 
     View2DIntHost index_season_lai("index_season_lai", plon, 12);
 
+    // convert to radians
+    for (int j = 0; j < plon; ++j) {
+      clat(j) *= r2d;
+    }
+
+    mo_drydep::find_season_index(clat, lat_lai, nlat_lai, wk_lai,
+                                 index_season_lai);
+
     auto policy = KTH::RangePolicy(0, plon);
     Kokkos::parallel_for(policy, [&](const int &j) {
       const auto index_season_lai_at_j = ekat::subview(index_season_lai, j);
-      // convert to radians
-      const Real clat_rads = clat(j) * r2d;
-      mo_drydep::find_season_index(clat_rads, lat_lai, nlat_lai, wk_lai,
-                                   index_season_lai_at_j);
       // c++ to Fortran; only for validation.
       for (int i = 0; i < 12; ++i) {
         index_season_lai_at_j(i) = index_season_lai_at_j(i) + 1;

--- a/src/validation/mo_drydep/find_season_index.cpp
+++ b/src/validation/mo_drydep/find_season_index.cpp
@@ -25,40 +25,40 @@ void find_season_index(Ensemble *ensemble) {
 
     const int plon = clat_db.size();
     View1D clat("clat", plon);
-    auto clat_host = View1DHost((Real *)clat_db.data(),plon );
+    auto clat_host = View1DHost((Real *)clat_db.data(), plon);
     Kokkos::deep_copy(clat, clat_host);
 
     const int nlat_lai = lat_lai_db.size();
     View1D lat_lai("lat_lai", nlat_lai);
-    auto lat_lai_host = View1DHost((Real *)lat_lai_db.data(),nlat_lai );
+    auto lat_lai_host = View1DHost((Real *)lat_lai_db.data(), nlat_lai);
     Kokkos::deep_copy(lat_lai, lat_lai_host);
 
     const int npft_lai = 11;
 
-    View3DInt wk_lai("wk_lai",nlat_lai, npft_lai, 12 );
+    View3DInt wk_lai("wk_lai", nlat_lai, npft_lai, 12);
     validation::convert_1d_vector_to_3d_view_int_device(wk_lai_db, wk_lai);
 
     View2DInt index_season_lai("index_season_lai", plon, 12);
     auto team_policy = ThreadTeamPolicy(plon, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-      const int j = team.league_rank();
-      const auto index_season_lai_at_j = ekat::subview(index_season_lai,j);
-      mo_drydep::find_season_index(clat(j), lat_lai, nlat_lai, wk_lai, index_season_lai_at_j);
+          const int j = team.league_rank();
+          const auto index_season_lai_at_j = ekat::subview(index_season_lai, j);
+          mo_drydep::find_season_index(clat(j), lat_lai, nlat_lai, wk_lai,
+                                       index_season_lai_at_j);
 
-    team.team_barrier();
-    // c++ to Fortran; only for validation.
-    Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, index_season_lai_at_j.extent(0)), [&](int i) {
-              index_season_lai_at_j(i)=index_season_lai_at_j(i)+1;
-    });
+          team.team_barrier();
+          // c++ to Fortran; only for validation.
+          Kokkos::parallel_for(
+              Kokkos::TeamVectorRange(team, index_season_lai_at_j.extent(0)),
+              [&](int i) {
+                index_season_lai_at_j(i) = index_season_lai_at_j(i) + 1;
+              });
+        });
 
-
-    });
-
-    std::vector<Real> index_season_lai_out(plon*12, 0.0);
-    mam4::validation::convert_2d_view_int_device_to_1d_vector(index_season_lai,
-                                                          index_season_lai_out);
+    std::vector<Real> index_season_lai_out(plon * 12, 0.0);
+    mam4::validation::convert_2d_view_int_device_to_1d_vector(
+        index_season_lai, index_season_lai_out);
     output.set("index_season_lai", index_season_lai_out);
   });
 }

--- a/src/validation/mo_drydep/find_season_index.cpp
+++ b/src/validation/mo_drydep/find_season_index.cpp
@@ -14,51 +14,63 @@ using namespace haero;
 void find_season_index(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
     // Assuming you have a way to get these from your input
-    using View2DInt = typename DeviceType::view_2d<int>;
-    using View3DInt = typename DeviceType::view_3d<int>;
-    using View1DHost = typename HostType::view_1d<Real>;
-    using View1D = typename DeviceType::view_1d<Real>;
+    using KTH = ekat::KokkosTypes<ekat::HostDevice>;
+    using View2DIntHost = typename KTH::view_2d<int>;
+    using View3DIntHost = typename KTH::view_3d<int>;
+    using View1DHost = typename KTH::view_1d<Real>;
 
     auto clat_db = input.get_array("clat");
     auto lat_lai_db = input.get_array("lat_lai");
     auto wk_lai_db = input.get_array("wk_lai");
 
     const int plon = clat_db.size();
-    View1D clat("clat", plon);
-    auto clat_host = View1DHost((Real *)clat_db.data(), plon);
-    Kokkos::deep_copy(clat, clat_host);
+    View1DHost clat((Real *)clat_db.data(), plon);
 
     const int nlat_lai = lat_lai_db.size();
-    View1D lat_lai("lat_lai", nlat_lai);
-    auto lat_lai_host = View1DHost((Real *)lat_lai_db.data(), nlat_lai);
-    Kokkos::deep_copy(lat_lai, lat_lai_host);
+    View1DHost lat_lai((Real *)lat_lai_db.data(), nlat_lai);
 
     const int npft_lai = 11;
 
-    View3DInt wk_lai("wk_lai", nlat_lai, npft_lai, 12);
-    validation::convert_1d_vector_to_3d_view_int_device(wk_lai_db, wk_lai);
+    View3DIntHost wk_lai("wk_lai", nlat_lai, npft_lai, 12);
 
-    View2DInt index_season_lai("index_season_lai", plon, 12);
-    auto team_policy = ThreadTeamPolicy(plon, Kokkos::AUTO);
-    Kokkos::parallel_for(
-        team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          const int j = team.league_rank();
-          const auto index_season_lai_at_j = ekat::subview(index_season_lai, j);
-          mo_drydep::find_season_index(clat(j), lat_lai, nlat_lai, wk_lai,
-                                       index_season_lai_at_j);
+    int count = 0;
+    for (int d3 = 0; d3 < wk_lai.extent(2); ++d3) {
+      for (int d2 = 0; d2 < wk_lai.extent(1); ++d2) {
+        for (int d1 = 0; d1 < wk_lai.extent(0); ++d1) {
+          // make sure that we are using int.
+          wk_lai(d1, d2, d3) = static_cast<int>(wk_lai_db[count]);
+          count++;
+        }
+      }
+    }
 
-          team.team_barrier();
-          // c++ to Fortran; only for validation.
-          Kokkos::parallel_for(
-              Kokkos::TeamVectorRange(team, index_season_lai_at_j.extent(0)),
-              [&](int i) {
-                index_season_lai_at_j(i) = index_season_lai_at_j(i) + 1;
-              });
-        });
+    constexpr Real r2d = 180.0 / Constants::pi; // degrees to radians
+
+    View2DIntHost index_season_lai("index_season_lai", plon, 12);
+
+    auto policy = KTH::RangePolicy(0, plon);
+    Kokkos::parallel_for(policy, [&](const int &j) {
+      const auto index_season_lai_at_j = ekat::subview(index_season_lai, j);
+      // convert to radians
+      const Real clat_rads = clat(j) * r2d;
+      mo_drydep::find_season_index(clat_rads, lat_lai, nlat_lai, wk_lai,
+                                   index_season_lai_at_j);
+      // c++ to Fortran; only for validation.
+      for (int i = 0; i < 12; ++i) {
+        index_season_lai_at_j(i) = index_season_lai_at_j(i) + 1;
+      }
+    });
 
     std::vector<Real> index_season_lai_out(plon * 12, 0.0);
-    mam4::validation::convert_2d_view_int_device_to_1d_vector(
-        index_season_lai, index_season_lai_out);
+    count = 0;
+    for (int d2 = 0; d2 < 12; ++d2) {
+      for (int d1 = 0; d1 < plon; ++d1) {
+        // make sure that we are using int.
+        index_season_lai_out[count] = index_season_lai(d1, d2);
+        count++;
+      }
+    }
+
     output.set("index_season_lai", index_season_lai_out);
   });
 }

--- a/src/validation/mo_drydep/mo_drydep_driver.cpp
+++ b/src/validation/mo_drydep/mo_drydep_driver.cpp
@@ -35,6 +35,7 @@ void calculate_ustar_over_water(Ensemble *ensemble);
 void calculate_ustar(const DryDepData &data, Ensemble *ensemble);
 void calculate_uustar(const DryDepData &data, Ensemble *ensemble);
 void drydep_xactive(const DryDepData &data, Ensemble *ensemble);
+void find_season_index(Ensemble *ensemble);
 
 namespace {
 
@@ -272,6 +273,8 @@ int main(int argc, char **argv) {
         calculate_uustar(data, ensemble);
       } else if (func_name == "drydep_xactive") {
         drydep_xactive(data, ensemble);
+      } else if (func_name == "find_season_index") {
+        find_season_index(ensemble);
       } else {
         std::cerr << "Error: Function name '" << func_name
                   << "' does not have an implemented test!" << std::endl;

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -159,7 +159,7 @@ void convert_2d_view_device_to_1d_vector(const View2D &var_device,
 }
 
 void convert_2d_view_int_device_to_1d_vector(const View2DInt &var_device,
-                                         std::vector<Real> &var_std) {
+                                             std::vector<Real> &var_std) {
   auto host = Kokkos::create_mirror_view(var_device);
   Kokkos::deep_copy(host, var_device);
   int count = 0;
@@ -200,7 +200,7 @@ void convert_1d_vector_to_3d_view_device(const std::vector<Real> &var_std,
 }
 
 void convert_1d_vector_to_3d_view_int_device(const std::vector<Real> &var_std,
-                                         const View3DInt &var_device) {
+                                             const View3DInt &var_device) {
   auto host = Kokkos::create_mirror_view(var_device);
   int count = 0;
   for (int d3 = 0; d3 < var_device.extent(2); ++d3) {
@@ -214,7 +214,6 @@ void convert_1d_vector_to_3d_view_int_device(const std::vector<Real> &var_std,
   }
   Kokkos::deep_copy(var_device, host);
 }
-
 
 void convert_3d_view_device_to_1d_vector(const View3D &var_device,
                                          std::vector<Real> &var_std) {

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -158,6 +158,19 @@ void convert_2d_view_device_to_1d_vector(const View2D &var_device,
   }
 }
 
+void convert_2d_view_int_device_to_1d_vector(const View2DInt &var_device,
+                                         std::vector<Real> &var_std) {
+  auto host = Kokkos::create_mirror_view(var_device);
+  Kokkos::deep_copy(host, var_device);
+  int count = 0;
+  for (int d2 = 0; d2 < var_device.extent(1); ++d2) {
+    for (int d1 = 0; d1 < var_device.extent(0); ++d1) {
+      var_std[count] = host(d1, d2);
+      count++;
+    }
+  }
+}
+
 void convert_transpose_2d_view_device_to_1d_vector(const View2D &var_device,
                                                    std::vector<Real> &var_std) {
   auto host = Kokkos::create_mirror_view(var_device);
@@ -185,6 +198,23 @@ void convert_1d_vector_to_3d_view_device(const std::vector<Real> &var_std,
   }
   Kokkos::deep_copy(var_device, host);
 }
+
+void convert_1d_vector_to_3d_view_int_device(const std::vector<Real> &var_std,
+                                         const View3DInt &var_device) {
+  auto host = Kokkos::create_mirror_view(var_device);
+  int count = 0;
+  for (int d3 = 0; d3 < var_device.extent(2); ++d3) {
+    for (int d2 = 0; d2 < var_device.extent(1); ++d2) {
+      for (int d1 = 0; d1 < var_device.extent(0); ++d1) {
+        // make sure that we are using int.
+        host(d1, d2, d3) = static_cast<int>(var_std[count]);
+        count++;
+      }
+    }
+  }
+  Kokkos::deep_copy(var_device, host);
+}
+
 
 void convert_3d_view_device_to_1d_vector(const View3D &var_device,
                                          std::vector<Real> &var_std) {

--- a/src/validation/validation.hpp
+++ b/src/validation/validation.hpp
@@ -28,6 +28,8 @@ Tendencies create_tendencies(int num_levels);
 
 namespace validation {
 
+using View3DInt = typename DeviceType::view_3d<int>;
+using View2DInt = typename DeviceType::view_2d<int>;
 using View2D = typename DeviceType::view_2d<Real>;
 using View3D = typename DeviceType::view_3d<Real>;
 
@@ -92,6 +94,8 @@ void convert_1d_vector_to_transpose_2d_view_device(
 void convert_2d_view_device_to_1d_vector(const View2D &var_device,
                                          std::vector<Real> &var_std);
 
+void convert_2d_view_int_device_to_1d_vector(const View2DInt &var_device,
+                                         std::vector<Real> &var_std);
 // Convert 2D view_device to 1D std::vector
 // create a mirror view of 2d_view_device. Then, it copies data from mirror view
 // to 1D std::vector using column-major order
@@ -109,6 +113,9 @@ void convert_1d_vector_to_3d_view_device(const std::vector<Real> &pmid_db,
 // to 1D std::vector
 void convert_3d_view_device_to_1d_vector(const View3D &var_device,
                                          std::vector<Real> &var_std);
+
+void convert_1d_vector_to_3d_view_int_device(const std::vector<Real> &var_std,
+                                         const View3DInt &var_device);
 
 // Given an input from skywalker and its name, return a ColumnView with data
 // from yaml file.

--- a/src/validation/validation.hpp
+++ b/src/validation/validation.hpp
@@ -95,7 +95,7 @@ void convert_2d_view_device_to_1d_vector(const View2D &var_device,
                                          std::vector<Real> &var_std);
 
 void convert_2d_view_int_device_to_1d_vector(const View2DInt &var_device,
-                                         std::vector<Real> &var_std);
+                                             std::vector<Real> &var_std);
 // Convert 2D view_device to 1D std::vector
 // create a mirror view of 2d_view_device. Then, it copies data from mirror view
 // to 1D std::vector using column-major order
@@ -115,7 +115,7 @@ void convert_3d_view_device_to_1d_vector(const View3D &var_device,
                                          std::vector<Real> &var_std);
 
 void convert_1d_vector_to_3d_view_int_device(const std::vector<Real> &var_std,
-                                         const View3DInt &var_device);
+                                             const View3DInt &var_device);
 
 // Given an input from skywalker and its name, return a ColumnView with data
 // from yaml file.


### PR DESCRIPTION
Implementing the find_season_index routine to encapsulate the interpolation of the season_wes.nc file, from [line 267](https://github.com/eagles-project/e3sm_mam4_refactor/blob/599e772e34a0a32dacadc40688fd091e1f532d76/components/eam/src/chemistry/mozart/mo_drydep.F90#L267) to  [line 318](https://github.com/eagles-project/e3sm_mam4_refactor/blob/599e772e34a0a32dacadc40688fd091e1f532d76/components/eam/src/chemistry/mozart/mo_drydep.F90#L318).

This function is only invoked during initialization and has a small kernel. Thus, only a host version was implemented.

One validation test is implemented, and it is passing with a relative error tolerance of 0. Note that the output of the function (`index_season_lai`) consists of integers. Thus, an error of 0 is required to pass this test.
