### PR TITLE
Adds init for an uninitialzed variable in mo_photo - fixes ERS test

### DIFF
--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -737,6 +737,15 @@ void table_photo(const ThreadTeam &team, const View2D &photo, // out
 
   constexpr Real zero = 0;
 
+  //-----------------------------------------------------------------
+  //	... zero all photorates
+  //-----------------------------------------------------------------
+  for (int mm = 0; mm < phtcnt; ++mm) {
+    for (int kk = 0; kk < pver; ++kk) {
+      photo(kk, mm) = zero;
+    }
+  }
+
   constexpr Real Pa2mb = 1.e-2;                      // pascals to mb
   constexpr Real r2d = 180.0 / haero::Constants::pi; // degrees to radians
   // BAD CONSTANT

--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -740,11 +740,10 @@ void table_photo(const ThreadTeam &team, const View2D &photo, // out
   //-----------------------------------------------------------------
   //	... zero all photorates
   //-----------------------------------------------------------------
-  for (int mm = 0; mm < phtcnt; ++mm) {
-    for (int kk = 0; kk < pver; ++kk) {
-      photo(kk, mm) = zero;
-    }
-  }
+  Kokkos::parallel_for(Kokkos::TeamThreadRange(team, pver), [&](const int kk) {
+    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team, phtcnt),
+                         [&](const int mm) { photo(kk, mm) = zero; });
+  });
 
   constexpr Real Pa2mb = 1.e-2;                      // pascals to mb
   constexpr Real r2d = 180.0 / haero::Constants::pi; // degrees to radians


### PR DESCRIPTION
Adds missing initialization of `photo` variable (see the Fortran code [here](https://github.com/eagles-project/e3sm_mam4_refactor/blob/refactor-maint-2.0/components/eam/src/chemistry/mozart/mo_photo.F90#L464-L471))

This fix fixes the ERS CIME test when all MAM4xx processes are turned on. 