### PR TITLE
Fixes an index so that it doesn't go negative to mimic Fortran version

### DIFF
--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -649,7 +649,7 @@ void jlong(const ThreadTeam &team, const Real sza_in, const Real *alb_in,
       // Fortran indexing to C++ indexing
       // number of temperatures in xsection table
       // BAD CONSTANT for 201 and 148.5
-      const int t_index = haero::min(201, haero::max(t_in[kk] - 148.5, 0)) - 1;
+      const int t_index = haero::min(201, haero::max(t_in[kk] - 148.5, 1)) - 1;
 
       /*----------------------------------------------------------------------
                  ... find pressure level


### PR DESCRIPTION
`t_index` was going negative for extremely low temperatures, causing the simulation to crash. Following the Fortran code (see [here](https://github.com/eagles-project/e3sm_mam4_refactor/blob/refactor-maint-2.0/components/eam/src/chemistry/mozart/mo_jlong.F90#L595-L596)), `t_index` is limited so that it stays positive (i.e., >=0). The simulation passed the crashing point after this change.