### PR TITLE
Oscar/gas dry deposition

### DIFF
--- a/src/mam4xx/mo_drydep.hpp
+++ b/src/mam4xx/mo_drydep.hpp
@@ -638,8 +638,7 @@ void drydep_xactive(
     const seq_drydep::Data &drydep_data,
     const Real fraction_landuse[n_land_type], // fraction of land use for column
                                               // by land type
-    const int month,                          // month
-    const int col_index_season[n_land_type], // column-specific mapping of month
+    const int index_season[n_land_type], // column-specific mapping of month
                                              // indices to seasonal land-type
                                              // indices [-]
     const Real sfc_temp,                     // surface temperature [K]
@@ -650,7 +649,6 @@ void drydep_xactive(
     const Real spec_hum,                     // specific humidity [kg/kg]
     const Real wind_speed,                   // 10-meter wind spped [m/s]
     const Real rain,                         // rain content [??]
-    const Real snow,                         // snow height [m]
     const Real solar_flux,     // direct shortwave surface radiation [W/m^2]
     const Real mmr[gas_pcnst], // constituent MMRs [kg/kg]
     Real dvel[gas_pcnst],      // deposition velocity [1/cm/s]
@@ -672,27 +670,7 @@ void drydep_xactive(
   Real heff[nddvels];
   mam4::seq_drydep::set_hcoeff_scalar(sfc_temp, heff);
 
-  //-------------------------------------------------------------------------------------
-  // define which season (relative to Northern hemisphere climate)
-  //-------------------------------------------------------------------------------------
 
-  //-------------------------------------------------------------------------------------
-  // define season index based on fixed LAI
-  //-------------------------------------------------------------------------------------
-
-  int index_season[n_land_type];
-  for (int lt = 0; lt < n_land_type; ++lt) {
-    index_season[lt] = col_index_season[month - 1];
-  }
-
-  //-------------------------------------------------------------------------------------
-  // special case for snow covered terrain
-  //-------------------------------------------------------------------------------------
-  if (snow > 0.01) { // BAD_CONSTANT
-    for (int lt = 0; lt < n_land_type; ++lt) {
-      index_season[lt] = 3;
-    }
-  }
 
   //-------------------------------------------------------------------------------------
   // scale rain and define logical arrays

--- a/src/mam4xx/mo_drydep.hpp
+++ b/src/mam4xx/mo_drydep.hpp
@@ -639,16 +639,16 @@ void drydep_xactive(
     const Real fraction_landuse[n_land_type], // fraction of land use for column
                                               // by land type
     const int index_season[n_land_type], // column-specific mapping of month
-                                             // indices to seasonal land-type
-                                             // indices [-]
-    const Real sfc_temp,                     // surface temperature [K]
-    const Real air_temp,                     // surface air temperature [K]
-    const Real tv,                           // potential temperature [K]
-    const Real pressure_sfc,                 // surface pressure [Pa]
-    const Real pressure_10m,                 // 10-meter pressure [Pa]
-    const Real spec_hum,                     // specific humidity [kg/kg]
-    const Real wind_speed,                   // 10-meter wind spped [m/s]
-    const Real rain,                         // rain content [??]
+                                         // indices to seasonal land-type
+                                         // indices [-]
+    const Real sfc_temp,                 // surface temperature [K]
+    const Real air_temp,                 // surface air temperature [K]
+    const Real tv,                       // potential temperature [K]
+    const Real pressure_sfc,             // surface pressure [Pa]
+    const Real pressure_10m,             // 10-meter pressure [Pa]
+    const Real spec_hum,                 // specific humidity [kg/kg]
+    const Real wind_speed,               // 10-meter wind spped [m/s]
+    const Real rain,                     // rain content [??]
     const Real solar_flux,     // direct shortwave surface radiation [W/m^2]
     const Real mmr[gas_pcnst], // constituent MMRs [kg/kg]
     Real dvel[gas_pcnst],      // deposition velocity [1/cm/s]
@@ -669,8 +669,6 @@ void drydep_xactive(
   //-------------------------------------------------------------------------------------
   Real heff[nddvels];
   mam4::seq_drydep::set_hcoeff_scalar(sfc_temp, heff);
-
-
 
   //-------------------------------------------------------------------------------------
   // scale rain and define logical arrays

--- a/src/mam4xx/mo_gas_phase_chemdr.hpp
+++ b/src/mam4xx/mo_gas_phase_chemdr.hpp
@@ -111,13 +111,11 @@ void mmr2vmr_col(const ThreadTeam &team, const haero::Atmosphere &atm,
 KOKKOS_INLINE_FUNCTION
 void perform_atmospheric_chemistry_and_microphysics(
     const ThreadTeam &team, const Real dt, const Real rlats,
-    const Real sfc_temp,
-    const Real pressure_sfc,
-    const Real wind_speed, const Real rain,
-    const Real solar_flux, const View1D cnst_offline_icol[num_tracer_cnst],
-    const Forcing *forcings_in, const haero::Atmosphere &atm,
-    const PhotoTableData &photo_table, const Real chlorine_loading,
-    const mam4::mo_setsox::Config &config_setsox,
+    const Real sfc_temp, const Real pressure_sfc, const Real wind_speed,
+    const Real rain, const Real solar_flux,
+    const View1D cnst_offline_icol[num_tracer_cnst], const Forcing *forcings_in,
+    const haero::Atmosphere &atm, const PhotoTableData &photo_table,
+    const Real chlorine_loading, const mam4::mo_setsox::Config &config_setsox,
     const AmicPhysConfig &config_amicphys, const Real linoz_psc_T,
     const Real zenith_angle_icol, const Real d_sfc_alb_dir_vis_icol,
     const View1D &o3_col_dens_i, const View2D &photo_rates_icol,
@@ -159,7 +157,7 @@ void perform_atmospheric_chemistry_and_microphysics(
   work_set_het_ptr += sethet_work_len;
 
   //
-  const int surface_lev = nlev - 1;                 // Surface level
+  const int surface_lev = nlev - 1; // Surface level
   // specific humidity [kg/kg]
   const Real spec_hum = atm.vapor_mixing_ratio(surface_lev);
   // surface air temperature [K]
@@ -171,7 +169,6 @@ void perform_atmospheric_chemistry_and_microphysics(
   // 10-meter pressure [Pa]
   // Surface pressure at 10m (Followed the fortran code)
   const Real pressure_10m = atm.pressure(surface_lev);
-
 
   mam4::mo_setext::extfrc_set(team, forcings_in, extfrc_icol);
 
@@ -226,7 +223,7 @@ void perform_atmospheric_chemistry_and_microphysics(
     mam4::mo_drydep::drydep_xactive(
         drydep_data,
         fraction_landuse, // fraction of land use for column by land type
-        index_season, // column-specific mapping of month indices to
+        index_season,     // column-specific mapping of month indices to
                           // seasonal land-type indices [-]
         sfc_temp,         // surface temperature [K]
         air_temp,         // surface air temperature [K]


### PR DESCRIPTION
I revised the `perform_atmospheric_chemistry_and_microphysics` function signature to minimize input requirements by utilizing the `atm` struct. Additionally, I relocated the `index_season` variable computation to further streamline inputs and integrate this variable with fields populated within the microphysics interface.

see [PR 6929](https://github.com/E3SM-Project/E3SM/pull/6929) 