### PR TITLE
Avoid race conditions in the mo_photo functions.

### DIFF
--- a/src/mam4xx/mo_gas_phase_chemdr.hpp
+++ b/src/mam4xx/mo_gas_phase_chemdr.hpp
@@ -109,7 +109,7 @@ void perform_atmospheric_chemistry_and_microphysics(
                                               work_photo_table_icol,   // in
                                               photo_work_arrays_icol); // out
 
-  mam4::mo_photo::table_photo(photo_rates_icol,                          // out
+  mam4::mo_photo::table_photo(team, photo_rates_icol,                          // out
                               atm.pressure, atm.hydrostatic_dp,          // in
                               atm.temperature, o3_col_dens_i,            // in
                               zenith_angle_icol, d_sfc_alb_dir_vis_icol, // in

--- a/src/mam4xx/mo_gas_phase_chemdr.hpp
+++ b/src/mam4xx/mo_gas_phase_chemdr.hpp
@@ -109,7 +109,7 @@ void perform_atmospheric_chemistry_and_microphysics(
                                               work_photo_table_icol,   // in
                                               photo_work_arrays_icol); // out
 
-  mam4::mo_photo::table_photo(team, photo_rates_icol,                          // out
+  mam4::mo_photo::table_photo(team, photo_rates_icol,                    // out
                               atm.pressure, atm.hydrostatic_dp,          // in
                               atm.temperature, o3_col_dens_i,            // in
                               zenith_angle_icol, d_sfc_alb_dir_vis_icol, // in

--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -132,7 +132,8 @@ void set_photo_table_work_arrays(const PhotoTableData &photo_table_data,
 } // set_photo_table_work_arrays
 
 KOKKOS_INLINE_FUNCTION
-void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
+void cloud_mod(const ThreadTeam &team,
+               const Real zen_angle, const Real *clouds, const Real *lwc,
                const Real *delp,
                const Real srf_alb, //  in
                Real *eff_alb, Real *cld_mult) {
@@ -152,10 +153,12 @@ void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
         ... modify lwc for cloud fraction and form
             liquid water path and tau for each layer
   ---------------------------------------------------------*/
-  const Real zero = 0.0;
-  const Real thousand = 1000.0;
-  const Real one = 1;
-  const Real half = 0.5;
+  constexpr Real zero = 0.0;
+  constexpr Real thousand = 1000.0;
+  constexpr Real one = 1;
+  constexpr Real half = 0.5;
+  constexpr int pver_local=pver;
+  constexpr int pverm_local = pverm;
 
   // cloud optical depth in each layer
   Real del_tau[pver] = {};
@@ -170,7 +173,8 @@ void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
       .155; // factor converting LWP to tau [unknown source and unit]
   const Real tau_min = 5.0; // tau threshold below which assign cloud as zero
 
-  for (int kk = 0; kk < pver; kk++) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver_local),
+                           [&](int kk) {
     if (clouds[kk] != zero) {
       // liquid water path in each layer [g/m2]
       const Real del_lwp = rgrav * lwc[kk] * delp[kk] * thousand /
@@ -179,7 +183,8 @@ void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
     } else {
       del_tau[kk] = zero;
     } // end if
-  }   // end kk
+  });   // end kk
+
   /*---------------------------------------------------------
               ... form integrated tau and cloud cover from top down
   --------------------------------------------------------- */
@@ -188,11 +193,13 @@ void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
   // cloud cover above this layer
   Real above_cld[pver] = {zero};
 
+  team.team_barrier();
   for (int kk = 0; kk < pverm; kk++) {
     above_tau[kk + 1] = del_tau[kk] + above_tau[kk];
     above_cld[kk + 1] = clouds[kk] * del_tau[kk] + above_cld[kk];
 
-  } // end kk
+  }; // end kk
+  team.team_barrier();
 
   for (int kk = 1; kk < pver; kk++) {
     if (above_tau[kk] != zero) {
@@ -200,7 +207,8 @@ void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
     } else {
       above_cld[kk] = above_cld[kk - 1];
     }
-  } // end kk
+  }; // end kk
+
 
   /*---------------------------------------------------------
               ... form integrated tau and cloud cover from bottom up
@@ -208,11 +216,20 @@ void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
 
   below_tau[pver - 1] = zero;
   below_cld[pver - 1] = zero;
+  team.team_barrier();
 
+  Kokkos::single(Kokkos::PerTeam(team),
+                       [&]() {
   for (int kk = pverm - 1; kk > -1; kk--) {
     below_tau[kk] = del_tau[kk + 1] + below_tau[kk + 1];
     below_cld[kk] = clouds[kk + 1] * del_tau[kk + 1] + below_cld[kk + 1];
   } // end kk
+  });
+  team.team_barrier();
+
+
+  Kokkos::single(Kokkos::PerTeam(team),
+                       [&]() {
 
   for (int kk = pverm - 1; kk > -1; kk--) {
     if (below_tau[kk] != zero) {
@@ -222,10 +239,14 @@ void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
     } // end if
 
   } // end kk
+                       });
+  team.team_barrier();
 
   /*---------------------------------------------------------
       ... modify above_tau and below_tau via jfm
   ---------------------------------------------------------*/
+  Kokkos::single(Kokkos::PerTeam(team),
+                       [&]() {
   for (int kk = 1; kk < pver; kk++) {
     if (above_cld[kk] != zero) {
       above_tau[kk] /= above_cld[kk];
@@ -237,6 +258,11 @@ void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
 
   } // end kk
 
+                       });
+team.team_barrier();
+  Kokkos::single(Kokkos::PerTeam(team),
+                       [&]() {
+
   for (int kk = 0; kk < pverm; kk++) {
     if (below_cld[kk] != zero) {
       below_tau[kk] /= below_cld[kk];
@@ -246,6 +272,7 @@ void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
     } // end if
 
   } // end kk
+                       });
 
   /*---------------------------------------------------------
       ... form transmission factors
@@ -257,8 +284,10 @@ void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
 
   // cos (solar zenith angle)
   const Real coschi = haero::max(haero::cos(zen_angle), half);
-
-  for (int kk = 0; kk < pver; kk++) {
+   team.team_barrier();
+  // for (int kk = 0; kk < pver; kk++) {
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver_local),
+                           [&](int kk) {
 
     /*---------------------------------------------------------
       ... form effective albedo
@@ -287,7 +316,7 @@ void cloud_mod(const Real zen_angle, const Real *clouds, const Real *lwc,
     // BAD CONSTANT
     cld_mult[kk] =
         haero::max(.05, one + fac1 * clouds[kk] + fac2 * above_cld[kk]);
-  } // end kk
+  }); // end kk
 
 } // end cloud_mod
 
@@ -740,6 +769,7 @@ void table_photo(const ThreadTeam &team, const View2D &photo, // out
   constexpr Real r2d = 180.0 / haero::Constants::pi; // degrees to radians
   // BAD CONSTANT
   constexpr Real max_zen_angle = 88.85; //  degrees
+  constexpr int pver_local = pver;
 
   // vertical pressure array [hPa]
   Real parg[pver] = {};
@@ -755,14 +785,15 @@ void table_photo(const ThreadTeam &team, const View2D &photo, // out
     /*-----------------------------------------------------------------
          ... compute eff_alb and cld_mult -- needs to be before jlong
     -----------------------------------------------------------------*/
-    cloud_mod(zen_angle, clouds.data(), lwc.data(), pdel.data(),
+    cloud_mod(team, zen_angle, clouds.data(), lwc.data(), pdel.data(),
               srf_alb, //  in
               eff_alb, cld_mult);
 
-    for (int kk = 0; kk < pver; ++kk) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver_local),
+                         [&](int kk) {
       parg[kk] = pmid(kk) * Pa2mb;
       cld_mult[kk] *= esfact;
-    } // kk
+    }); // kk
     /*-----------------------------------------------------------------
      ... long wave length component
     -----------------------------------------------------------------*/
@@ -782,17 +813,19 @@ void table_photo(const ThreadTeam &team, const View2D &photo, // out
           work_arrays.rsf, work_arrays.xswk, work_arrays.psum_l.data(),
           work_arrays.psum_u.data());
 
-    for (int mm = 0; mm < phtcnt; ++mm) {
+    team.team_barrier();
+    Kokkos::parallel_for(
+      Kokkos::TeamThreadRange(team, phtcnt), [&](int mm) {
       if (table_data.lng_indexer(mm) > -1) {
-        for (int kk = 0; kk < pver; ++kk) {
+      Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, pver), [&](int kk) {
           photo(kk, mm) =
               cld_mult[kk] *
               (photo(kk, mm) +
                table_data.pht_alias_mult_1(mm) *
                    work_arrays.lng_prates(table_data.lng_indexer(mm), kk));
-        } // end kk
+        }); // end kk
       }   // end if
-    }     // end mm
+    });     // end mm
   }
 
   // } // end col_loop

--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -542,9 +542,10 @@ void interpolate_rsf(const ThreadTeam &team, const Real *alb_in,
      -- nm)
        ... --> convert to photons/cm^2/s
      ------------------------------------------------------------------------------*/
+    team.team_barrier();
     for (int wn = 0; wn < nw; wn++) {
       Kokkos::single(Kokkos::PerTeam(team),
-                     [&]() { rsf(wn, kk) *= etfphot[wn]; });
+                     [=]() { rsf(wn, kk) *= etfphot[wn]; });
 
     } // end for wn
 

--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -760,12 +760,9 @@ void table_photo(const ThreadTeam &team, const View2D &photo, // out
               srf_alb, //  in
               eff_alb, cld_mult);
     for (int kk = 0; kk < pver; kk++) {
-      // Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver_local),
-      //                      [&](int kk) {
       parg[kk] = pmid(kk) * Pa2mb;
       cld_mult[kk] *= esfact;
     }
-    // ); // kk
     /*-----------------------------------------------------------------
      ... long wave length component
     -----------------------------------------------------------------*/

--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -633,8 +633,11 @@ void jlong( const ThreadTeam &team,const Real sza_in, const Real *alb_in, const 
    150 to 350 degrees K.  Make sure the index is a value
    between 1 and 201.
   ------------------------------------------------------------------------------*/
-
-  for (int kk = 0; kk < pver; kk++) {
+  // To avoid the 'pver is undefined' error during CUDA code compilation.
+  constexpr int pver_local = pver;
+  team.team_barrier();
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver_local),
+                         [&](int kk) {
     /*----------------------------------------------------------------------
       ... get index into xsqy
      ----------------------------------------------------------------------*/
@@ -695,7 +698,7 @@ void jlong( const ThreadTeam &team,const Real sza_in, const Real *alb_in, const 
       } // wn
       j_long(i, kk) = suma;
     } // i
-  }   // end kk
+  });   // end kk
 
 } // jlong
 

--- a/src/validation/mo_photo/cloud_mod.cpp
+++ b/src/validation/mo_photo/cloud_mod.cpp
@@ -28,32 +28,30 @@ void cloud_mod(Ensemble *ensemble) {
     const auto srf_alb = input.get_array("srf_alb")[0];
     // const auto  = input.get_array("");
     constexpr Real zero = 0;
-    std::cout << "clouds_db.size() " << clouds_db.size()<< "\n";
-
-    auto clouds_host = View1DHost((Real *)clouds_db.data(), clouds_db.size());
-    View1D clouds("clouds", clouds_db.size());
+    auto clouds_host = View1DHost((Real *)clouds_db.data(), pver);
+    View1D clouds("clouds", pver);
     Kokkos::deep_copy(clouds, clouds_host);
 
-    auto lwc_host = View1DHost((Real *)lwc_db.data(), lwc_db.size());
-    const auto lwc = View1D("lwc", lwc_db.size());
+    auto lwc_host = View1DHost((Real *)lwc_db.data(), pver);
+    const auto lwc = View1D("lwc", pver);
     Kokkos::deep_copy(lwc, lwc_host);
 
-    auto delp_host = View1DHost((Real *)delp_db.data(), delp_db.size());
-    const auto delp = View1D("delp", delp_db.size());
+    auto delp_host = View1DHost((Real *)delp_db.data(), pver);
+    const auto delp = View1D("delp", pver);
     Kokkos::deep_copy(delp, delp_host);
 
     View1D eff_alb("eff_alb", pver);
     View1D cld_mult("cld_mult", pver);
 
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
-#if 1
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-    cloud_mod(team, zen_angle, clouds.data(), lwc.data(), delp.data(),
+    cloud_mod(
+       zen_angle, clouds, lwc, delp,
               srf_alb, //  in
               eff_alb.data(), cld_mult.data());
+
     });
-#endif
     std::vector<Real> eff_alb_db(pver, zero);
     std::vector<Real> cld_mult_db(pver, zero);
 

--- a/src/validation/mo_photo/cloud_mod.cpp
+++ b/src/validation/mo_photo/cloud_mod.cpp
@@ -15,7 +15,6 @@ using namespace haero;
 using namespace mo_photo;
 void cloud_mod(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
-
     using View1DHost = typename HostType::view_1d<Real>;
     using View1D = typename DeviceType::view_1d<Real>;
 
@@ -46,12 +45,10 @@ void cloud_mod(Ensemble *ensemble) {
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-    cloud_mod(
-       zen_angle, clouds, lwc, delp,
-              srf_alb, //  in
-              eff_alb.data(), cld_mult.data());
-
-    });
+          cloud_mod(zen_angle, clouds, lwc, delp,
+                    srf_alb, //  in
+                    eff_alb.data(), cld_mult.data());
+        });
     std::vector<Real> eff_alb_db(pver, zero);
     std::vector<Real> cld_mult_db(pver, zero);
 
@@ -59,7 +56,6 @@ void cloud_mod(Ensemble *ensemble) {
     auto cld_mult_host = View1DHost((Real *)cld_mult_db.data(), pver);
     Kokkos::deep_copy(eff_alb_host, eff_alb);
     Kokkos::deep_copy(cld_mult_host, cld_mult);
-
 
     output.set("eff_alb", eff_alb_db);
     output.set("cld_mult", cld_mult_db);

--- a/src/validation/mo_photo/cloud_mod.cpp
+++ b/src/validation/mo_photo/cloud_mod.cpp
@@ -15,24 +15,55 @@ using namespace haero;
 using namespace mo_photo;
 void cloud_mod(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
+
+    using View1DHost = typename HostType::view_1d<Real>;
+    using View1D = typename DeviceType::view_1d<Real>;
+
     // number of vertical points.
     // validation test from standalone mo_photo.
     const auto zen_angle = input.get_array("zen_angle")[0];
-    const auto clouds = input.get_array("clouds");
-    const auto lwc = input.get_array("lwc");
-    const auto delp = input.get_array("delp");
+    const auto clouds_db = input.get_array("clouds");
+    const auto lwc_db = input.get_array("lwc");
+    const auto delp_db = input.get_array("delp");
     const auto srf_alb = input.get_array("srf_alb")[0];
     // const auto  = input.get_array("");
-    const Real zero = 0;
+    constexpr Real zero = 0;
+    std::cout << "clouds_db.size() " << clouds_db.size()<< "\n";
 
-    std::vector<Real> eff_alb(pver, zero);
-    std::vector<Real> cld_mult(pver, zero);
+    auto clouds_host = View1DHost((Real *)clouds_db.data(), clouds_db.size());
+    View1D clouds("clouds", clouds_db.size());
+    Kokkos::deep_copy(clouds, clouds_host);
 
-    cloud_mod(zen_angle, clouds.data(), lwc.data(), delp.data(),
+    auto lwc_host = View1DHost((Real *)lwc_db.data(), lwc_db.size());
+    const auto lwc = View1D("lwc", lwc_db.size());
+    Kokkos::deep_copy(lwc, lwc_host);
+
+    auto delp_host = View1DHost((Real *)delp_db.data(), delp_db.size());
+    const auto delp = View1D("delp", delp_db.size());
+    Kokkos::deep_copy(delp, delp_host);
+
+    View1D eff_alb("eff_alb", pver);
+    View1D cld_mult("cld_mult", pver);
+
+    auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
+#if 1
+    Kokkos::parallel_for(
+        team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
+    cloud_mod(team, zen_angle, clouds.data(), lwc.data(), delp.data(),
               srf_alb, //  in
               eff_alb.data(), cld_mult.data());
+    });
+#endif
+    std::vector<Real> eff_alb_db(pver, zero);
+    std::vector<Real> cld_mult_db(pver, zero);
 
-    output.set("eff_alb", eff_alb);
-    output.set("cld_mult", cld_mult);
+    auto eff_alb_host = View1DHost((Real *)eff_alb_db.data(), pver);
+    auto cld_mult_host = View1DHost((Real *)cld_mult_db.data(), pver);
+    Kokkos::deep_copy(eff_alb_host, eff_alb);
+    Kokkos::deep_copy(cld_mult_host, cld_mult);
+
+
+    output.set("eff_alb", eff_alb_db);
+    output.set("cld_mult", cld_mult_db);
   });
 }

--- a/src/validation/mo_photo/interpolate_rsf.cpp
+++ b/src/validation/mo_photo/interpolate_rsf.cpp
@@ -108,10 +108,10 @@ void interpolate_rsf(Ensemble *ensemble) {
     auto psum_u = View1D("psum_u", nw);
 
     View2D rsf("rsf", nw, pver);
-    auto team_policy = ThreadTeamPolicy(1u, 1u);
+    auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          interpolate_rsf(alb_in.data(), sza_in, p_in.data(), colo3_in.data(),
+          interpolate_rsf(team, alb_in.data(), sza_in, p_in.data(), colo3_in.data(),
                           pver, //  in
                           sza.data(), del_sza.data(), alb.data(), press.data(),
                           del_p.data(), colo3.data(), o3rat.data(),

--- a/src/validation/mo_photo/interpolate_rsf.cpp
+++ b/src/validation/mo_photo/interpolate_rsf.cpp
@@ -111,7 +111,8 @@ void interpolate_rsf(Ensemble *ensemble) {
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          interpolate_rsf(team, alb_in.data(), sza_in, p_in.data(), colo3_in.data(),
+          interpolate_rsf(team, alb_in.data(), sza_in, p_in.data(),
+                          colo3_in.data(),
                           pver, //  in
                           sza.data(), del_sza.data(), alb.data(), press.data(),
                           del_p.data(), colo3.data(), o3rat.data(),

--- a/src/validation/mo_photo/jlong.cpp
+++ b/src/validation/mo_photo/jlong.cpp
@@ -141,7 +141,7 @@ void jlong(Ensemble *ensemble) {
     auto team_policy = ThreadTeamPolicy(1u, 1u);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          jlong(sza_in, alb_in.data(), p_in.data(), t_in.data(),
+          jlong(team, sza_in, alb_in.data(), p_in.data(), t_in.data(),
                 colo3_in.data(), xsqy, sza.data(), del_sza.data(), alb.data(),
                 press.data(), del_p.data(), colo3.data(), o3rat.data(),
                 del_alb.data(), del_o3rat.data(), etfphot.data(),

--- a/src/validation/mo_photo/table_photo.cpp
+++ b/src/validation/mo_photo/table_photo.cpp
@@ -149,7 +149,7 @@ void table_photo(Ensemble *ensemble) {
     Kokkos::deep_copy(srf_alb, srf_alb_host);
     Kokkos::deep_copy(zen_angle, zen_angle_host);
 
-    auto team_policy = ThreadTeamPolicy(ncol, Kokkos::AUTO );
+    auto team_policy = ThreadTeamPolicy(ncol, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
           const int i = team.league_rank();

--- a/src/validation/mo_photo/table_photo.cpp
+++ b/src/validation/mo_photo/table_photo.cpp
@@ -149,7 +149,7 @@ void table_photo(Ensemble *ensemble) {
     Kokkos::deep_copy(srf_alb, srf_alb_host);
     Kokkos::deep_copy(zen_angle, zen_angle_host);
 
-    auto team_policy = ThreadTeamPolicy(ncol, 7 );
+    auto team_policy = ThreadTeamPolicy(ncol, Kokkos::AUTO );
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
           const int i = team.league_rank();

--- a/src/validation/mo_photo/table_photo.cpp
+++ b/src/validation/mo_photo/table_photo.cpp
@@ -149,7 +149,7 @@ void table_photo(Ensemble *ensemble) {
     Kokkos::deep_copy(srf_alb, srf_alb_host);
     Kokkos::deep_copy(zen_angle, zen_angle_host);
 
-    auto team_policy = ThreadTeamPolicy(ncol, 1u);
+    auto team_policy = ThreadTeamPolicy(ncol, 7 );
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
           const int i = team.league_rank();
@@ -173,7 +173,7 @@ void table_photo(Ensemble *ensemble) {
           work_arrays.psum_l = Kokkos::subview(psum_l, i, Kokkos::ALL());
           work_arrays.psum_u = Kokkos::subview(psum_u, i, Kokkos::ALL());
 
-          table_photo(photo_icol, // out
+          table_photo(team, photo_icol, // out
                       pmid_icol, pdel_icol,
                       temper_icol, // in
                       colo3_in_icol, zen_angle(i), srf_alb(i), lwc_icol,


### PR DESCRIPTION
We were encountering an FPE in the pm-gpu configuration of eamxx in [PR 3013](https://github.com/E3SM-Project/scream/pull/3013). To fix this issue, we made the necessary changes to avoid race conditions. However, the mo_photo function will need further modifications to fully utilize parallelism from GPUs.