### PR TITLE
Removing .data() from calcsize routines.

### DIFF
--- a/src/mam4xx/modal_aer_opt.hpp
+++ b/src/mam4xx/modal_aer_opt.hpp
@@ -507,17 +507,14 @@ void binterp(const View3D &table, const Real ref_real, const Real ref_img,
   } // icoef
 
 } // binterp
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void compute_calcsize_and_water_uptake_dr(const Real &pmid,
-                                          const Real &temperature, Real &cldn,
-                                          const VectorType& state_q_kk,   // in
-                                          const VectorType& qqcw_k, // in
-                                          const Real &dt,
-                                          const CalcsizeData &calcsizedata,
-                                          // outputs
-                                          Real dgnumwet_m_kk[ntot_amode],
-                                          Real qaerwat_m_kk[ntot_amode]) {
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void compute_calcsize_and_water_uptake_dr(
+    const Real &pmid, const Real &temperature, Real &cldn,
+    const VectorType &state_q_kk, // in
+    const VectorType &qqcw_k,     // in
+    const Real &dt, const CalcsizeData &calcsizedata,
+    // outputs
+    Real dgnumwet_m_kk[ntot_amode], Real qaerwat_m_kk[ntot_amode]) {
 
   Real dgncur_c_kk[ntot_amode] = {};
   Real dgnumdry_m_kk[ntot_amode] = {};
@@ -536,12 +533,11 @@ void compute_calcsize_and_water_uptake_dr(const Real &pmid,
       temperature, pmid, cldn, dgnumdry_m_kk, dgnumwet_m_kk, qaerwat_m_kk);
 } // compute_calcsize_water_uptake_dr
 
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void modal_aero_sw_wo_diagnostics_k(
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void modal_aero_sw_wo_diagnostics_k(
     const Real &pdeldry, const Real &pmid, const Real &temperature, Real &cldn,
-    const VectorType& state_q_kk,   // in
-    const VectorType& qqcw_k, // in
+    const VectorType &state_q_kk, // in
+    const VectorType &qqcw_k,     // in
     const Real &dt, const AerosolOpticsDeviceData &aersol_optics_data,
     const CalcsizeData &calcsizedata,
     // outputs
@@ -861,17 +857,15 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt,
       aodvis);
 
 } //
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void modal_aero_lw_k(const Real &pdeldry, const Real &pmid,
-                     const Real &temperature, Real &cldn,
-                     const VectorType&state_q_kk,   // in
-                     const VectorType&qqcw_k, // in
-                     const Real &dt,
-                     const AerosolOpticsDeviceData &aersol_optics_data,
-                     const CalcsizeData &calcsizedata,
-                     // outputs
-                     Real *tauxar) {
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void modal_aero_lw_k(
+    const Real &pdeldry, const Real &pmid, const Real &temperature, Real &cldn,
+    const VectorType &state_q_kk, // in
+    const VectorType &qqcw_k,     // in
+    const Real &dt, const AerosolOpticsDeviceData &aersol_optics_data,
+    const CalcsizeData &calcsizedata,
+    // outputs
+    Real *tauxar) {
 
   // FORTRAN refactoring: For prognostic aerosols only, other options are
   // removed

--- a/src/mam4xx/modal_aer_opt.hpp
+++ b/src/mam4xx/modal_aer_opt.hpp
@@ -507,12 +507,12 @@ void binterp(const View3D &table, const Real ref_real, const Real ref_img,
   } // icoef
 
 } // binterp
-
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void compute_calcsize_and_water_uptake_dr(const Real &pmid,
                                           const Real &temperature, Real &cldn,
-                                          Real *state_q_kk,   // in
-                                          const Real *qqcw_k, // in
+                                          const VectorType& state_q_kk,   // in
+                                          const VectorType& qqcw_k, // in
                                           const Real &dt,
                                           const CalcsizeData &calcsizedata,
                                           // outputs
@@ -536,11 +536,12 @@ void compute_calcsize_and_water_uptake_dr(const Real &pmid,
       temperature, pmid, cldn, dgnumdry_m_kk, dgnumwet_m_kk, qaerwat_m_kk);
 } // compute_calcsize_water_uptake_dr
 
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void modal_aero_sw_wo_diagnostics_k(
     const Real &pdeldry, const Real &pmid, const Real &temperature, Real &cldn,
-    Real *state_q_kk,   // in
-    const Real *qqcw_k, // in
+    const VectorType& state_q_kk,   // in
+    const VectorType& qqcw_k, // in
     const Real &dt, const AerosolOpticsDeviceData &aersol_optics_data,
     const CalcsizeData &calcsizedata,
     // outputs
@@ -860,12 +861,12 @@ void modal_aero_sw(const ThreadTeam &team, const Real dt,
       aodvis);
 
 } //
-
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void modal_aero_lw_k(const Real &pdeldry, const Real &pmid,
                      const Real &temperature, Real &cldn,
-                     Real *state_q_kk,   // in
-                     const Real *qqcw_k, // in
+                     const VectorType&state_q_kk,   // in
+                     const VectorType&qqcw_k, // in
                      const Real &dt,
                      const AerosolOpticsDeviceData &aersol_optics_data,
                      const CalcsizeData &calcsizedata,

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -266,7 +266,7 @@ void compute_coef_acc_ait_transfer(
   }
 
 } // end compute_coef_acc_ait_transfer
-
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION void size_adjustment(
     const int imode, const Real dryvol_i, const Real n_i_imode,
     const Real dryvol_c,
@@ -283,7 +283,7 @@ KOKKOS_INLINE_FUNCTION void size_adjustment(
     Real &num2vol_ratio_cur_c, Real &dryvol_i_accsv, Real &dryvol_c_accsv,
     Real &dryvol_i_aitsv, Real &dryvol_c_aitsv, Real &drv_i_sv, Real &drv_c_sv,
     Real &num_i_k_accsv, Real &num_c_k_accsv, Real &num_i_k_aitsv,
-    Real &num_c_k_aitsv, Real &num_i_sv, Real &num_c_sv, Real &dnidt_imode,
+    Real &num_c_k_aitsv, Real &num_i_sv, Real &num_c_sv,  VectorType &dnidt_imode,
     Real &dncdt_imode) {
 
   constexpr Real zero = 0;
@@ -353,9 +353,6 @@ KOKKOS_INLINE_FUNCTION void size_adjustment(
 
     // number tendencies to be updated by adjust_num_sizes subroutine
 
-    auto &interstitial_tend = dnidt_imode;
-    auto &cloudborne_tend = dncdt_imode;
-
     /*NOTE: Only number tendencies (NOT mass mixing ratios) are
      updated in adjust_num_sizes Effect of these adjustment will be
      reflected in the particle diameters (via
@@ -368,7 +365,7 @@ KOKKOS_INLINE_FUNCTION void size_adjustment(
           num2vol_ratio_min_imode, num2vol_ratio_max_imode,
           adj_tscale_inv,                      // in
           num_i_k, num_c_k,                    // out
-          interstitial_tend, cloudborne_tend); // out
+          dnidt_imode, dncdt_imode); // out
     }
   }
 
@@ -463,7 +460,7 @@ void update_tends_flx(const int jmode,         // in
                       const int *src_species_idx, //
                       const int *dest_species_idx,
                       const Real xfertend_num[2][2], const Real xfercoef,
-                      const VectorType& state_q, const VectorType& qqcw, Real *ptend,
+                      const VectorType& state_q, const VectorType& qqcw, VectorType& ptend,
                       Real *dqqcwdt) {
 
   // NOTES on arrays and indices:
@@ -509,13 +506,13 @@ void update_tends_flx(const int jmode,         // in
 template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void aitken_accum_exchange(
-  const VectorType&state_q, const VectorType&qqcw, const int &aitken_idx,
+    const VectorType& state_q, const VectorType& qqcw, const int &aitken_idx,
     const int &accum_idx, const CalcsizeData &calcsizedata,
     const Real &adj_tscale_inv, const Real &dt, const Real &drv_i_aitsv,
     const Real &num_i_aitsv, const Real &drv_c_aitsv, const Real &num_c_aitsv,
     const Real &drv_i_accsv, const Real &num_i_accsv, const Real &drv_c_accsv,
     const Real &num_c_accsv, Real &dgncur_i_aitken, Real &dgncur_i_accum,
-    Real &dgncur_c_aitken, Real &dgncur_c_accum, Real *ptend, Real *dqqcwdt) {
+    Real &dgncur_c_aitken, Real &dgncur_c_accum,  VectorType& ptend, Real *dqqcwdt) {
 
   // FIXME: This version of does not include 	update_mmr=true, i.e tendencies
   // are not updated.
@@ -763,7 +760,7 @@ void modal_aero_calcsize_sub(const VectorType& state_q, // in
                              const Real dt, const CalcsizeData &calcsizedata,
                              Real dgncur_i[AeroConfig::num_modes()],
                              Real dgncur_c[AeroConfig::num_modes()],
-                             Real *ptend, Real *dqqcwdt) {
+                             VectorType& ptend, Real *dqqcwdt) {
 
   const Real zero = 0.0;
   const int aitken_idx = int(ModeIndex::Aitken);

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -461,7 +461,7 @@ void update_tends_flx(const int jmode,         // in
                       const int *dest_species_idx,
                       const Real xfertend_num[2][2], const Real xfercoef,
                       const VectorType& state_q, const VectorType& qqcw, VectorType& ptend,
-                      Real *dqqcwdt) {
+                      VectorType& dqqcwdt) {
 
   // NOTES on arrays and indices:
   // jmode==0 is aitken->accumulation transfer;
@@ -512,7 +512,7 @@ void aitken_accum_exchange(
     const Real &num_i_aitsv, const Real &drv_c_aitsv, const Real &num_c_aitsv,
     const Real &drv_i_accsv, const Real &num_i_accsv, const Real &drv_c_accsv,
     const Real &num_c_accsv, Real &dgncur_i_aitken, Real &dgncur_i_accum,
-    Real &dgncur_c_aitken, Real &dgncur_c_accum,  VectorType& ptend, Real *dqqcwdt) {
+    Real &dgncur_c_aitken, Real &dgncur_c_accum,  VectorType& ptend, VectorType& dqqcwdt) {
 
   // FIXME: This version of does not include 	update_mmr=true, i.e tendencies
   // are not updated.
@@ -753,14 +753,14 @@ void aitken_accum_exchange(
 
 } // aitken_accum_exchange
 
-template<typename VectorType>
+template<typename VectorType, typename VectorTypeModes>
 KOKKOS_INLINE_FUNCTION
 void modal_aero_calcsize_sub(const VectorType& state_q, // in
                              const VectorType& qqcw,    // in
                              const Real dt, const CalcsizeData &calcsizedata,
-                             Real dgncur_i[AeroConfig::num_modes()],
-                             Real dgncur_c[AeroConfig::num_modes()],
-                             VectorType& ptend, Real *dqqcwdt) {
+                             VectorTypeModes& dgncur_i,
+                             VectorTypeModes& dgncur_c,
+                             VectorType& ptend, VectorType& dqqcwdt) {
 
   const Real zero = 0.0;
   const int aitken_idx = int(ModeIndex::Aitken);

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -165,10 +165,11 @@ struct CalcsizeData {
 };
 
 // NOTE: this version uses state_q and qqcw variables using format from e3sm
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void compute_coef_acc_ait_transfer(
     int iacc, const Real num2vol_ratio_geomean, const Real adj_tscale_inv,
-    const Real *state_q, const Real *qqcw, const Real drv_i_accsv,
+    const VectorType&state_q, const VectorType&qqcw, const Real drv_i_accsv,
     const Real drv_c_accsv, const Real num_i_accsv, const Real num_c_accsv,
     const bool noxf_acc2ait[AeroConfig::num_aerosol_ids()],
     const Real voltonum_ait,
@@ -426,12 +427,12 @@ KOKKOS_INLINE_FUNCTION void size_adjustment(
   num_c_sv = num_c_k;
 
 } /// size_adjustment
-
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void compute_dry_volume(
     int imode,           // in
-    const Real *state_q, // in
-    const Real *qqcw,    // in
+    const VectorType& state_q, // in
+    const VectorType& qqcw,    // in
     const Real inv_density[AeroConfig::num_modes()]
                           [AeroConfig::num_aerosol_ids()], // in
     const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
@@ -453,6 +454,7 @@ void compute_dry_volume(
 } // end
 
 //------------------------------------------------------------------------------------------------
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void update_tends_flx(const int jmode,         // in
                       const int src_mode_ixd,  // in
@@ -461,7 +463,7 @@ void update_tends_flx(const int jmode,         // in
                       const int *src_species_idx, //
                       const int *dest_species_idx,
                       const Real xfertend_num[2][2], const Real xfercoef,
-                      const Real *state_q, const Real *qqcw, Real *ptend,
+                      const VectorType& state_q, const VectorType& qqcw, Real *ptend,
                       Real *dqqcwdt) {
 
   // NOTES on arrays and indices:
@@ -504,10 +506,10 @@ void update_tends_flx(const int jmode,         // in
   }
 
 } // end update_tends_flx
-
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void aitken_accum_exchange(
-    const Real *state_q, const Real *qqcw, const int &aitken_idx,
+  const VectorType&state_q, const VectorType&qqcw, const int &aitken_idx,
     const int &accum_idx, const CalcsizeData &calcsizedata,
     const Real &adj_tscale_inv, const Real &dt, const Real &drv_i_aitsv,
     const Real &num_i_aitsv, const Real &drv_c_aitsv, const Real &num_c_aitsv,
@@ -754,9 +756,10 @@ void aitken_accum_exchange(
 
 } // aitken_accum_exchange
 
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
-void modal_aero_calcsize_sub(const Real *state_q, // in
-                             const Real *qqcw,    // in
+void modal_aero_calcsize_sub(const VectorType& state_q, // in
+                             const VectorType& qqcw,    // in
                              const Real dt, const CalcsizeData &calcsizedata,
                              Real dgncur_i[AeroConfig::num_modes()],
                              Real dgncur_c[AeroConfig::num_modes()],

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -165,11 +165,10 @@ struct CalcsizeData {
 };
 
 // NOTE: this version uses state_q and qqcw variables using format from e3sm
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void compute_coef_acc_ait_transfer(
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void compute_coef_acc_ait_transfer(
     int iacc, const Real num2vol_ratio_geomean, const Real adj_tscale_inv,
-    const VectorType&state_q, const VectorType&qqcw, const Real drv_i_accsv,
+    const VectorType &state_q, const VectorType &qqcw, const Real drv_i_accsv,
     const Real drv_c_accsv, const Real num_i_accsv, const Real num_c_accsv,
     const bool noxf_acc2ait[AeroConfig::num_aerosol_ids()],
     const Real voltonum_ait,
@@ -266,7 +265,7 @@ void compute_coef_acc_ait_transfer(
   }
 
 } // end compute_coef_acc_ait_transfer
-template<typename VectorType>
+template <typename VectorType>
 KOKKOS_INLINE_FUNCTION void size_adjustment(
     const int imode, const Real dryvol_i, const Real n_i_imode,
     const Real dryvol_c,
@@ -283,8 +282,8 @@ KOKKOS_INLINE_FUNCTION void size_adjustment(
     Real &num2vol_ratio_cur_c, Real &dryvol_i_accsv, Real &dryvol_c_accsv,
     Real &dryvol_i_aitsv, Real &dryvol_c_aitsv, Real &drv_i_sv, Real &drv_c_sv,
     Real &num_i_k_accsv, Real &num_c_k_accsv, Real &num_i_k_aitsv,
-    Real &num_c_k_aitsv, Real &num_i_sv, Real &num_c_sv,  VectorType &dnidt_imode,
-    Real &dncdt_imode) {
+    Real &num_c_k_aitsv, Real &num_i_sv, Real &num_c_sv,
+    VectorType &dnidt_imode, Real &dncdt_imode) {
 
   constexpr Real zero = 0;
 
@@ -363,8 +362,8 @@ KOKKOS_INLINE_FUNCTION void size_adjustment(
       calcsize::adjust_num_sizes(
           dryvol_i, dryvol_c, init_num_i, init_num_c, dt, // in
           num2vol_ratio_min_imode, num2vol_ratio_max_imode,
-          adj_tscale_inv,                      // in
-          num_i_k, num_c_k,                    // out
+          adj_tscale_inv,            // in
+          num_i_k, num_c_k,          // out
           dnidt_imode, dncdt_imode); // out
     }
   }
@@ -424,12 +423,11 @@ KOKKOS_INLINE_FUNCTION void size_adjustment(
   num_c_sv = num_c_k;
 
 } /// size_adjustment
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void compute_dry_volume(
-    int imode,           // in
-    const VectorType& state_q, // in
-    const VectorType& qqcw,    // in
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void compute_dry_volume(
+    int imode,                 // in
+    const VectorType &state_q, // in
+    const VectorType &qqcw,    // in
     const Real inv_density[AeroConfig::num_modes()]
                           [AeroConfig::num_aerosol_ids()], // in
     const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
@@ -451,17 +449,17 @@ void compute_dry_volume(
 } // end
 
 //------------------------------------------------------------------------------------------------
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void update_tends_flx(const int jmode,         // in
-                      const int src_mode_ixd,  // in
-                      const int dest_mode_ixd, // in
-                      const int n_common_species_ait_accum,
-                      const int *src_species_idx, //
-                      const int *dest_species_idx,
-                      const Real xfertend_num[2][2], const Real xfercoef,
-                      const VectorType& state_q, const VectorType& qqcw, VectorType& ptend,
-                      VectorType& dqqcwdt) {
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void
+update_tends_flx(const int jmode,         // in
+                 const int src_mode_ixd,  // in
+                 const int dest_mode_ixd, // in
+                 const int n_common_species_ait_accum,
+                 const int *src_species_idx, //
+                 const int *dest_species_idx, const Real xfertend_num[2][2],
+                 const Real xfercoef, const VectorType &state_q,
+                 const VectorType &qqcw, VectorType &ptend,
+                 VectorType &dqqcwdt) {
 
   // NOTES on arrays and indices:
   // jmode==0 is aitken->accumulation transfer;
@@ -503,16 +501,16 @@ void update_tends_flx(const int jmode,         // in
   }
 
 } // end update_tends_flx
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void aitken_accum_exchange(
-    const VectorType& state_q, const VectorType& qqcw, const int &aitken_idx,
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void aitken_accum_exchange(
+    const VectorType &state_q, const VectorType &qqcw, const int &aitken_idx,
     const int &accum_idx, const CalcsizeData &calcsizedata,
     const Real &adj_tscale_inv, const Real &dt, const Real &drv_i_aitsv,
     const Real &num_i_aitsv, const Real &drv_c_aitsv, const Real &num_c_aitsv,
     const Real &drv_i_accsv, const Real &num_i_accsv, const Real &drv_c_accsv,
     const Real &num_c_accsv, Real &dgncur_i_aitken, Real &dgncur_i_accum,
-    Real &dgncur_c_aitken, Real &dgncur_c_accum,  VectorType& ptend, VectorType& dqqcwdt) {
+    Real &dgncur_c_aitken, Real &dgncur_c_accum, VectorType &ptend,
+    VectorType &dqqcwdt) {
 
   // FIXME: This version of does not include 	update_mmr=true, i.e tendencies
   // are not updated.
@@ -753,14 +751,13 @@ void aitken_accum_exchange(
 
 } // aitken_accum_exchange
 
-template<typename VectorType, typename VectorTypeModes>
-KOKKOS_INLINE_FUNCTION
-void modal_aero_calcsize_sub(const VectorType& state_q, // in
-                             const VectorType& qqcw,    // in
-                             const Real dt, const CalcsizeData &calcsizedata,
-                             VectorTypeModes& dgncur_i,
-                             VectorTypeModes& dgncur_c,
-                             VectorType& ptend, VectorType& dqqcwdt) {
+template <typename VectorType, typename VectorTypeModes>
+KOKKOS_INLINE_FUNCTION void
+modal_aero_calcsize_sub(const VectorType &state_q, // in
+                        const VectorType &qqcw,    // in
+                        const Real dt, const CalcsizeData &calcsizedata,
+                        VectorTypeModes &dgncur_i, VectorTypeModes &dgncur_c,
+                        VectorType &ptend, VectorType &dqqcwdt) {
 
   const Real zero = 0.0;
   const int aitken_idx = int(ModeIndex::Aitken);

--- a/src/mam4xx/utils.hpp
+++ b/src/mam4xx/utils.hpp
@@ -219,9 +219,10 @@ void get_num_idx_in_state_q(int idxs[AeroConfig::num_modes()]) {
 // This object can be provided to mam4xx for the column.
 
 // MUST FIXME: address James comments about making the code better.
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void extract_stateq_from_prognostics(const mam4::Prognostics &progs,
-                                     const haero::Atmosphere &atm, Real *q,
+                                     const haero::Atmosphere &atm, VectorType&q,
                                      const int klev) {
 
   int s_idx = ekat::ScalarTraits<int>::invalid();
@@ -257,8 +258,9 @@ void extract_stateq_from_prognostics(const mam4::Prognostics &progs,
   }
 } // extract_stateq_from_prognostics
 
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
-void extract_ptend_from_tendencies(const Tendencies &tends, Real *ptend,
+void extract_ptend_from_tendencies(const Tendencies &tends, VectorType&ptend,
                                    const int klev) {
 
   int s_idx = ekat::ScalarTraits<int>::invalid();
@@ -288,9 +290,9 @@ void extract_ptend_from_tendencies(const Tendencies &tends, Real *ptend,
     s_idx++; // update index
   }
 } // extract_ptend_from_tendencies
-
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
-void inject_stateq_to_prognostics(const Real *q, mam4::Prognostics &progs,
+void inject_stateq_to_prognostics(const VectorType&q, mam4::Prognostics &progs,
                                   const int klev) {
 
   int s_idx = ekat::ScalarTraits<int>::invalid();
@@ -322,9 +324,9 @@ void inject_stateq_to_prognostics(const Real *q, mam4::Prognostics &progs,
     s_idx++; // update index
   }          // m
 }
-
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
-void inject_ptend_to_tendencies(const Real *ptend, const Tendencies &tends,
+void inject_ptend_to_tendencies(const VectorType&ptend, const Tendencies &tends,
                                 const int klev) {
 
   int s_idx = ekat::ScalarTraits<int>::invalid();
@@ -360,8 +362,9 @@ void inject_ptend_to_tendencies(const Real *ptend, const Tendencies &tends,
 // Given an AerosolState with views for dry aerosol quantities, creates a
 // cloudborne aerosol mmr 1D view for the column with the given index.
 // This object can be provided to mam4xx for the column.
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
-void extract_qqcw_from_prognostics(const mam4::Prognostics &progs, Real *qqcw,
+void extract_qqcw_from_prognostics(const mam4::Prognostics &progs, VectorType&qqcw,
                                    const int klev) {
 
   // NOTE: qqcw view has the same dimension and indexing as state_q array.
@@ -389,8 +392,9 @@ void extract_qqcw_from_prognostics(const mam4::Prognostics &progs, Real *qqcw,
 // Given an AerosolState with views for dry aerosol quantities, creates a
 // cloudborne aerosol mmr 1D view for the column with the given index.
 // This object can be provided to mam4xx for the column.
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
-void inject_qqcw_to_prognostics(const Real *qqcw, mam4::Prognostics &progs,
+void inject_qqcw_to_prognostics(const VectorType&qqcw, mam4::Prognostics &progs,
                                 const int klev) {
 
   // NOTE: qqcw view has the same dimension and indexing as state_q array.

--- a/src/mam4xx/utils.hpp
+++ b/src/mam4xx/utils.hpp
@@ -219,11 +219,11 @@ void get_num_idx_in_state_q(int idxs[AeroConfig::num_modes()]) {
 // This object can be provided to mam4xx for the column.
 
 // MUST FIXME: address James comments about making the code better.
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void extract_stateq_from_prognostics(const mam4::Prognostics &progs,
-                                     const haero::Atmosphere &atm, VectorType&q,
-                                     const int klev) {
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void
+extract_stateq_from_prognostics(const mam4::Prognostics &progs,
+                                const haero::Atmosphere &atm, VectorType &q,
+                                const int klev) {
 
   int s_idx = ekat::ScalarTraits<int>::invalid();
   q[0] = atm.vapor_mixing_ratio(klev);               // qv
@@ -258,10 +258,10 @@ void extract_stateq_from_prognostics(const mam4::Prognostics &progs,
   }
 } // extract_stateq_from_prognostics
 
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void extract_ptend_from_tendencies(const Tendencies &tends, VectorType&ptend,
-                                   const int klev) {
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void
+extract_ptend_from_tendencies(const Tendencies &tends, VectorType &ptend,
+                              const int klev) {
 
   int s_idx = ekat::ScalarTraits<int>::invalid();
   // FIXME: tendencies for first five item (qv, qc, qi, nc, ni) should no be
@@ -290,10 +290,10 @@ void extract_ptend_from_tendencies(const Tendencies &tends, VectorType&ptend,
     s_idx++; // update index
   }
 } // extract_ptend_from_tendencies
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void inject_stateq_to_prognostics(const VectorType&q, mam4::Prognostics &progs,
-                                  const int klev) {
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void
+inject_stateq_to_prognostics(const VectorType &q, mam4::Prognostics &progs,
+                             const int klev) {
 
   int s_idx = ekat::ScalarTraits<int>::invalid();
 
@@ -324,10 +324,10 @@ void inject_stateq_to_prognostics(const VectorType&q, mam4::Prognostics &progs,
     s_idx++; // update index
   }          // m
 }
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void inject_ptend_to_tendencies(const VectorType&ptend, const Tendencies &tends,
-                                const int klev) {
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void inject_ptend_to_tendencies(const VectorType &ptend,
+                                                       const Tendencies &tends,
+                                                       const int klev) {
 
   int s_idx = ekat::ScalarTraits<int>::invalid();
 
@@ -362,10 +362,10 @@ void inject_ptend_to_tendencies(const VectorType&ptend, const Tendencies &tends,
 // Given an AerosolState with views for dry aerosol quantities, creates a
 // cloudborne aerosol mmr 1D view for the column with the given index.
 // This object can be provided to mam4xx for the column.
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void extract_qqcw_from_prognostics(const mam4::Prognostics &progs, VectorType&qqcw,
-                                   const int klev) {
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void
+extract_qqcw_from_prognostics(const mam4::Prognostics &progs, VectorType &qqcw,
+                              const int klev) {
 
   // NOTE: qqcw view has the same dimension and indexing as state_q array.
   //  This array doesn't store gasses, so the indexing starts at aerosols
@@ -392,10 +392,10 @@ void extract_qqcw_from_prognostics(const mam4::Prognostics &progs, VectorType&qq
 // Given an AerosolState with views for dry aerosol quantities, creates a
 // cloudborne aerosol mmr 1D view for the column with the given index.
 // This object can be provided to mam4xx for the column.
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void inject_qqcw_to_prognostics(const VectorType&qqcw, mam4::Prognostics &progs,
-                                const int klev) {
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void inject_qqcw_to_prognostics(const VectorType &qqcw,
+                                                       mam4::Prognostics &progs,
+                                                       const int klev) {
 
   // NOTE: qqcw view has the same dimension and indexing as state_q array.
   //  This array doesn't store gasses, so the indexing starts at aerosols

--- a/src/mam4xx/water_uptake.hpp
+++ b/src/mam4xx/water_uptake.hpp
@@ -354,14 +354,13 @@ void get_e3sm_parameters(
   }
 }
 
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void modal_aero_water_uptake_dryaer(
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dryaer(
     const int nspec_amode[AeroConfig::num_modes()],
     const Real specdens_amode[maxd_aspectype],
     const Real spechygro[maxd_aspectype],
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const VectorType& state_q, Real dgncur_a[AeroConfig::num_modes()],
+    const VectorType &state_q, Real dgncur_a[AeroConfig::num_modes()],
     Real hygro[AeroConfig::num_modes()], Real naer[AeroConfig::num_modes()],
     Real dryrad[AeroConfig::num_modes()], Real dryvol[AeroConfig::num_modes()],
     Real drymass[AeroConfig::num_modes()],
@@ -433,14 +432,13 @@ void modal_aero_water_uptake_dryaer(
     dryrad[imode] = haero::cbrt(dryvol[imode] / (Constants::pi * 4.0 / 3.0));
   }
 }
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void modal_aero_water_uptake_dr_b4_wetdens(
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dr_b4_wetdens(
     const int nspec_amode[AeroConfig::num_modes()],
     const Real specdens_amode[maxd_aspectype],
     const Real spechygro[maxd_aspectype],
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const VectorType& state_q, Real temperature, Real pmid, Real cldn,
+    const VectorType &state_q, Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
     Real qaerwat[AeroConfig::num_modes()], Real wetvol[AeroConfig::num_modes()],
@@ -476,14 +474,13 @@ void modal_aero_water_uptake_dr_b4_wetdens(
                                  rh, naer, dryvol, wetrad, wetvol, wtrvol,
                                  dgncur_awet, qaerwat);
 }
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void modal_aero_water_uptake_dr(
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dr(
     const int nspec_amode[AeroConfig::num_modes()],
     const Real specdens_amode[maxd_aspectype],
     const Real spechygro[maxd_aspectype],
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const VectorType& state_q, Real temperature, Real pmid, Real cldn,
+    const VectorType &state_q, Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
     Real qaerwat[AeroConfig::num_modes()],
@@ -505,14 +502,13 @@ void modal_aero_water_uptake_dr(
   // compute wet aerosol density
   modal_aero_water_uptake_wetdens(wetvol, wtrvol, drymass, specdens_1, wetdens);
 }
-template<typename VectorType>
-KOKKOS_INLINE_FUNCTION
-void modal_aero_water_uptake_dr(
+template <typename VectorType>
+KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dr(
     const int nspec_amode[AeroConfig::num_modes()],
     const Real specdens_amode[maxd_aspectype],
     const Real spechygro[maxd_aspectype],
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const VectorType& state_q, Real temperature, Real pmid, Real cldn,
+    const VectorType &state_q, Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
     Real qaerwat[AeroConfig::num_modes()]) {

--- a/src/mam4xx/water_uptake.hpp
+++ b/src/mam4xx/water_uptake.hpp
@@ -354,13 +354,14 @@ void get_e3sm_parameters(
   }
 }
 
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void modal_aero_water_uptake_dryaer(
     const int nspec_amode[AeroConfig::num_modes()],
     const Real specdens_amode[maxd_aspectype],
     const Real spechygro[maxd_aspectype],
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    Real state_q[aero_model::pcnst], Real dgncur_a[AeroConfig::num_modes()],
+    const VectorType& state_q, Real dgncur_a[AeroConfig::num_modes()],
     Real hygro[AeroConfig::num_modes()], Real naer[AeroConfig::num_modes()],
     Real dryrad[AeroConfig::num_modes()], Real dryvol[AeroConfig::num_modes()],
     Real drymass[AeroConfig::num_modes()],
@@ -432,14 +433,14 @@ void modal_aero_water_uptake_dryaer(
     dryrad[imode] = haero::cbrt(dryvol[imode] / (Constants::pi * 4.0 / 3.0));
   }
 }
-
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void modal_aero_water_uptake_dr_b4_wetdens(
     const int nspec_amode[AeroConfig::num_modes()],
     const Real specdens_amode[maxd_aspectype],
     const Real spechygro[maxd_aspectype],
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    Real state_q[aero_model::pcnst], Real temperature, Real pmid, Real cldn,
+    const VectorType& state_q, Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
     Real qaerwat[AeroConfig::num_modes()], Real wetvol[AeroConfig::num_modes()],
@@ -475,14 +476,14 @@ void modal_aero_water_uptake_dr_b4_wetdens(
                                  rh, naer, dryvol, wetrad, wetvol, wtrvol,
                                  dgncur_awet, qaerwat);
 }
-
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void modal_aero_water_uptake_dr(
     const int nspec_amode[AeroConfig::num_modes()],
     const Real specdens_amode[maxd_aspectype],
     const Real spechygro[maxd_aspectype],
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    Real state_q[aero_model::pcnst], Real temperature, Real pmid, Real cldn,
+    const VectorType& state_q, Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
     Real qaerwat[AeroConfig::num_modes()],
@@ -504,14 +505,14 @@ void modal_aero_water_uptake_dr(
   // compute wet aerosol density
   modal_aero_water_uptake_wetdens(wetvol, wtrvol, drymass, specdens_1, wetdens);
 }
-
+template<typename VectorType>
 KOKKOS_INLINE_FUNCTION
 void modal_aero_water_uptake_dr(
     const int nspec_amode[AeroConfig::num_modes()],
     const Real specdens_amode[maxd_aspectype],
     const Real spechygro[maxd_aspectype],
     const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    Real state_q[aero_model::pcnst], Real temperature, Real pmid, Real cldn,
+    const VectorType& state_q, Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
     Real qaerwat[AeroConfig::num_modes()]) {

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1814,7 +1814,7 @@ void aero_model_wetdep(
       //  uptake for prognostic aerosols
       modal_aero_calcsize::modal_aero_calcsize_sub(
           // Inputs
-          state_q_kk.data(), qqcw_kk.data(), dt, calcsizedata,
+          state_q_kk, qqcw_kk, dt, calcsizedata,
           // Outputs
           dgnumdry_m_kk, dgncur_c_kk, ptend_q_kk.data(), dqqcwdt_kk);
       // NOTE: dgnumdry_m_kk is interstitial dry diameter size and

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1554,7 +1554,9 @@ int get_aero_model_wetdep_work_len() {
                  // scavt, bcscavt, rcscavt,
                  2 * mam4::nlev * pcnst +
                  // ptend_q, rtscavt_sv
-                 2 * pcnst;
+                 2 * pcnst+
+                 //dqqcwdt
+                 aero_model::pcnst*mam4::nlev;
   //  qsrflx_mzaer2cnvpr
   return work_len;
 }
@@ -1720,6 +1722,8 @@ void aero_model_wetdep(
 
   View2D qsrflx_mzaer2cnvpr(work_ptr, aero_model::pcnst, 2);
   work_ptr += aero_model::pcnst * 2;
+  View2D dqqcwdt(work_ptr, mam4::nlev, aero_model::pcnst);
+  work_ptr += aero_model::pcnst*mam4::nlev;
 
   /// error check
   const int workspace_used(work_ptr - work.data()),
@@ -1809,7 +1813,8 @@ void aero_model_wetdep(
 
     {
       Real dgncur_c_kk[ntot_amode] = {};
-      Real dqqcwdt_kk[pcnst] = {};
+      // Real dqqcwdt_kk[pcnst] = {};
+      auto dqqcwdt_kk = ekat::subview(dqqcwdt, kk);
       //  Calculate aerosol size distribution parameters and aerosol water
       //  uptake for prognostic aerosols
       modal_aero_calcsize::modal_aero_calcsize_sub(

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1776,9 +1776,9 @@ void aero_model_wetdep(
     const auto state_q_kk = ekat::subview(state_q, kk);
     const auto qqcw_kk = ekat::subview(qqcw, kk);
     const auto ptend_q_kk = ekat::subview(ptend_q, kk);
-    utils::extract_stateq_from_prognostics(progs, atm, state_q_kk.data(), kk);
-    utils::extract_qqcw_from_prognostics(progs, qqcw_kk.data(), kk);
-    utils::extract_ptend_from_tendencies(tends, ptend_q_kk.data(), kk);
+    utils::extract_stateq_from_prognostics(progs, atm, state_q_kk, kk);
+    utils::extract_qqcw_from_prognostics(progs, qqcw_kk, kk);
+    utils::extract_ptend_from_tendencies(tends, ptend_q_kk, kk);
   });
   team.team_barrier();
 

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1554,9 +1554,9 @@ int get_aero_model_wetdep_work_len() {
                  // scavt, bcscavt, rcscavt,
                  2 * mam4::nlev * pcnst +
                  // ptend_q, rtscavt_sv
-                 2 * pcnst+
-                 //dqqcwdt
-                 aero_model::pcnst*mam4::nlev;
+                 2 * pcnst +
+                 // dqqcwdt
+                 aero_model::pcnst * mam4::nlev;
   //  qsrflx_mzaer2cnvpr
   return work_len;
 }
@@ -1723,7 +1723,7 @@ void aero_model_wetdep(
   View2D qsrflx_mzaer2cnvpr(work_ptr, aero_model::pcnst, 2);
   work_ptr += aero_model::pcnst * 2;
   View2D dqqcwdt(work_ptr, mam4::nlev, aero_model::pcnst);
-  work_ptr += aero_model::pcnst*mam4::nlev;
+  work_ptr += aero_model::pcnst * mam4::nlev;
 
   /// error check
   const int workspace_used(work_ptr - work.data()),

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1792,7 +1792,7 @@ void aero_model_wetdep(
   Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 0, nlev), [&](int kk) {
     const auto state_q_kk = ekat::subview(state_q, kk);
     const auto qqcw_kk = ekat::subview(qqcw, kk);
-    const auto ptend_q_kk = ekat::subview(ptend_q, kk);
+    auto ptend_q_kk = ekat::subview(ptend_q, kk);
     Real dgnumwet_m_kk[ntot_amode] = {};
     // wetdens and qaerwat are input/ouput to water_uptake
     Real qaerwat_m_kk[ntot_amode] = {};
@@ -1816,7 +1816,7 @@ void aero_model_wetdep(
           // Inputs
           state_q_kk, qqcw_kk, dt, calcsizedata,
           // Outputs
-          dgnumdry_m_kk, dgncur_c_kk, ptend_q_kk.data(), dqqcwdt_kk);
+          dgnumdry_m_kk, dgncur_c_kk, ptend_q_kk, dqqcwdt_kk);
       // NOTE: dgnumdry_m_kk is interstitial dry diameter size and
       // dgncur_c_kk is cloud borne dry diameter size
 

--- a/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
+++ b/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
@@ -92,8 +92,8 @@ void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
                 const auto dqqcwdt_k =
                     Kokkos::subview(dqqcwdt, kk, Kokkos::ALL());
                 modal_aero_calcsize::modal_aero_calcsize_sub(
-                    state_q_k.data(), // in
-                    qqcw_k.data(),    // in/out
+                    state_q_k, // in
+                    qqcw_k,    // in/out
                     dt, cal_data,
                     // outputs
                     dgncur_i.data(), dgncur_c, ptend_q_k.data(),
@@ -111,7 +111,7 @@ void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
                 mam4::water_uptake::modal_aero_water_uptake_dr(
                     cal_data.nspec_amode, cal_data.specdens_amode,
                     cal_data.spechygro, cal_data.lspectype_amode,
-                    state_q_k.data(), temperature(kk), pmid(kk), cldn(kk),
+                    state_q_k, temperature(kk), pmid(kk), cldn(kk),
                     dgncur_i.data(), dgnumwet_kk.data(), qaerwat_kk.data(),
                     wetdens_kk.data());
 

--- a/src/validation/aero_model/aero_model_wetdep.cpp
+++ b/src/validation/aero_model/aero_model_wetdep.cpp
@@ -176,9 +176,8 @@ void aero_model_wetdep(Ensemble *ensemble) {
                 // copy data from prog to stateq
                 const auto state_q_kk = ekat::subview(state_q, kk);
                 const auto qqcw_kk = ekat::subview(qqcw, kk);
-                utils::inject_qqcw_to_prognostics(qqcw_kk.data(), progs_in, kk);
-                utils::inject_stateq_to_prognostics(state_q_kk.data(), progs_in,
-                                                    kk);
+                utils::inject_qqcw_to_prognostics(qqcw_kk, progs_in, kk);
+                utils::inject_stateq_to_prognostics(state_q_kk, progs_in, kk);
               });
           team.team_barrier();
 
@@ -198,8 +197,7 @@ void aero_model_wetdep(Ensemble *ensemble) {
           Kokkos::parallel_for(
               Kokkos::TeamVectorRange(team, 0, nlev), [&](int kk) {
                 const auto ptend_q_kk = ekat::subview(ptend_q, kk);
-                utils::extract_ptend_from_tendencies(tends_in,
-                                                     ptend_q_kk.data(), kk);
+                utils::extract_ptend_from_tendencies(tends_in, ptend_q_kk, kk);
               });
         });
 

--- a/src/validation/aerosol_optics/aer_rad_props_lw.cpp
+++ b/src/validation/aerosol_optics/aer_rad_props_lw.cpp
@@ -305,8 +305,8 @@ void aer_rad_props_lw(Ensemble *ensemble) {
                 const auto state_q_kk = ekat::subview(state_q, kk);
                 const auto qqcw_kk = ekat::subview(qqcw, kk);
                 utils::extract_stateq_from_prognostics(progs_in, atm,
-                                                       state_q_kk.data(), kk);
-                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk.data(),
+                                                       state_q_kk, kk);
+                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk,
                                                      kk);
               });
         });

--- a/src/validation/aerosol_optics/aer_rad_props_lw.cpp
+++ b/src/validation/aerosol_optics/aer_rad_props_lw.cpp
@@ -306,8 +306,7 @@ void aer_rad_props_lw(Ensemble *ensemble) {
                 const auto qqcw_kk = ekat::subview(qqcw, kk);
                 utils::extract_stateq_from_prognostics(progs_in, atm,
                                                        state_q_kk, kk);
-                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk,
-                                                     kk);
+                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk, kk);
               });
         });
 

--- a/src/validation/aerosol_optics/aer_rad_props_sw.cpp
+++ b/src/validation/aerosol_optics/aer_rad_props_sw.cpp
@@ -362,8 +362,7 @@ void aer_rad_props_sw(Ensemble *ensemble) {
                 utils::extract_stateq_from_prognostics(progs_in, atm,
                                                        state_q_kk, kk);
 
-                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk,
-                                                     kk);
+                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk, kk);
               });
         });
 

--- a/src/validation/aerosol_optics/aer_rad_props_sw.cpp
+++ b/src/validation/aerosol_optics/aer_rad_props_sw.cpp
@@ -360,9 +360,9 @@ void aer_rad_props_sw(Ensemble *ensemble) {
                 const auto state_q_kk = ekat::subview(state_q, kk);
                 const auto qqcw_kk = ekat::subview(qqcw, kk);
                 utils::extract_stateq_from_prognostics(progs_in, atm,
-                                                       state_q_kk.data(), kk);
+                                                       state_q_kk, kk);
 
-                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk.data(),
+                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk,
                                                      kk);
               });
         });

--- a/src/validation/aerosol_optics/data_transfer_state_q_qqwc_to_prog.cpp
+++ b/src/validation/aerosol_optics/data_transfer_state_q_qqwc_to_prog.cpp
@@ -130,10 +130,9 @@ void data_transfer_state_q_qqwc_to_prog(Ensemble *ensemble) {
                 const auto state_q_output_kk =
                     ekat::subview(state_q_output, kk);
                 const auto qqcw_output_kk = ekat::subview(qqcw_output, kk);
-                utils::extract_stateq_from_prognostics(
-                    progs, atm, state_q_output_kk, kk);
-                utils::extract_qqcw_from_prognostics(progs,
-                                                     qqcw_output_kk, kk);
+                utils::extract_stateq_from_prognostics(progs, atm,
+                                                       state_q_output_kk, kk);
+                utils::extract_qqcw_from_prognostics(progs, qqcw_output_kk, kk);
               });
 
           team.team_barrier();

--- a/src/validation/aerosol_optics/data_transfer_state_q_qqwc_to_prog.cpp
+++ b/src/validation/aerosol_optics/data_transfer_state_q_qqwc_to_prog.cpp
@@ -131,9 +131,9 @@ void data_transfer_state_q_qqwc_to_prog(Ensemble *ensemble) {
                     ekat::subview(state_q_output, kk);
                 const auto qqcw_output_kk = ekat::subview(qqcw_output, kk);
                 utils::extract_stateq_from_prognostics(
-                    progs, atm, state_q_output_kk.data(), kk);
+                    progs, atm, state_q_output_kk, kk);
                 utils::extract_qqcw_from_prognostics(progs,
-                                                     qqcw_output_kk.data(), kk);
+                                                     qqcw_output_kk, kk);
               });
 
           team.team_barrier();

--- a/src/validation/aerosol_optics/modal_aero_lw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_lw.cpp
@@ -279,8 +279,8 @@ void modal_aero_lw(Ensemble *ensemble) {
                 const auto state_q_kk = ekat::subview(state_q, kk);
                 const auto qqcw_kk = ekat::subview(qqcw, kk);
                 utils::extract_stateq_from_prognostics(progs_in, atm,
-                                                       state_q_kk.data(), kk);
-                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk.data(),
+                                                       state_q_kk, kk);
+                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk,
                                                      kk);
               });
         });

--- a/src/validation/aerosol_optics/modal_aero_lw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_lw.cpp
@@ -280,8 +280,7 @@ void modal_aero_lw(Ensemble *ensemble) {
                 const auto qqcw_kk = ekat::subview(qqcw, kk);
                 utils::extract_stateq_from_prognostics(progs_in, atm,
                                                        state_q_kk, kk);
-                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk,
-                                                     kk);
+                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk, kk);
               });
         });
 

--- a/src/validation/aerosol_optics/modal_aero_sw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_sw.cpp
@@ -317,8 +317,7 @@ void modal_aero_sw(Ensemble *ensemble) {
                 const auto qqcw_kk = ekat::subview(qqcw, kk);
                 utils::extract_stateq_from_prognostics(progs_in, atm,
                                                        state_q_kk, kk);
-                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk,
-                                                     kk);
+                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk, kk);
               });
         });
 

--- a/src/validation/aerosol_optics/modal_aero_sw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_sw.cpp
@@ -316,8 +316,8 @@ void modal_aero_sw(Ensemble *ensemble) {
                 const auto state_q_kk = ekat::subview(state_q, kk);
                 const auto qqcw_kk = ekat::subview(qqcw, kk);
                 utils::extract_stateq_from_prognostics(progs_in, atm,
-                                                       state_q_kk.data(), kk);
-                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk.data(),
+                                                       state_q_kk, kk);
+                utils::extract_qqcw_from_prognostics(progs_in, qqcw_kk,
                                                      kk);
               });
         });

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -41,6 +41,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
     }
     Kokkos::deep_copy(qqcw, qqcw_host);
     View2D dgnumdry_m("dgnumdry_m", pver, ntot_amode);
+    View2D dgncur_c("dgncur_c", pver, ntot_amode);
     mam4::modal_aer_opt::CalcsizeData cal_data;
     cal_data.initialize();
 
@@ -56,13 +57,15 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
             const auto qqcw_k = Kokkos::subview(qqcw, kk, Kokkos::ALL());
             const auto dgncur_i =
                 Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
-            Real dgncur_c[ntot_amode] = {};
+            // Real dgncur_c[ntot_amode] = {};
+            const auto dgncur_c_k =
+                Kokkos::subview(dgncur_c, kk, Kokkos::ALL());
             // Real dqqcwdt[pcnst] = {};
             auto dqqcwdt_k = Kokkos::subview(dqqcwdt, kk, Kokkos::ALL());
             modal_aero_calcsize::modal_aero_calcsize_sub(
                 state_q_k, // in
                 qqcw_k,    // in/out
-                dt, cal_data, dgncur_i.data(), dgncur_c, ptend_k, dqqcwdt_k);
+                dt, cal_data, dgncur_i, dgncur_c_k, ptend_k, dqqcwdt_k);
               } // k
         });
 

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -27,6 +27,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
 
     View2D state_q("state_q", pver, pcnst);
     View2D ptend("ptend", pver, pcnst);
+    View2D dqqcwdt("dqqcwdt", pver, pcnst);
     mam4::validation::convert_1d_vector_to_2d_view_device(state_q_db, state_q);
     View2D qqcw("qqcw", pver, pcnst);
     auto qqcw_host = create_mirror_view(qqcw);
@@ -56,11 +57,12 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
             const auto dgncur_i =
                 Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
             Real dgncur_c[ntot_amode] = {};
-            Real dqqcwdt[pcnst] = {};
+            // Real dqqcwdt[pcnst] = {};
+            auto dqqcwdt_k = Kokkos::subview(dqqcwdt, kk, Kokkos::ALL());
             modal_aero_calcsize::modal_aero_calcsize_sub(
                 state_q_k, // in
                 qqcw_k,    // in/out
-                dt, cal_data, dgncur_i.data(), dgncur_c, ptend_k, dqqcwdt);
+                dt, cal_data, dgncur_i.data(), dgncur_c, ptend_k, dqqcwdt_k);
               } // k
         });
 

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -66,7 +66,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
                 state_q_k, // in
                 qqcw_k,    // in/out
                 dt, cal_data, dgncur_i, dgncur_c_k, ptend_k, dqqcwdt_k);
-              } // k
+          } // k
         });
 
     constexpr Real zero = 0;

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -26,6 +26,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
     const auto dt = input.get_array("dt")[0];
 
     View2D state_q("state_q", pver, pcnst);
+    View2D ptend("ptend", pver, pcnst);
     mam4::validation::convert_1d_vector_to_2d_view_device(state_q_db, state_q);
     View2D qqcw("qqcw", pver, pcnst);
     auto qqcw_host = create_mirror_view(qqcw);
@@ -50,17 +51,17 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
 
           for (int kk = top_lev; kk < pver; ++kk) {
             const auto state_q_k = Kokkos::subview(state_q, kk, Kokkos::ALL());
+            auto ptend_k = Kokkos::subview(ptend, kk, Kokkos::ALL());
             const auto qqcw_k = Kokkos::subview(qqcw, kk, Kokkos::ALL());
             const auto dgncur_i =
                 Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
             Real dgncur_c[ntot_amode] = {};
-            Real ptend[pcnst] = {};
             Real dqqcwdt[pcnst] = {};
             modal_aero_calcsize::modal_aero_calcsize_sub(
                 state_q_k, // in
                 qqcw_k,    // in/out
-                dt, cal_data, dgncur_i.data(), dgncur_c, ptend, dqqcwdt);
-          } // k
+                dt, cal_data, dgncur_i.data(), dgncur_c, ptend_k, dqqcwdt);
+              } // k
         });
 
     constexpr Real zero = 0;

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -57,8 +57,8 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
             Real ptend[pcnst] = {};
             Real dqqcwdt[pcnst] = {};
             modal_aero_calcsize::modal_aero_calcsize_sub(
-                state_q_k.data(), // in
-                qqcw_k.data(),    // in/out
+                state_q_k, // in
+                qqcw_k,    // in/out
                 dt, cal_data, dgncur_i.data(), dgncur_c, ptend, dqqcwdt);
           } // k
         });

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -65,15 +65,15 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
             const auto dgncur_i =
                 Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
             Real dgncur_c[ntot_amode] = {};
-            const auto ptend_q_k = Kokkos::subview(ptend_q, kk, Kokkos::ALL());
+            auto ptend_q_k = Kokkos::subview(ptend_q, kk, Kokkos::ALL());
             const auto dqqcwdt_k = Kokkos::subview(dqqcwdt, kk, Kokkos::ALL());
             modal_aero_calcsize::modal_aero_calcsize_sub(
                 state_q_k, // in
                 qqcw_k,    // in/out
                 dt, cal_data,
                 // outputs
-                dgncur_i.data(), dgncur_c, ptend_q_k.data(), dqqcwdt_k.data());
-          } // k
+                dgncur_i.data(), dgncur_c, ptend_q_k, dqqcwdt_k.data());
+              } // k
         });
 
     constexpr Real zero = 0;

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -66,13 +66,13 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
                 Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
             Real dgncur_c[ntot_amode] = {};
             auto ptend_q_k = Kokkos::subview(ptend_q, kk, Kokkos::ALL());
-            const auto dqqcwdt_k = Kokkos::subview(dqqcwdt, kk, Kokkos::ALL());
+            auto dqqcwdt_k = Kokkos::subview(dqqcwdt, kk, Kokkos::ALL());
             modal_aero_calcsize::modal_aero_calcsize_sub(
                 state_q_k, // in
                 qqcw_k,    // in/out
                 dt, cal_data,
                 // outputs
-                dgncur_i.data(), dgncur_c, ptend_q_k, dqqcwdt_k.data());
+                dgncur_i.data(), dgncur_c, ptend_q_k, dqqcwdt_k);
               } // k
         });
 

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -38,6 +38,8 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
     }
     Kokkos::deep_copy(qqcw, qqcw_host);
     View2D dgnumdry_m("dgnumdry_m", pver, ntot_amode);
+    View2D dgncur_c("dgncur_c", pver, ntot_amode);
+
     if (input.has("dgncur_a")) {
       auto dgncur_a_db = input.get_array("dgncur_a");
       mam4::validation::convert_1d_vector_to_2d_view_device(dgncur_a_db,
@@ -64,7 +66,9 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
             const auto qqcw_k = Kokkos::subview(qqcw, kk, Kokkos::ALL());
             const auto dgncur_i =
                 Kokkos::subview(dgnumdry_m, kk, Kokkos::ALL());
-            Real dgncur_c[ntot_amode] = {};
+            const auto dgncur_c_k =
+                Kokkos::subview(dgncur_c, kk, Kokkos::ALL());
+            // Real dgncur_c[ntot_amode] = {};
             auto ptend_q_k = Kokkos::subview(ptend_q, kk, Kokkos::ALL());
             auto dqqcwdt_k = Kokkos::subview(dqqcwdt, kk, Kokkos::ALL());
             modal_aero_calcsize::modal_aero_calcsize_sub(
@@ -72,7 +76,7 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
                 qqcw_k,    // in/out
                 dt, cal_data,
                 // outputs
-                dgncur_i.data(), dgncur_c, ptend_q_k, dqqcwdt_k);
+                dgncur_i, dgncur_c_k, ptend_q_k, dqqcwdt_k);
               } // k
         });
 

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -71,13 +71,13 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
             // Real dgncur_c[ntot_amode] = {};
             auto ptend_q_k = Kokkos::subview(ptend_q, kk, Kokkos::ALL());
             auto dqqcwdt_k = Kokkos::subview(dqqcwdt, kk, Kokkos::ALL());
-            modal_aero_calcsize::modal_aero_calcsize_sub(
-                state_q_k, // in
-                qqcw_k,    // in/out
-                dt, cal_data,
-                // outputs
-                dgncur_i, dgncur_c_k, ptend_q_k, dqqcwdt_k);
-              } // k
+            modal_aero_calcsize::modal_aero_calcsize_sub(state_q_k, // in
+                                                         qqcw_k,    // in/out
+                                                         dt, cal_data,
+                                                         // outputs
+                                                         dgncur_i, dgncur_c_k,
+                                                         ptend_q_k, dqqcwdt_k);
+          } // k
         });
 
     constexpr Real zero = 0;

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -68,8 +68,8 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
             const auto ptend_q_k = Kokkos::subview(ptend_q, kk, Kokkos::ALL());
             const auto dqqcwdt_k = Kokkos::subview(dqqcwdt, kk, Kokkos::ALL());
             modal_aero_calcsize::modal_aero_calcsize_sub(
-                state_q_k.data(), // in
-                qqcw_k.data(),    // in/out
+                state_q_k, // in
+                qqcw_k,    // in/out
                 dt, cal_data,
                 // outputs
                 dgncur_i.data(), dgncur_c, ptend_q_k.data(), dqqcwdt_k.data());


### PR DESCRIPTION
I am removing `view.data()` from the `calcisize` routines. I am using a template parameter `VectorType` to replace` Real* var ` because we are using Real arrays a few times.

I compiled and ran the main branch of mam4xx in Frontier, and four validation tests failed:

```
    16 - validate_stand_modal_aero_calcsize_sub_update_ptend (Failed)
    18 - validate_stand_calcsize_aero_model_wetdep_ts_379 (Failed)
    492 - validate_chm_diags_ts_355 (Failed)
    524 - validate_gas_washout_merged (Failed)
```

I note that this PR fixes `validate_stand_modal_aero_calcsize_sub_update_ptend` and `validate_stand_calcsize_aero_model_wetdep_ts_379`. Thus, using raw pointers is producing issues in the AMD backend. I will continue replacing .data() in a follow-up PR.

See [PR 7335](https://github.com/E3SM-Project/E3SM/pull/7335) for eamxx testing.