### PR TITLE
Usability upgrades for manually-triggered workflows and fix codecov bug

### DIFF
--- a/.github/workflows/AT2-README.md
+++ b/.github/workflows/AT2-README.md
@@ -1,0 +1,80 @@
+# Autotester2 (AT2) Workflow for MAM4xx
+ This document contains a brief description of how AT2 is used to automate testing on SNL hardware.
+Additionally, any helpful notes and TODOs may be kept here to assist developers.
+
+## Overview
+
+AT2 is a Sandia-developed project for automating testing via GitHub Actions to be run on self-hosted runners on the SNL network.
+Part of what AT2 does is control access using information about the repository, organization, user, etc. obtained via the GitHub API.
+This is done for security/policy reasons and ensures that only those with approved SNL computing accounts can run the CI code on SNL hardware.
+
+### Test Hardware and Compiler Configurations
+
+| Test Name            | GPU Brand | GPU Type | Micoarchitecture | Compute Capability | Machine | Compilers                    |
+| -------------------- | --------- | -------- | ---------------- | ------------------ | ------- | ---------------------------- |
+| gcc_12-3-0_cuda_12-1 | NVIDIA    | H100     | Hopper           | 9.0                | blake   | `gcc` 12.3.0/`nvcc` 12.1.105 |
+
+### The Flow of the CI Workflow
+
+AT2 runs on the target SNL machine and makes a handful of self-hosted runners available to the MAM4xx repo.
+This is all controlled by the **MAM4xx** SNL entity account that is linked to the **mam4xxSNL** GitHub account.
+Each runner stays in a "holding pattern" until it is assigned a job via GitHub Actions.
+The holding pattern pulls the testing image from the AT2 Gitlab repo (if necessary), runs the related container for 3 minutes, and then tears down and starts over.
+As of now, the image is of a UBI 8 system, with Spack-installed compilers and all of the requisite TPLs to clone/build/run MAM4xx.
+
+#### Triggering the Testing Workflow
+
+This autotesting workflow is triggered by opening a pull request to `main` and also by a handful of actions on such a PR that is already open, including:
+
+- `reopened`
+- `ready_for_review`
+  - I.e., converted to ***Ready for Review*** from ***Draft***
+- `synchronize`
+  - E.g., pushing a new commit or force pushing after rebase
+
+The workflow may also be run manually by members of the `snl-testing` team--that is, via
+
+> **Actions** -> **SNL-AT2 Workflow** -> **Run Workflow** -> *Choose Branch from Dropdown Menu*.
+
+or
+
+> **Actions** -> `<Previously-run SNL-AT2 Workflow/Job>` -> **Re-run `[all,this]` job(s)**.
+
+The AT2 configuration on `blake` currently attempts to keep 3 runners available
+to accept jobs at all times.
+This workflow is configured to allow concurrent testing, so up to 3 test-matrix
+configurations can run at once.
+The concurrency setting is also configured to kill any active job if another
+instance of this workflow is started for the same PR ref.
+
+##### Other Types of Job Control
+
+- In the case that a PR is submitted by someone who is not a member of the `snl-testing` team or contains commits from someone outside of that team will not trigger AT2-based autotesting (i.e., GPU-based).
+  - An approving review by a member of the `snl-testing` team is required to trigger autotesting for such a PR.
+  - This also applies if a new commit is pushed to an open PR by a developer not on the `snl-testing` team.
+- If a PR contains changes to the `.github` directory, autotesting will not trigger.
+  - Akin to above, a member of the `snl-testing-admins` team must add the `CI-AT2_special_approval` tag to the PR in order to kick off the autotesting.
+- For changes unrelated to the `.github` directory, any PR that is submitted by a member of the `snl-testing` team, and *only contains commits from members of that team* will automatically trigger this autotesting.
+
+## Development Details
+
+Most of the required configuration is provided by the AT2 docs and instructional Confluence page (on the Sandia network :confused:--reach out if you need access).
+However, some non-obvious choices and configurations are listed here.
+
+- To add some info to the testing output, we employ a custom action, cribbed from E3SM/EAMxx, that prints out the workflow's trigger.
+
+### Hacks
+
+- For whatever reason, Skywalker does not like building in the `gcc_12-3-0_cuda_12-1` container for the H100 GPU.
+  - This appears to be an issue of the (Haero?) build not auto-detecting the correct Compute Capability (CC 9.0 => `sm_90`).
+  - To overcome this, we first obtain the CC flag via `nvidia-smi` within the testing container.
+  - Then, we employ `sed` to manually change the `default_arch="sm_<xyz>"` of the Haero-provided `nvcc_wrapper` (`haero_install/bin/nvcc_wrapper`).
+  - We follow up with a quick `grep` to confirm this.
+
+### Tokens
+
+- AT2 requires 2 fine-grained tokens for the **mam4xxSNL** account from the `eagles-project` GitHub Organization in order to access information related to the `mam4xx` repo.
+  - One token used to fetch and read/write runner information.
+  - **Expires 11 April 2026**
+  - One token used fetch and read repository information via the API.
+  - **Expires 2 May 2025**

--- a/.github/workflows/at2_gcc-cuda.yml
+++ b/.github/workflows/at2_gcc-cuda.yml
@@ -1,19 +1,72 @@
 name: "GPU AT2 gcc 12.3 cuda 12.1"
 
 on:
-  workflow_call
+  workflow_call:
+    inputs:
+      precision:
+        required: false
+        type: string
+      build_type:
+        required: false
+        type: string
 
 jobs:
+  # this is more work than I'd expect, but this is how you pass info after
+  # operating on it in a job/step
+  # TODO: factor this out into an action?
+  # parse the inputs from the workflow call that'll be used by strategy.matrix
+  define_matrix:
+    runs-on: ubuntu-22.04
+    # define the outputs that will come from the steps below
+    outputs:
+      build_type: ${{ steps.build_type.outputs.build_type }}
+      precision: ${{ steps.precision.outputs.precision }}
+    steps:
+      - name: Define build_type
+        id: build_type
+        env:
+          # if empty (i.e., triggered by PR) make ALL default
+          btype: ${{ inputs.build_type || 'ALL' }}
+        # this is a little over-cautious, since the 'else' should never happen
+        run: |
+          case ${{ env.btype }} in
+            "Debug")
+              echo 'build_type=["Debug"]' >> "$GITHUB_OUTPUT" ;;
+            "Release")
+              echo 'build_type=["Release"]' >> "$GITHUB_OUTPUT" ;;
+            "ALL")
+              echo 'build_type=["Debug", "Release"]' >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo 'build_type=["Debug", "Release"]' >> "$GITHUB_OUTPUT" ;;
+          esac
+      - name: Define precision
+        id: precision
+        env:
+          prec: ${{ inputs.precision || 'ALL' }}
+        run: |
+          case ${{ env.prec }} in
+            "Debug")
+              echo 'precision=["single"]' >> "$GITHUB_OUTPUT" ;;
+            "Release")
+              echo 'precision=["double"]' >> "$GITHUB_OUTPUT" ;;
+            "ALL")
+              echo 'precision=["single", "double"]' >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo 'precision=["single", "double"]' >> "$GITHUB_OUTPUT" ;;
+          esac
   gcc-cuda:
     runs-on:  [self-hosted, m4xci-snl-cuda, cuda, gcc]
     # will run other tests in the matrix even if one fails
     # NOTE: prioritizes extra info over speed, so consider whether this makes sense
     continue-on-error: false
+    needs: define_matrix
+    # A build matrix storing all desired configurations.
     strategy:
       fail-fast: true
       matrix:
-        build-type: [Debug, Release]
-        fp-precision: [single, double]
+        # to get the array instead of a string, need the fromJSON()
+        build-type: ${{ fromJSON(needs.define_matrix.outputs.build_type) }}
+        fp-precision: ${{ fromJSON(needs.define_matrix.outputs.precision) }}
     name: gcc-cuda / ${{ matrix.build-type }} - ${{ matrix.fp-precision }}
     steps:
       - name: Check out the repository

--- a/.github/workflows/gh_gcc-cpu.yml
+++ b/.github/workflows/gh_gcc-cpu.yml
@@ -65,6 +65,7 @@ jobs:
           esac
   # This job builds the box model and runs our test suite.
   build_test_coverage:
+    continue-on-error: false
     needs: define_matrix
     # A build matrix storing all desired configurations.
     strategy:

--- a/.github/workflows/gh_gcc-cpu.yml
+++ b/.github/workflows/gh_gcc-cpu.yml
@@ -4,18 +4,76 @@ name: "GitHub CPU Auto-test Ubuntu 22.04"
 # 1. when someone creates a pull request for a merge to the main branch
 # 2. when changes are merged into the main branch (via a pull request)
 on:
-  workflow_call
+  workflow_call:
+    inputs:
+      precision:
+        required: false
+        type: string
+      build_type:
+        required: false
+        type: string
+    # this is required because secrets are not passed to reusable
+    # workflows by default
+    secrets:
+      cc_token:
+        required: true
 
 # Below are jobs, each of which runs sequentially.
 jobs:
+  # this is more work than I'd expect, but this is how you pass info after
+  # operating on it in a job/step
+  # TODO: factor this out into an action?
+  # parse the inputs from the workflow call that'll be used by strategy.matrix
+  define_matrix:
+    runs-on: ubuntu-22.04
+    # define the outputs that will come from the steps below
+    outputs:
+      build_type: ${{ steps.build_type.outputs.build_type }}
+      precision: ${{ steps.precision.outputs.precision }}
+    steps:
+      - name: Define build_type
+        id: build_type
+        env:
+          # if empty (i.e., triggered by PR) make ALL default
+          btype: ${{ inputs.build_type || 'ALL' }}
+        # this is a little over-cautious, since the 'else' should never happen
+        run: |
+          case ${{ env.btype }} in
+            "Debug")
+              echo 'build_type=["Debug"]' >> "$GITHUB_OUTPUT" ;;
+            "Release")
+              echo 'build_type=["Release"]' >> "$GITHUB_OUTPUT" ;;
+            "ALL")
+              echo 'build_type=["Debug", "Release"]' >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo 'build_type=["Debug", "Release"]' >> "$GITHUB_OUTPUT" ;;
+          esac
+      - name: Define precision
+        id: precision
+        env:
+          prec: ${{ inputs.precision || 'ALL' }}
+        run: |
+          case ${{ env.prec }} in
+            "Debug")
+              echo 'precision=["single"]' >> "$GITHUB_OUTPUT" ;;
+            "Release")
+              echo 'precision=["double"]' >> "$GITHUB_OUTPUT" ;;
+            "ALL")
+              echo 'precision=["single", "double"]' >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo 'precision=["single", "double"]' >> "$GITHUB_OUTPUT" ;;
+          esac
   # This job builds the box model and runs our test suite.
   build_test_coverage:
+    needs: define_matrix
     # A build matrix storing all desired configurations.
     strategy:
+      fail-fast: true
       matrix:
         os: [ubuntu-22.04] #, macos-latest]
-        build-type: [Debug, Release]
-        fp-precision: [single, double]
+        # to get the array instead of a string, need the fromJSON()
+        build-type: ${{ fromJSON(needs.define_matrix.outputs.build_type) }}
+        fp-precision: ${{ fromJSON(needs.define_matrix.outputs.precision) }}
 
     runs-on: ${{ matrix.os }}
 
@@ -109,10 +167,10 @@ jobs:
 
       - name: Uploading coverage report to codecov.io
         if: ${{ (contains(matrix.os, 'ubuntu')) && (matrix.build-type == 'Debug') && (matrix.fp-precision == 'double') }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           files: build/coverage.info
           name: mam4xx
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.cc_token }}
           verbose: true

--- a/.github/workflows/m4x_autotester_main.yml
+++ b/.github/workflows/m4x_autotester_main.yml
@@ -24,9 +24,28 @@ on:
         description: 'Test Machine Architecture'
         required: true
         type: choice
+        default: 'GPU-NVIDIA_H100'
         options:
           - GPU-NVIDIA_H100
           - CPU-Ubuntu_22-04
+          - ALL
+      precision:
+        description: 'Floating-point Precision'
+        required: true
+        type: choice
+        default: 'double'
+        options:
+          - double
+          - single
+          - ALL
+      build_type:
+        description: 'Build Type'
+        required: true
+        type: choice
+        default: 'Debug'
+        options:
+          - Debug
+          - Release
           - ALL
 
   # Add schedule trigger for nightly runs at midnight MT (Standard Time)
@@ -37,6 +56,9 @@ concurrency:
   # Two runs are in the same group if they are testing the same git ref
   #  - if trigger=pull_request, the ref is refs/pull/<PR_NUMBER>/merge
   #  - for other triggers, the ref is the branch tested
+  # TODO: There's probably a less ugly way to create this group name, but
+  # currently unsure how to add a literal '-', contingent upon existence of
+  # github.event.inputs.architecture
   group: ${{ github.workflow }}-${{ github.ref }}${{ github.event.inputs.architecture }}
   cancel-in-progress: true
 
@@ -45,10 +67,12 @@ jobs:
     if: ${{ github.event.pull_request || github.event.schedule }}
     uses:
       ./.github/workflows/at2_gcc-cuda.yml
-  gh_auto_test:
+  gcc-cpu_gh:
     if: ${{ github.event.pull_request || github.event.schedule }}
+    secrets:
+      cc_token: ${{ secrets.CODECOV_TOKEN }}
     uses:
-      ./.github/workflows/gh_auto_test.yml
+      ./.github/workflows/gh_gcc-cpu.yml
   clang-format_check:
     if: ${{ github.event.pull_request }}
     uses:
@@ -56,10 +80,18 @@ jobs:
   manual-gpu_cuda:
     if: ${{ contains(github.event.inputs.architecture, 'GPU-NVIDIA_H100') ||
             contains(github.event.inputs.architecture, 'ALL') }}
+    with:
+      precision: ${{ github.event.inputs.precision }}
+      build_type: ${{ github.event.inputs.build_type }}
     uses:
       "./.github/workflows/at2_gcc-cuda.yml"
   manual-cpu_gh:
     if: ${{ contains(github.event.inputs.architecture, 'CPU-Ubuntu_22-04') ||
             contains(github.event.inputs.architecture, 'ALL') }}
+    with:
+      precision: ${{ github.event.inputs.precision }}
+      build_type: ${{ github.event.inputs.build_type }}
+    secrets:
+      cc_token: ${{ secrets.CODECOV_TOKEN }}
     uses:
-      ./.github/workflows/gh_auto_test.yml
+      ./.github/workflows/gh_gcc-cpu.yml


### PR DESCRIPTION
This PR modifies the following:

1. Options for manually-triggered workflows
    - More granularity for choosing the type of test--options are now:
      - Branch
      - Test Machine Architecture
        - Current Options:
          - `GPU-NVIDIA_H100`
          - `CPU-Ubuntu_22-04`
          - `ALL`
      - Floating-point Precision
        - Current Options:
          - `single`
          - `double`
          - `ALL`
      - Build Type
        - Current Options:
          - `Debug`
          - `Release`
          - `ALL`
    - Some helpful resources for setting this up:
      - [Workflow Dispatch Inputs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs)
      - [Workflow Call Syntax - Inputs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_call)
1. Updates the codecov action to v5
    - This wasn't strictly necessary but was a part of debugging a token issue and figured I might as well.
1. Fixes an issue with the `CODECOV_TOKEN`
    - As it turns out, sub-workflows don't naturally have access to repository secrets, so this needs to be passed manually.
      - This process is rather tortuous and took some time to track down.
      - These doc pages were helpful:
        - [Passing secrets to nested workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#passing-secrets-to-nested-workflows)
        - [Using an output to define matrix strategies](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#example-using-an-output-to-define-two-matrices)
        - [Using Job Outputs in a Matrix Job](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#using-job-outputs-in-a-matrix-job)
        - [Defining outputs for a job](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-defining-outputs-for-a-job)
        - [Workflow Syntax - `needs`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds)
          - [The `needs` Context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#needs-context)
---

## Old PR Message

Uploading codecov reports is currently failing, so this seemed like a good time to use the latest version and see if it's a magic fix 🤞 

I suspect it may be a token issue, though, since I'm seeing this in the logs

```
[2025-04-29T16:30:46.807Z] ['verbose'] Passed token was 0 characters long

[...]

[2025-04-29T16:30:47.007Z] ['error'] There was an error running the uploader: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 429 - {"message":"Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 406s."}

[2025-04-29T16:30:47.008Z] ['verbose'] The error stack is: Error: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 429 - {"message":"Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 406s."}
```