### PR TITLE
CalcsizeData struct

### DIFF
--- a/src/mam4xx/aer_rad_props.hpp
+++ b/src/mam4xx/aer_rad_props.hpp
@@ -258,7 +258,8 @@ void aer_rad_props_sw(const ThreadTeam &team, const Real dt,
                       const View2D &tau_w_f,
                       // FIXME
                       const AerosolOpticsDeviceData &aersol_optics_data,
-                      Real &aodvis, const View1D &work) {
+                      const CalcsizeData &calcsizedata, Real &aodvis,
+                      const View1D &work) {
 
   const ConstColumnView temperature = atm.temperature;
   const ConstColumnView pmid = atm.pressure;
@@ -319,7 +320,7 @@ void aer_rad_props_sw(const ThreadTeam &team, const Real dt,
   const int ilev_tropp = tropopause_or_quit(pmid, pint, temperature, zm, zi);
   // std::cout << ilev_tropp << " ilev_tropp \n";
   modal_aero_sw(team, dt, progs, atm, pdel, pdeldry, tau, tau_w, tau_w_g,
-                tau_w_f, aersol_optics_data, aodvis, work);
+                tau_w_f, aersol_optics_data, calcsizedata, aodvis, work);
 
   team.team_barrier();
 
@@ -343,6 +344,7 @@ void aer_rad_props_lw(
     const haero::Atmosphere &atm, const ConstColumnView &zi,
     const ConstColumnView &pdel, const View2D &ext_cmip6_lw_m,
     const AerosolOpticsDeviceData &aersol_optics_data,
+    const CalcsizeData &calcsizedata,
     // output
     const View2D &odap_aer
 
@@ -381,6 +383,7 @@ void aer_rad_props_lw(
     layer [unitless]
    Compute contributions from the modal aerosols.*/
   modal_aero_lw(team, dt, progs, atm, pdel, pdeldry, aersol_optics_data,
+                calcsizedata,
                 // outputs
                 odap_aer);
 

--- a/src/mam4xx/modal_aer_opt.hpp
+++ b/src/mam4xx/modal_aer_opt.hpp
@@ -87,6 +87,54 @@ struct AerosolOpticsDeviceData {
   ComplexView2D specrefindex_lw[ntot_amode];
 };
 
+struct CalcsizeData {
+  int nspec_amode[ntot_amode];
+  int lspectype_amode[ndrop::maxd_aspectype][ntot_amode];
+  Real specdens_amode[ndrop::maxd_aspectype];
+  int lmassptr_amode[ndrop::maxd_aspectype][ntot_amode];
+  Real spechygro[ndrop::maxd_aspectype];
+  Real mean_std_dev_nmodes[ntot_amode];
+
+  int numptr_amode[ntot_amode];
+  int mam_idx[ntot_amode][ndrop::nspec_max];
+  int mam_cnst_idx[ntot_amode][ndrop::nspec_max];
+
+  // FIXME: inv_density: we have different order of species in mam4xx.
+  Real inv_density[ntot_amode][AeroConfig::num_aerosol_ids()] = {};
+  Real num2vol_ratio_min[ntot_amode] = {};
+  Real num2vol_ratio_max[ntot_amode] = {};
+  Real num2vol_ratio_max_nmodes[ntot_amode] = {};
+  Real num2vol_ratio_min_nmodes[ntot_amode] = {};
+  Real num2vol_ratio_nom_nmodes[ntot_amode] = {};
+  Real dgnmin_nmodes[ntot_amode] = {};
+  Real dgnmax_nmodes[ntot_amode] = {};
+  Real dgnnom_nmodes[ntot_amode] = {};
+  bool noxf_acc2ait[AeroConfig::num_aerosol_ids()] = {};
+  int n_common_species_ait_accum = {};
+  int ait_spec_in_acc[AeroConfig::num_aerosol_ids()] = {};
+  int acc_spec_in_ait[AeroConfig::num_aerosol_ids()] = {};
+
+  const bool do_adjust = true;
+  const bool do_aitacc_transfer = true;
+  const bool update_mmr = false;
+
+  void initialize() {
+
+    ndrop::get_e3sm_parameters(nspec_amode, lspectype_amode, lmassptr_amode,
+                               numptr_amode, specdens_amode, spechygro, mam_idx,
+                               mam_cnst_idx);
+
+    modal_aero_calcsize::init_calcsize(
+        inv_density, num2vol_ratio_min, num2vol_ratio_max,
+        num2vol_ratio_max_nmodes, num2vol_ratio_min_nmodes,
+        num2vol_ratio_nom_nmodes, dgnmin_nmodes, dgnmax_nmodes, dgnnom_nmodes,
+        mean_std_dev_nmodes,
+        // outputs
+        noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
+        acc_spec_in_ait);
+  }
+};
+
 inline void set_aerosol_optics_data_for_modal_aero_sw_views(
     AerosolOpticsDeviceData &aersol_optics_data) {
 
@@ -509,56 +557,15 @@ void binterp(const View3D &table, const Real ref_real, const Real ref_img,
 } // binterp
 
 KOKKOS_INLINE_FUNCTION
-void compute_calcsize_and_water_uptake_dr(
-    const Real &pmid, const Real &temperature, Real &cldn,
-    Real *state_q_kk,   // in
-    const Real *qqcw_k, // in
-    const Real &dt,
-    // outputs
-    int nspec_amode[ntot_amode],
-    int lspectype_amode[ndrop::maxd_aspectype][ntot_amode],
-    Real specdens_amode[ndrop::maxd_aspectype],
-    int lmassptr_amode[ndrop::maxd_aspectype][ntot_amode],
-    Real spechygro[ndrop::maxd_aspectype], Real mean_std_dev_nmodes[ntot_amode],
-    Real dgnumwet_m_kk[ntot_amode], Real qaerwat_m_kk[ntot_amode]) {
-
-  const bool do_adjust = true;
-  const bool do_aitacc_transfer = true;
-  const bool update_mmr = false;
-
-  int numptr_amode[ntot_amode];
-  int mam_idx[ntot_amode][ndrop::nspec_max];
-  int mam_cnst_idx[ntot_amode][ndrop::nspec_max];
-
-  ndrop::get_e3sm_parameters(nspec_amode, lspectype_amode, lmassptr_amode,
-                             numptr_amode, specdens_amode, spechygro, mam_idx,
-                             mam_cnst_idx);
-
-  // FIXME: inv_density: we have different order of species in mam4xx.
-  Real inv_density[ntot_amode][AeroConfig::num_aerosol_ids()] = {};
-  Real num2vol_ratio_min[ntot_amode] = {};
-  Real num2vol_ratio_max[ntot_amode] = {};
-  Real num2vol_ratio_max_nmodes[ntot_amode] = {};
-  Real num2vol_ratio_min_nmodes[ntot_amode] = {};
-  Real num2vol_ratio_nom_nmodes[ntot_amode] = {};
-  Real dgnmin_nmodes[ntot_amode] = {};
-  Real dgnmax_nmodes[ntot_amode] = {};
-  Real dgnnom_nmodes[ntot_amode] = {};
-  // Real mean_std_dev_nmodes[ntot_amode] = {};
-  // outputs
-  bool noxf_acc2ait[AeroConfig::num_aerosol_ids()] = {};
-  int n_common_species_ait_accum = {};
-  int ait_spec_in_acc[AeroConfig::num_aerosol_ids()] = {};
-  int acc_spec_in_ait[AeroConfig::num_aerosol_ids()] = {};
-  // FIXME: inv_density
-  modal_aero_calcsize::init_calcsize(
-      inv_density, num2vol_ratio_min, num2vol_ratio_max,
-      num2vol_ratio_max_nmodes, num2vol_ratio_min_nmodes,
-      num2vol_ratio_nom_nmodes, dgnmin_nmodes, dgnmax_nmodes, dgnnom_nmodes,
-      mean_std_dev_nmodes,
-      // outputs
-      noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-      acc_spec_in_ait);
+void compute_calcsize_and_water_uptake_dr(const Real &pmid,
+                                          const Real &temperature, Real &cldn,
+                                          Real *state_q_kk,   // in
+                                          const Real *qqcw_k, // in
+                                          const Real &dt,
+                                          const CalcsizeData &calcsizedata,
+                                          // outputs
+                                          Real dgnumwet_m_kk[ntot_amode],
+                                          Real qaerwat_m_kk[ntot_amode]) {
 
   Real dgncur_c_kk[ntot_amode] = {};
   Real dgnumdry_m_kk[ntot_amode] = {};
@@ -569,18 +576,24 @@ void compute_calcsize_and_water_uptake_dr(
   modal_aero_calcsize::modal_aero_calcsize_sub(
       state_q_kk, // in
       qqcw_k,     // in/out
-      dt, do_adjust, do_aitacc_transfer, update_mmr, lmassptr_amode,
-      numptr_amode,
-      inv_density, // in
-      num2vol_ratio_min, num2vol_ratio_max, num2vol_ratio_max_nmodes,
-      num2vol_ratio_min_nmodes, num2vol_ratio_nom_nmodes, dgnmin_nmodes,
-      dgnmax_nmodes, dgnnom_nmodes, mean_std_dev_nmodes,
+      dt, calcsizedata.do_adjust, calcsizedata.do_aitacc_transfer,
+      calcsizedata.update_mmr, calcsizedata.lmassptr_amode,
+      calcsizedata.numptr_amode,
+      calcsizedata.inv_density, // in
+      calcsizedata.num2vol_ratio_min, calcsizedata.num2vol_ratio_max,
+      calcsizedata.num2vol_ratio_max_nmodes,
+      calcsizedata.num2vol_ratio_min_nmodes,
+      calcsizedata.num2vol_ratio_nom_nmodes, calcsizedata.dgnmin_nmodes,
+      calcsizedata.dgnmax_nmodes, calcsizedata.dgnnom_nmodes,
+      calcsizedata.mean_std_dev_nmodes,
       // outputs
-      noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-      acc_spec_in_ait, dgnumdry_m_kk, dgncur_c_kk, ptend, dqqcwdt);
+      calcsizedata.noxf_acc2ait, calcsizedata.n_common_species_ait_accum,
+      calcsizedata.ait_spec_in_acc, calcsizedata.acc_spec_in_ait, dgnumdry_m_kk,
+      dgncur_c_kk, ptend, dqqcwdt);
 
   mam4::water_uptake::modal_aero_water_uptake_dr(
-      nspec_amode, specdens_amode, spechygro, lspectype_amode, state_q_kk,
+      calcsizedata.nspec_amode, calcsizedata.specdens_amode,
+      calcsizedata.spechygro, calcsizedata.lspectype_amode, state_q_kk,
       temperature, pmid, cldn, dgnumdry_m_kk, dgnumwet_m_kk, qaerwat_m_kk);
 } // compute_calcsize_water_uptake_dr
 
@@ -590,6 +603,7 @@ void modal_aero_sw_wo_diagnostics_k(
     Real *state_q_kk,   // in
     const Real *qqcw_k, // in
     const Real &dt, const AerosolOpticsDeviceData &aersol_optics_data,
+    const CalcsizeData &calcsizedata,
     // outputs
     const View2D &tauxar, const View2D &wa, const View2D &ga,
     const View2D &fa) {
@@ -655,27 +669,19 @@ void modal_aero_sw_wo_diagnostics_k(
 
   Real cheb_kk[ncoef] = {};
   Real specvol[max_nspec] = {};
-  // inputs
-  int nspec_amode[ntot_amode];
-  int lspectype_amode[ndrop::maxd_aspectype][ntot_amode];
-  int lmassptr_amode[ndrop::maxd_aspectype][ntot_amode];
-  Real specdens_amode[ndrop::maxd_aspectype];
-  Real spechygro[ndrop::maxd_aspectype];
-
-  Real mean_std_dev_nmodes[ntot_amode] = {};
+  // Real mean_std_dev_nmodes[ntot_amode] = {};
   Real dgnumwet_m_kk[ntot_amode] = {};
   Real qaerwat_m_kk[ntot_amode] = {};
   compute_calcsize_and_water_uptake_dr(
       pmid, temperature, cldn, state_q_kk, qqcw_k, dt, // in
-      nspec_amode, lspectype_amode, specdens_amode, lmassptr_amode, spechygro,
-      mean_std_dev_nmodes, dgnumwet_m_kk, qaerwat_m_kk);
+      calcsizedata, dgnumwet_m_kk, qaerwat_m_kk);
 
   for (int mm = 0; mm < ntot_amode; ++mm) {
     //  get mode info
-    const int nspec = nspec_amode[mm];
+    const int nspec = calcsizedata.nspec_amode[mm];
     // const Real sigma_logr_aer = sigmag_amode[mm];
     // CHECK if mean_std_dev_nmodes is equivalent to sigmag_amode
-    const Real sigma_logr_aer = mean_std_dev_nmodes[mm];
+    const Real sigma_logr_aer = calcsizedata.mean_std_dev_nmodes[mm];
 
     Real logradsurf = 0;
     Real radsurf = 0;
@@ -688,9 +694,12 @@ void modal_aero_sw_wo_diagnostics_k(
 
         // get aerosol properties and save for each species
         // Fortran to C++ indexing
-        auto specmmr = state_q_kk[lmassptr_amode[ll][mm] - 1];
-        // Fortran to C++ indexing
-        const Real specdens = specdens_amode[lspectype_amode[ll][mm] - 1];
+        auto specmmr = state_q_kk[calcsizedata.lmassptr_amode[ll][mm] - 1];
+        // FIXME: move specdens to init
+        //  Fortran to C++ indexing
+        const Real specdens =
+            calcsizedata
+                .specdens_amode[calcsizedata.lspectype_amode[ll][mm] - 1];
 
         // allocate(specvol(pcols,nspec),stat=istat)
         specvol[ll] = specmmr / specdens;
@@ -790,6 +799,7 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt,
                    const View2D &tauxar, const View2D &wa, const View2D &ga,
                    const View2D &fa,
                    const AerosolOpticsDeviceData &aersol_optics_data,
+                   const CalcsizeData &calcsizedata,
                    // aerosol optical depth
                    Real &aodvis, const View1D &work)
 
@@ -853,15 +863,13 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt,
             Kokkos::subview(ga_work, kk, Kokkos::ALL(), Kokkos::ALL());
         const auto fa_kkp =
             Kokkos::subview(fa_work, kk, Kokkos::ALL(), Kokkos::ALL());
-
         modal_aero_sw_wo_diagnostics_k(pdeldry(kk), pmid(kk), temperature(kk),
                                        cldn_kk,
                                        state_q, // in
                                        qqcw,    // in
-                                       dt, aersol_optics_data,
+                                       dt, aersol_optics_data, calcsizedata,
                                        // outputs
                                        tauxar_kkp, wa_kkp, ga_kkp, fa_kkp);
-
         utils::inject_qqcw_to_prognostics(qqcw, progs, kk);
         utils::inject_stateq_to_prognostics(state_q, progs, kk);
       });
@@ -921,6 +929,7 @@ void modal_aero_lw_k(const Real &pdeldry, const Real &pmid,
                      const Real *qqcw_k, // in
                      const Real &dt,
                      const AerosolOpticsDeviceData &aersol_optics_data,
+                     const CalcsizeData &calcsizedata,
                      // outputs
                      Real *tauxar) {
 
@@ -936,29 +945,21 @@ void modal_aero_lw_k(const Real &pdeldry, const Real &pmid,
 
   // layer dry mass [kg/m2]
   const Real mass = pdeldry * rga;
-  // e3sm parameters
-  int nspec_amode[ntot_amode];
-  int lspectype_amode[ndrop::maxd_aspectype][ntot_amode];
-  int lmassptr_amode[ndrop::maxd_aspectype][ntot_amode];
-  Real specdens_amode[ndrop::maxd_aspectype];
-  Real spechygro[ndrop::maxd_aspectype];
-  Real mean_std_dev_nmodes[ntot_amode] = {};
 
   // calcsize and water_uptake_dr outputs that are required by aerosol_optics
   Real dgnumwet_m_kk[ntot_amode] = {};
   Real qaerwat_m_kk[ntot_amode] = {};
   compute_calcsize_and_water_uptake_dr(
       pmid, temperature, cldn, state_q_kk, qqcw_k, dt, // in
-      nspec_amode, lspectype_amode, specdens_amode, lmassptr_amode, spechygro,
-      mean_std_dev_nmodes, dgnumwet_m_kk, qaerwat_m_kk);
+      calcsizedata, dgnumwet_m_kk, qaerwat_m_kk);
 
   for (int mm = 0; mm < ntot_amode; ++mm) {
 
     // get mode info
-    const int nspec = nspec_amode[mm];
+    const int nspec = calcsizedata.nspec_amode[mm];
     // const Real sigma_logr_aer = sigmag_amode[mm];
     // CHECK if mean_std_dev_nmodes is equivalent to sigmag_amode
-    const Real sigma_logr_aer = mean_std_dev_nmodes[mm];
+    const Real sigma_logr_aer = calcsizedata.mean_std_dev_nmodes[mm];
 
     // calc size parameter for all columns
     // FORTRAN refactoring: ismethod2 is tempararily used to ensure BFB test.
@@ -972,9 +973,12 @@ void modal_aero_lw_k(const Real &pdeldry, const Real &pmid,
 
       for (int ll = 0; ll < nspec; ++ll) {
         // Fortran to C++ indexing
-        auto specmmr = state_q_kk[lmassptr_amode[ll][mm] - 1];
-        // Fortran to C++ indexing
-        const Real specdens = specdens_amode[lspectype_amode[ll][mm] - 1];
+        auto specmmr = state_q_kk[calcsizedata.lmassptr_amode[ll][mm] - 1];
+        // FIXME: move specdens to int
+        //  Fortran to C++ indexing
+        const Real specdens =
+            calcsizedata
+                .specdens_amode[calcsizedata.lspectype_amode[ll][mm] - 1];
 
         specvol[ll] = specmmr / specdens;
       } // ll
@@ -1037,6 +1041,7 @@ void modal_aero_lw(const ThreadTeam &team, const Real dt,
                    const ConstColumnView &pdel, const ConstColumnView &pdeldry,
                    // parameters
                    const AerosolOpticsDeviceData &aersol_optics_data,
+                   const CalcsizeData &calcsizedata,
                    // output
                    const View2D &tauxar) {
 
@@ -1081,18 +1086,18 @@ void modal_aero_lw(const ThreadTeam &team, const Real dt,
         utils::extract_qqcw_from_prognostics(progs, qqcw, kk);
 
         Real tauxar_kkp[nlwbands] = {};
-
+#if 1
         modal_aero_lw_k(pdeldry(kk), pmid(kk), temperature(kk), cldn_kk,
                         state_q, // in
                         qqcw,    // in
-                        dt, aersol_optics_data,
+                        dt, aersol_optics_data, calcsizedata,
                         // outputs
                         tauxar_kkp);
 
         for (int ilw = 0; ilw < nlwbands; ++ilw) {
           tauxar(ilw, kk) = tauxar_kkp[ilw];
         }
-
+#endif
         utils::inject_qqcw_to_prognostics(qqcw, progs, kk);
         utils::inject_stateq_to_prognostics(state_q, progs, kk);
       });

--- a/src/mam4xx/water_uptake.hpp
+++ b/src/mam4xx/water_uptake.hpp
@@ -356,9 +356,10 @@ void get_e3sm_parameters(
 
 KOKKOS_INLINE_FUNCTION
 void modal_aero_water_uptake_dryaer(
-    int nspec_amode[AeroConfig::num_modes()],
-    Real specdens_amode[maxd_aspectype], Real spechygro[maxd_aspectype],
-    int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
+    const int nspec_amode[AeroConfig::num_modes()],
+    const Real specdens_amode[maxd_aspectype],
+    const Real spechygro[maxd_aspectype],
+    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
     Real state_q[aero_model::pcnst], Real dgncur_a[AeroConfig::num_modes()],
     Real hygro[AeroConfig::num_modes()], Real naer[AeroConfig::num_modes()],
     Real dryrad[AeroConfig::num_modes()], Real dryvol[AeroConfig::num_modes()],
@@ -434,9 +435,10 @@ void modal_aero_water_uptake_dryaer(
 
 KOKKOS_INLINE_FUNCTION
 void modal_aero_water_uptake_dr_b4_wetdens(
-    int nspec_amode[AeroConfig::num_modes()],
-    Real specdens_amode[maxd_aspectype], Real spechygro[maxd_aspectype],
-    int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
+    const int nspec_amode[AeroConfig::num_modes()],
+    const Real specdens_amode[maxd_aspectype],
+    const Real spechygro[maxd_aspectype],
+    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
     Real state_q[aero_model::pcnst], Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
@@ -476,9 +478,10 @@ void modal_aero_water_uptake_dr_b4_wetdens(
 
 KOKKOS_INLINE_FUNCTION
 void modal_aero_water_uptake_dr(
-    int nspec_amode[AeroConfig::num_modes()],
-    Real specdens_amode[maxd_aspectype], Real spechygro[maxd_aspectype],
-    int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
+    const int nspec_amode[AeroConfig::num_modes()],
+    const Real specdens_amode[maxd_aspectype],
+    const Real spechygro[maxd_aspectype],
+    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
     Real state_q[aero_model::pcnst], Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
@@ -504,9 +507,10 @@ void modal_aero_water_uptake_dr(
 
 KOKKOS_INLINE_FUNCTION
 void modal_aero_water_uptake_dr(
-    int nspec_amode[AeroConfig::num_modes()],
-    Real specdens_amode[maxd_aspectype], Real spechygro[maxd_aspectype],
-    int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
+    const int nspec_amode[AeroConfig::num_modes()],
+    const Real specdens_amode[maxd_aspectype],
+    const Real spechygro[maxd_aspectype],
+    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
     Real state_q[aero_model::pcnst], Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],

--- a/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
+++ b/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
@@ -18,8 +18,6 @@ void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
     constexpr int pcnst = aero_model::pcnst;
     constexpr int pver = ndrop::pver;
     constexpr int ntot_amode = AeroConfig::num_modes();
-    constexpr int nspec_max = ndrop::nspec_max;
-    constexpr int maxd_aspectype = ndrop::maxd_aspectype;
 
     using View2D = DeviceType::view_2d<Real>;
     constexpr Real zero = 0.0;
@@ -69,55 +67,15 @@ void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
     ColumnView pmid = validation::get_input_in_columnview(input, "pmid");
 
     ColumnView cldn = validation::get_input_in_columnview(input, "cldn");
-    std::cout << "calcsize : "
-              << "\n";
+
+    mam4::modal_aero_calcsize::CalcsizeData cal_data;
+    cal_data.initialize();
+    const bool update_mmr = true;
+    cal_data.set_update_mmr(update_mmr);
 
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          Real inv_density[AeroConfig::num_modes()]
-                          [AeroConfig::num_aerosol_ids()] = {};
-          Real num2vol_ratio_min[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_max[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_max_nmodes[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_min_nmodes[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_nom_nmodes[AeroConfig::num_modes()] = {};
-          Real dgnmin_nmodes[AeroConfig::num_modes()] = {};
-          Real dgnmax_nmodes[AeroConfig::num_modes()] = {};
-          Real dgnnom_nmodes[AeroConfig::num_modes()] = {};
-          Real mean_std_dev_nmodes[AeroConfig::num_modes()] = {};
-          // outputs
-          bool noxf_acc2ait[AeroConfig::num_aerosol_ids()] = {};
-          int n_common_species_ait_accum = {};
-          int ait_spec_in_acc[AeroConfig::num_aerosol_ids()] = {};
-          int acc_spec_in_ait[AeroConfig::num_aerosol_ids()] = {};
-
-          modal_aero_calcsize::init_calcsize(
-              inv_density, num2vol_ratio_min, num2vol_ratio_max,
-              num2vol_ratio_max_nmodes, num2vol_ratio_min_nmodes,
-              num2vol_ratio_nom_nmodes, dgnmin_nmodes, dgnmax_nmodes,
-              dgnnom_nmodes, mean_std_dev_nmodes,
-              // outputs
-              noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-              acc_spec_in_ait);
-
-          const bool do_adjust = true;
-          const bool do_aitacc_transfer = true;
-          const bool update_mmr = true;
-
-          int nspec_amode[ntot_amode];
-          int lspectype_amode[maxd_aspectype][ntot_amode];
-          int lmassptr_amode[maxd_aspectype][ntot_amode];
-          Real specdens_amode[maxd_aspectype];
-          Real spechygro[maxd_aspectype];
-          int numptr_amode[ntot_amode];
-          int mam_idx[ntot_amode][nspec_max];
-          int mam_cnst_idx[ntot_amode][nspec_max];
-
-          ndrop::get_e3sm_parameters(
-              nspec_amode, lspectype_amode, lmassptr_amode, numptr_amode,
-              specdens_amode, spechygro, mam_idx, mam_cnst_idx);
-
           // FIXME: top_lev is set to 1 in calcsize ?
           const int top_lev = 0; // 1( in fortran )
 
@@ -136,15 +94,7 @@ void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
                 modal_aero_calcsize::modal_aero_calcsize_sub(
                     state_q_k.data(), // in
                     qqcw_k.data(),    // in/out
-                    dt, do_adjust, do_aitacc_transfer, update_mmr,
-                    lmassptr_amode, numptr_amode,
-                    inv_density, // in
-                    num2vol_ratio_min, num2vol_ratio_max,
-                    num2vol_ratio_max_nmodes, num2vol_ratio_min_nmodes,
-                    num2vol_ratio_nom_nmodes, dgnmin_nmodes, dgnmax_nmodes,
-                    dgnnom_nmodes, mean_std_dev_nmodes, noxf_acc2ait,
-                    n_common_species_ait_accum, ait_spec_in_acc,
-                    acc_spec_in_ait,
+                    dt, cal_data,
                     // outputs
                     dgncur_i.data(), dgncur_c, ptend_q_k.data(),
                     dqqcwdt_k.data());
@@ -159,7 +109,8 @@ void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
                     Kokkos::subview(wetdens, kk, Kokkos::ALL());
 
                 mam4::water_uptake::modal_aero_water_uptake_dr(
-                    nspec_amode, specdens_amode, spechygro, lspectype_amode,
+                    cal_data.nspec_amode, cal_data.specdens_amode,
+                    cal_data.spechygro, cal_data.lspectype_amode,
                     state_q_k.data(), temperature(kk), pmid(kk), cldn(kk),
                     dgncur_i.data(), dgnumwet_kk.data(), qaerwat_kk.data(),
                     wetdens_kk.data());

--- a/src/validation/aero_model/aero_model_wetdep.cpp
+++ b/src/validation/aero_model/aero_model_wetdep.cpp
@@ -147,8 +147,14 @@ void aero_model_wetdep(Ensemble *ensemble) {
     // work arrays
     const int work_len = wetdep::get_aero_model_wetdep_work_len();
     wetdep::View1D work("work", work_len);
-    std::cout << "aero_model_wetdep : "
-              << "\n";
+
+    mam4::modal_aero_calcsize::CalcsizeData cal_data;
+    cal_data.initialize();
+    const bool update_mmr = true;
+    cal_data.set_update_mmr(update_mmr);
+    // std::cout << "aero_model_wetdep : "
+    //           << "\n";
+
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -173,7 +179,7 @@ void aero_model_wetdep(Ensemble *ensemble) {
                                     dp_frac, sh_frac, icwmrdp, icwmrsh, evapr,
                                     // outputs
                                     dlf, prain, scavimptblnum, scavimptblvol,
-                                    wet_geometric_mean_diameter_i,
+                                    cal_data, wet_geometric_mean_diameter_i,
                                     dry_geometric_mean_diameter_i, qaerwat,
                                     wetdens,
                                     // output
@@ -187,11 +193,6 @@ void aero_model_wetdep(Ensemble *ensemble) {
                                                      ptend_q_kk.data(), kk);
               });
         });
-
-    // std::vector<Real> dlf_output(nlev, 0);
-    // auto dlf_host = View1DHost((Real *)dlf_output.data(), nlev);
-    // Kokkos::deep_copy(dlf, dlf_host);
-    // output.set("dlf", dlf_output);
 
     std::vector<Real> output_pcnst(aero_model::pcnst, 0);
     auto aerdepwetcw_host =

--- a/src/validation/aero_model/aero_model_wetdep.cpp
+++ b/src/validation/aero_model/aero_model_wetdep.cpp
@@ -152,8 +152,6 @@ void aero_model_wetdep(Ensemble *ensemble) {
     cal_data.initialize();
     const bool update_mmr = true;
     cal_data.set_update_mmr(update_mmr);
-    // std::cout << "aero_model_wetdep : "
-    //           << "\n";
 
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(

--- a/src/validation/aerosol_optics/aer_rad_props_lw.cpp
+++ b/src/validation/aerosol_optics/aer_rad_props_lw.cpp
@@ -275,6 +275,8 @@ void aer_rad_props_lw(Ensemble *ensemble) {
                           cloud_fraction, updraft_vel_ice_nucleation, pblh);
 
     mam4::Prognostics progs = validation::create_prognostics(nlev);
+    mam4::modal_aer_opt::CalcsizeData cal_data;
+    cal_data.initialize();
 
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -293,6 +295,7 @@ void aer_rad_props_lw(Ensemble *ensemble) {
           team.team_barrier();
           aer_rad_props::aer_rad_props_lw(team, dt, progs_in, atm, zi, pdel,
                                           ext_cmip6_lw, aersol_optics_data,
+                                          cal_data,
                                           // output
                                           odap_aer);
           team.team_barrier();

--- a/src/validation/aerosol_optics/aer_rad_props_sw.cpp
+++ b/src/validation/aerosol_optics/aer_rad_props_sw.cpp
@@ -326,6 +326,9 @@ void aer_rad_props_sw(Ensemble *ensemble) {
 
     mam4::Prognostics progs = validation::create_prognostics(nlev);
 
+    mam4::modal_aer_opt::CalcsizeData cal_data;
+    cal_data.initialize();
+
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -348,7 +351,7 @@ void aer_rad_props_sw(Ensemble *ensemble) {
               team, dt, progs_in, atm, zi, pdel, ssa_cmip6_sw, af_cmip6_sw,
               ext_cmip6_sw, tau, tau_w, tau_w_g, tau_w_f,
               // FIXME
-              aersol_optics_data, aodvis, work);
+              aersol_optics_data, cal_data, aodvis, work);
 
           team.team_barrier();
           // 2. Let's extract state_q and qqcw from prog.

--- a/src/validation/aerosol_optics/modal_aero_lw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_lw.cpp
@@ -248,6 +248,8 @@ void modal_aero_lw(Ensemble *ensemble) {
                           cloud_fraction, updraft_vel_ice_nucleation, pblh);
 
     mam4::Prognostics progs = validation::create_prognostics(nlev);
+    mam4::modal_aer_opt::CalcsizeData cal_data;
+    cal_data.initialize();
 
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
@@ -267,7 +269,7 @@ void modal_aero_lw(Ensemble *ensemble) {
           team.team_barrier();
 
           modal_aero_lw(team, dt, progs_in, atm, pdel, pdeldry,
-                        aersol_optics_data,
+                        aersol_optics_data, cal_data,
                         // outputs
                         tauxar);
           team.team_barrier();

--- a/src/validation/aerosol_optics/modal_aero_sw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_sw.cpp
@@ -285,6 +285,9 @@ void modal_aero_sw(Ensemble *ensemble) {
 
     mam4::Prognostics progs = validation::create_prognostics(nlev);
 
+    mam4::modal_aer_opt::CalcsizeData cal_data;
+    cal_data.initialize();
+
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -304,7 +307,7 @@ void modal_aero_sw(Ensemble *ensemble) {
 
           Real aodvis = 0.0;
           modal_aero_sw(team, dt, progs_in, atm, pdel, pdeldry, tauxar, wa, ga,
-                        fa, aersol_optics_data, aodvis, work);
+                        fa, aersol_optics_data, cal_data, aodvis, work);
 
           team.team_barrier();
           // 2. Let's extract state_q and qqcw from prog.

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -18,8 +18,6 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
     constexpr int pcnst = aero_model::pcnst;
     constexpr int pver = ndrop::pver;
     constexpr int ntot_amode = AeroConfig::num_modes();
-    constexpr int nspec_max = ndrop::nspec_max;
-    constexpr int maxd_aspectype = ndrop::maxd_aspectype;
 
     using View2D = DeviceType::view_2d<Real>;
 
@@ -41,62 +39,12 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
     }
     Kokkos::deep_copy(qqcw, qqcw_host);
     View2D dgnumdry_m("dgnumdry_m", pver, ntot_amode);
+    mam4::modal_aer_opt::CalcsizeData cal_data;
+    cal_data.initialize();
 
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          Real inv_density[AeroConfig::num_modes()]
-                          [AeroConfig::num_aerosol_ids()] = {};
-          Real num2vol_ratio_min[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_max[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_max_nmodes[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_min_nmodes[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_nom_nmodes[AeroConfig::num_modes()] = {};
-          Real dgnmin_nmodes[AeroConfig::num_modes()] = {};
-          Real dgnmax_nmodes[AeroConfig::num_modes()] = {};
-          Real dgnnom_nmodes[AeroConfig::num_modes()] = {};
-          Real mean_std_dev_nmodes[AeroConfig::num_modes()] = {};
-          // outputs
-          bool noxf_acc2ait[AeroConfig::num_aerosol_ids()] = {};
-          int n_common_species_ait_accum = {};
-          int ait_spec_in_acc[AeroConfig::num_aerosol_ids()] = {};
-          int acc_spec_in_ait[AeroConfig::num_aerosol_ids()] = {};
-
-          modal_aero_calcsize::init_calcsize(
-              inv_density, num2vol_ratio_min, num2vol_ratio_max,
-              num2vol_ratio_max_nmodes, num2vol_ratio_min_nmodes,
-              num2vol_ratio_nom_nmodes, dgnmin_nmodes, dgnmax_nmodes,
-              dgnnom_nmodes, mean_std_dev_nmodes,
-              // outputs
-              noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-              acc_spec_in_ait);
-
-          const bool do_adjust = true;
-          const bool do_aitacc_transfer = true;
-          const bool update_mmr = false;
-
-          int nspec_amode[ntot_amode];
-          int lspectype_amode[maxd_aspectype][ntot_amode];
-          int lmassptr_amode[maxd_aspectype][ntot_amode];
-          Real specdens_amode[maxd_aspectype];
-          Real spechygro[maxd_aspectype];
-          int numptr_amode[ntot_amode];
-          int mam_idx[ntot_amode][nspec_max];
-          int mam_cnst_idx[ntot_amode][nspec_max];
-
-          ndrop::get_e3sm_parameters(
-              nspec_amode, lspectype_amode, lmassptr_amode, numptr_amode,
-              specdens_amode, spechygro, mam_idx, mam_cnst_idx);
-
-          // Note: Need to compute inv density using indexing from e3sm
-          for (int imode = 0; imode < ntot_amode; ++imode) {
-            const int nspec = nspec_amode[imode];
-            for (int isp = 0; isp < nspec; ++isp) {
-              const int idx = lspectype_amode[isp][imode] - 1;
-              inv_density[imode][isp] = 1.0 / specdens_amode[idx];
-            } // isp
-          }   // imode
-
           // FIXME: top_lev is set to 1 in calcsize ?
           const int top_lev = 0; // 1( in fortran )
 
@@ -111,16 +59,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
             modal_aero_calcsize::modal_aero_calcsize_sub(
                 state_q_k.data(), // in
                 qqcw_k.data(),    // in/out
-                dt, do_adjust, do_aitacc_transfer, update_mmr, lmassptr_amode,
-                numptr_amode,
-                inv_density, // in
-                num2vol_ratio_min, num2vol_ratio_max, num2vol_ratio_max_nmodes,
-                num2vol_ratio_min_nmodes, num2vol_ratio_nom_nmodes,
-                dgnmin_nmodes, dgnmax_nmodes, dgnnom_nmodes,
-                mean_std_dev_nmodes,
-                // outputs
-                noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-                acc_spec_in_ait, dgncur_i.data(), dgncur_c, ptend, dqqcwdt);
+                dt, cal_data, dgncur_i.data(), dgncur_c, ptend, dqqcwdt);
           } // k
         });
 

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -18,9 +18,6 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
     constexpr int pcnst = aero_model::pcnst;
     constexpr int pver = ndrop::pver;
     constexpr int ntot_amode = AeroConfig::num_modes();
-    constexpr int nspec_max = ndrop::nspec_max;
-    constexpr int maxd_aspectype = ndrop::maxd_aspectype;
-
     using View2D = DeviceType::view_2d<Real>;
 
     auto state_q_db = input.get_array("state_q");
@@ -50,52 +47,14 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
     View2D ptend_q("ptend_q", pver, pcnst);
     View2D dqqcwdt("dqqcwdt", pver, pcnst);
 
+    mam4::modal_aero_calcsize::CalcsizeData cal_data;
+    cal_data.initialize();
+    const bool update_mmr = true;
+    cal_data.set_update_mmr(update_mmr);
+
     auto team_policy = ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
-          Real inv_density[AeroConfig::num_modes()]
-                          [AeroConfig::num_aerosol_ids()] = {};
-          Real num2vol_ratio_min[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_max[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_max_nmodes[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_min_nmodes[AeroConfig::num_modes()] = {};
-          Real num2vol_ratio_nom_nmodes[AeroConfig::num_modes()] = {};
-          Real dgnmin_nmodes[AeroConfig::num_modes()] = {};
-          Real dgnmax_nmodes[AeroConfig::num_modes()] = {};
-          Real dgnnom_nmodes[AeroConfig::num_modes()] = {};
-          Real mean_std_dev_nmodes[AeroConfig::num_modes()] = {};
-          // outputs
-          bool noxf_acc2ait[AeroConfig::num_aerosol_ids()] = {};
-          int n_common_species_ait_accum = {};
-          int ait_spec_in_acc[AeroConfig::num_aerosol_ids()] = {};
-          int acc_spec_in_ait[AeroConfig::num_aerosol_ids()] = {};
-
-          modal_aero_calcsize::init_calcsize(
-              inv_density, num2vol_ratio_min, num2vol_ratio_max,
-              num2vol_ratio_max_nmodes, num2vol_ratio_min_nmodes,
-              num2vol_ratio_nom_nmodes, dgnmin_nmodes, dgnmax_nmodes,
-              dgnnom_nmodes, mean_std_dev_nmodes,
-              // outputs
-              noxf_acc2ait, n_common_species_ait_accum, ait_spec_in_acc,
-              acc_spec_in_ait);
-
-          const bool do_adjust = true;
-          const bool do_aitacc_transfer = true;
-          const bool update_mmr = true;
-
-          int nspec_amode[ntot_amode];
-          int lspectype_amode[maxd_aspectype][ntot_amode];
-          int lmassptr_amode[maxd_aspectype][ntot_amode];
-          Real specdens_amode[maxd_aspectype];
-          Real spechygro[maxd_aspectype];
-          int numptr_amode[ntot_amode];
-          int mam_idx[ntot_amode][nspec_max];
-          int mam_cnst_idx[ntot_amode][nspec_max];
-
-          ndrop::get_e3sm_parameters(
-              nspec_amode, lspectype_amode, lmassptr_amode, numptr_amode,
-              specdens_amode, spechygro, mam_idx, mam_cnst_idx);
-
           // FIXME: top_lev is set to 1 in calcsize ?
           const int top_lev = 0; // 1( in fortran )
 
@@ -111,14 +70,7 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
             modal_aero_calcsize::modal_aero_calcsize_sub(
                 state_q_k.data(), // in
                 qqcw_k.data(),    // in/out
-                dt, do_adjust, do_aitacc_transfer, update_mmr, lmassptr_amode,
-                numptr_amode,
-                inv_density, // in
-                num2vol_ratio_min, num2vol_ratio_max, num2vol_ratio_max_nmodes,
-                num2vol_ratio_min_nmodes, num2vol_ratio_nom_nmodes,
-                dgnmin_nmodes, dgnmax_nmodes, dgnnom_nmodes,
-                mean_std_dev_nmodes, noxf_acc2ait, n_common_species_ait_accum,
-                ait_spec_in_acc, acc_spec_in_ait,
+                dt, cal_data,
                 // outputs
                 dgncur_i.data(), dgncur_c, ptend_q_k.data(), dqqcwdt_k.data());
           } // k


### PR DESCRIPTION
Creating a calcsize data structure to group the many parameters used by calcsize. Additionally, this allows us to move the initialization of these parameters outside of the main computation kernel.

See also [PR 7161](https://github.com/E3SM-Project/E3SM/pull/7161) in e3sm.