### PR TITLE
Change `aero_model_wetdep()` Signature to Correspond to EAMxx Interface

### DIFF
--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -307,7 +307,7 @@ void sethet_detail(
                        [&](int kk) {
                          for (int mm = 0; mm < gas_wetdep_cnt; mm++) {
                            const int mm2 = wetdep_map[mm];
-                           if (mm2 > 0)
+                           if (mm2 >= 0)
                              het_rates(kk, mm2) = MISSING;
                          }
                        });
@@ -477,7 +477,7 @@ void sethet_detail(
   //	... Set rates above tropopause = 0.
   //-----------------------------------------------------------------
   team.team_barrier();
-  Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, ktop), [&](int kk) {
+  Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, ktop + 1), [&](int kk) {
     for (int mm = 0; mm < gas_wetdep_cnt; mm++)
       het_rates(kk, wetdep_map[mm]) = 0.0;
   });

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -307,7 +307,7 @@ void sethet_detail(
                        [&](int kk) {
                          for (int mm = 0; mm < gas_wetdep_cnt; mm++) {
                            const int mm2 = wetdep_map[mm];
-                           if (mm2 >= 0)
+                           if (mm2 > 0)
                              het_rates(kk, mm2) = MISSING;
                          }
                        });
@@ -477,7 +477,7 @@ void sethet_detail(
   //	... Set rates above tropopause = 0.
   //-----------------------------------------------------------------
   team.team_barrier();
-  Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, ktop + 1), [&](int kk) {
+  Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, ktop), [&](int kk) {
     for (int mm = 0; mm < gas_wetdep_cnt; mm++)
       het_rates(kk, wetdep_map[mm]) = 0.0;
   });

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1720,7 +1720,7 @@ void aero_model_wetdep(
   // cldt // layer cloud fraction [fraction] from pbuf_get_field
   // FIXME:
   constexpr int nwetdep = 1; // number of elements in wetdep_list
-  int isprx[mam4::nlev] = {-1};
+  int isprx[mam4::nlev] = {};
 
   // inputs
   // Compute variables needed for convproc unified convective transport
@@ -2333,7 +2333,7 @@ void WetDeposition::compute_tendencies(
   wetdep::zero_values(team, aerdepwetis, pcnst);
   wetdep::zero_values(team, aerdepwetcw, pcnst);
 
-  int isprx[mam4::nlev] = {-1};
+  int isprx[mam4::nlev] = {};
 
   // set the mass-weighted sol_factic for coarse mode species.
   wetdep::set_f_act(team, isprx, f_act_conv_coarse, f_act_conv_coarse_dust,

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1649,11 +1649,6 @@ void aero_model_wetdep(
   View1D rain(work_ptr, mam4::nlev);
   work_ptr += mam4::nlev;
 
-  // FIXME: I need to get this variables from calcsize
-  // need to connect ptend_q to tends
-  View2D ptend_q(work_ptr, mam4::nlev, pcnst);
-  work_ptr += mam4::nlev * pcnst;
-
   // CHECK; is work array ?
   View1D cldv(work_ptr, mam4::nlev);
   work_ptr += mam4::nlev;
@@ -1687,8 +1682,16 @@ void aero_model_wetdep(
   View1D scavt(work_ptr, mam4::nlev);
   work_ptr += mam4::nlev;
 
+  View1D bcscavt(work_ptr, mam4::nlev);
+  work_ptr += mam4::nlev;
+
   View1D rcscavt(work_ptr, mam4::nlev);
   work_ptr += mam4::nlev;
+
+  // FIXME: I need to get this variables from calcsize
+  // need to connect ptend_q to tends
+  View2D ptend_q(work_ptr, mam4::nlev, pcnst);
+  work_ptr += mam4::nlev * pcnst;
 
   View2D rtscavt_sv(work_ptr, mam4::nlev, pcnst);
   work_ptr += pcnst * mam4::nlev;
@@ -1697,8 +1700,6 @@ void aero_model_wetdep(
                          [&](int j) { rtscavt_sv(i, j) = zero; });
   });
 
-  View1D bcscavt(work_ptr, mam4::nlev);
-  work_ptr += mam4::nlev;
 
   wetdep::zero_values(team, aerdepwetis, pcnst);
   wetdep::zero_values(team, aerdepwetcw, pcnst);

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1240,8 +1240,7 @@ void set_f_act(const ThreadTeam &team, int *isprx,
 // Computes lookup table for aerosol impaction/interception scavenging rates
 KOKKOS_INLINE_FUNCTION
 void modal_aero_bcscavcoef_get(
-    const ThreadTeam &team, const Diagnostics &diags,
-    const int *isprx,
+    const ThreadTeam &team, const Diagnostics &diags, const int *isprx,
     const Real scavimptblvol[aero_model::nimptblgrow_total]
                             [AeroConfig::num_modes()],
     const Real scavimptblnum[aero_model::nimptblgrow_total]
@@ -1528,20 +1527,19 @@ void update_q_tendencies(const ThreadTeam &team, const View2D &ptend_q,
 // =============================================================================
 KOKKOS_INLINE_FUNCTION
 int get_aero_model_wetdep_work_len() {
-  int work_len =
-      2 * mam4::nlev * pcnst +
-        // state_q, qqcw
-      25 * mam4::nlev +
-        // cldcu, cldst, evapc, cmfdqr, totcond, conicw,
-        // f_act_conv_coarse, f_act_conv_coarse_dust, f_act_conv_coarse_nacl,
-        // rain, cldv, cldvcu, cldvst,
-        // scavcoefnum, scavcoefvol
-        // sol_facti, sol_factic, sol_factb, f_act_conv,
-        // scavt, bcscavt, rcscavt,
-      2 * mam4::nlev * pcnst +
-        // ptend_q, rtscavt_sv
-      2 * pcnst;
-        //  qsrflx_mzaer2cnvpr
+  int work_len = 2 * mam4::nlev * pcnst +
+                 // state_q, qqcw
+                 25 * mam4::nlev +
+                 // cldcu, cldst, evapc, cmfdqr, totcond, conicw,
+                 // f_act_conv_coarse, f_act_conv_coarse_dust,
+                 // f_act_conv_coarse_nacl, rain, cldv, cldvcu, cldvst,
+                 // scavcoefnum, scavcoefvol
+                 // sol_facti, sol_factic, sol_factb, f_act_conv,
+                 // scavt, bcscavt, rcscavt,
+                 2 * mam4::nlev * pcnst +
+                 // ptend_q, rtscavt_sv
+                 2 * pcnst;
+  //  qsrflx_mzaer2cnvpr
   return work_len;
 }
 // =============================================================================
@@ -1699,7 +1697,6 @@ void aero_model_wetdep(
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, pcnst),
                          [&](int j) { rtscavt_sv(i, j) = zero; });
   });
-
 
   wetdep::zero_values(team, aerdepwetis, pcnst);
   wetdep::zero_values(team, aerdepwetcw, pcnst);

--- a/src/validation/aero_model/aero_model_wetdep.cpp
+++ b/src/validation/aero_model/aero_model_wetdep.cpp
@@ -174,7 +174,7 @@ void aero_model_wetdep(Ensemble *ensemble) {
               cldt, rprdsh, rprddp, evapcdp, evapcsh, dp_frac, sh_frac, icwmrdp,
               icwmrsh, evapr,
               // outputs
-              dlf, prain, isprx, scavimptblnum, scavimptblvol,
+              dlf, prain, scavimptblnum, scavimptblvol,
               wet_geometric_mean_diameter_i, dry_geometric_mean_diameter_i,
               qaerwat, wetdens,
               // output

--- a/src/validation/aero_model/aero_model_wetdep.cpp
+++ b/src/validation/aero_model/aero_model_wetdep.cpp
@@ -168,17 +168,17 @@ void aero_model_wetdep(Ensemble *ensemble) {
               });
           team.team_barrier();
 
-          wetdep::aero_model_wetdep(
-              team, atm, progs_in, tends_in, dt,
-              // inputs
-              cldt, rprdsh, rprddp, evapcdp, evapcsh, dp_frac, sh_frac, icwmrdp,
-              icwmrsh, evapr,
-              // outputs
-              dlf, prain, scavimptblnum, scavimptblvol,
-              wet_geometric_mean_diameter_i, dry_geometric_mean_diameter_i,
-              qaerwat, wetdens,
-              // output
-              aerdepwetis, aerdepwetcw, work);
+          wetdep::aero_model_wetdep(team, atm, progs_in, tends_in, dt,
+                                    // inputs
+                                    cldt, rprdsh, rprddp, evapcdp, evapcsh,
+                                    dp_frac, sh_frac, icwmrdp, icwmrsh, evapr,
+                                    // outputs
+                                    dlf, prain, scavimptblnum, scavimptblvol,
+                                    wet_geometric_mean_diameter_i,
+                                    dry_geometric_mean_diameter_i, qaerwat,
+                                    wetdens,
+                                    // output
+                                    aerdepwetis, aerdepwetcw, work);
 
           team.team_barrier();
           Kokkos::parallel_for(


### PR DESCRIPTION
With @overfelt knocking out the issues related to the failing tests and non-determinism that's been happening in EAMxx/E3SM, these are the last few things that were required to get it talking to the EAMxx _**wet scavenging**_ interface.

Admittedly, I'm not sure that the use of a local `int isprx[nlev]` array is the most elegant solution, but I'm happy to change this up later.

In favor of getting the EAMxx changes PR'd to the E3SM repo ASAP, I'm going to immediately merge this into `main`, and we can update after winter shutdown if I've done anything super dumb.

Thanks, and have a great holiday break!

@singhbalwinder
@odiazib 
@jaelynlitz 