### PR TITLE
Remove calls to printf on device as SYCL does not support it.

### DIFF
--- a/src/mam4xx/drydep.hpp
+++ b/src/mam4xx/drydep.hpp
@@ -129,10 +129,8 @@ Real cfint2(const haero::ConstColumnView xw /*nlev+1*/,
       intz = kk;
     }
   }
-  if (intz < 0) {
-    printf(" mo_spitfire_transport: cfint2 -- interval was not found\n");
-    Kokkos::abort(" mo_spitfire_transport: cfint2 -- interval was not found");
-  }
+  EKAT_KERNEL_ASSERT_MSG(
+      0 <= intz, " mo_spitfire_transport: cfint2 -- interval was not found");
 
   // now interpolate
 

--- a/src/mam4xx/gas_chem.hpp
+++ b/src/mam4xx/gas_chem.hpp
@@ -390,7 +390,7 @@ void imp_sol(Real base_sol[gas_pcnst], // inout - species mixing ratios [vmr]
     if (haero::abs(delt - interval_done) <= 0.0001) {
       if (fail_cnt > 0) {
         // FIXME: probably handle this more gracefully via error logging?
-        printf("ERROR: imp_sol failure @ (lchnk,lev,col) = \n");
+        EKAT_KERNEL_ERROR_MSG("ERROR: imp_sol failure @ (lchnk,lev,col) = \n");
       }
       break;
     } else {


### PR DESCRIPTION
Calls to printf will cause compiler errors on Aurora.