### PR TITLE
Adds missing init code for drydep

### DIFF
--- a/src/mam4xx/seq_drydep.hpp
+++ b/src/mam4xx/seq_drydep.hpp
@@ -172,7 +172,8 @@ inline Data set_gas_drydep_data() {
   View1DHost drat_h(drat_a, n_drydep);
   Kokkos::deep_copy(data.drat, drat_h);
 
-  Real foxd_a[n_drydep] = {1.0, 1e-36, 1e-36};
+  Real small_value = 1e-36;
+  Real foxd_a[n_drydep] = {1.0, small_value, small_value};
   View1DHost foxd_h(foxd_a, n_drydep);
   Kokkos::deep_copy(data.foxd, foxd_h);
 
@@ -186,6 +187,7 @@ inline Data set_gas_drydep_data() {
   auto rac_h = Kokkos::create_mirror_view(data.rac);
   for (int i = 0; i < NSeas; ++i) {
     for (int j = 0; j < NLUse; ++j) {
+        if(rac_a[i][j]< small_value) rac_a[i][j] = small_value;
         rac_h(i, j) = rac_a[i][j];
     }
   }  
@@ -242,6 +244,7 @@ inline Data set_gas_drydep_data() {
   auto rgss_h = Kokkos::create_mirror_view(data.rgss);
   for (int i = 0; i < NSeas; ++i) {
     for (int j = 0; j < NLUse; ++j) {
+        if (rgss_a[i][j]< 1.0) rgss_a[i][j] = 1.0;
         rgss_h(i, j) = rgss_a[i][j];
     }
   }


### PR DESCRIPTION
Adds two missing limiters in drydep. The EAMxx code with all processes was crashing due to these missing values at the very first time step. Fortunately, the kernel checks helped diagnose the issue. The Fortran code equivalent for this logic is [here](https://github.com/eagles-project/e3sm_mam4_refactor/blob/refactor-maint-2.0/driver-mct/shr/seq_drydep_mod.F90#L1138-#L1144)