### PR TITLE
Adds logic to avoid very small numbers for dryvol

### DIFF
--- a/src/mam4xx/modal_aer_opt.hpp
+++ b/src/mam4xx/modal_aer_opt.hpp
@@ -644,21 +644,21 @@ KOKKOS_INLINE_FUNCTION void modal_aero_sw_wo_diagnostics_k(
       Real dryvol, wetvol, watervol = {};
       // NOTE: The following logic exists only in MAM4xx,
       // it doesn't exists in Fortan MAM4. This logic is added
-      // to deal with very small (essentially zero) 
+      // to deal with very small (essentially zero)
       // negative values for dryvol
       dryvol = zero;
       for (int ispec = 0; ispec < nspec; ++ispec) {
-          dryvol += specvol[ispec];
+        dryvol += specvol[ispec];
       }
       if (dryvol < zero && dryvol > neg_small_value_16) {
-        // if dryvol is negative and a very small number, 
-        //set all optical properties to zero
+        // if dryvol is negative and a very small number,
+        // set all optical properties to zero
         // and continue to next iteration
         tauxar(mm, isw) = zero;
         wa(mm, isw) = zero;
         ga(mm, isw) = zero;
         fa(mm, isw) = zero;
-        continue; //continue to next isw
+        continue; // continue to next isw
       }
 
       Kokkos::complex<Real> crefin = {};

--- a/src/mam4xx/modal_aer_opt.hpp
+++ b/src/mam4xx/modal_aer_opt.hpp
@@ -7,6 +7,7 @@
 #include <mam4xx/modal_aero_calcsize.hpp>
 #include <mam4xx/ndrop.hpp>
 #include <mam4xx/water_uptake.hpp>
+#include <ekat/util/ekat_math_utils.hpp>
 
 namespace mam4 {
 namespace modal_aer_opt {
@@ -42,6 +43,7 @@ constexpr int prefi = 10;
 
 // BAD CONSTANT
 constexpr Real small_value_40 = 1.e-40;
+constexpr Real neg_small_value_16 = -1.e-16;
 
 // Density of liquid water (STP)
 constexpr Real rhoh2o = haero::Constants::density_h2o;
@@ -368,12 +370,10 @@ also output wetvol and watervol
     dryvol += specvol[i];
     crefin += specvol[i] * specrefindex(i, ilwsw);
   }
-  // printf("qaerwat_kk %e  rhoh2o %e \n", qaerwat_kk,  rhoh2o);
 
   watervol = qaerwat_kk / rhoh2o;
   wetvol = watervol + dryvol;
-  // printf("wetvol %e watervol %e dryvol %e \n ", wetvol, watervol,dryvol);
-  if (watervol < zero && lwsw == 0) // lwsw=='lw'
+  if (watervol < zero) // lwsw=='lw'
   {
     // BAD CONSTANT
     // FIXME
@@ -405,7 +405,7 @@ also output wetvol and watervol
   } // lwsw=='lw'
   // FIXME
   refr = crefin.real();
-  refi = crefin.imag();
+  refi = haero::abs(crefin.imag());
 
 } // calc_refin_complex
 
@@ -643,6 +643,25 @@ KOKKOS_INLINE_FUNCTION void modal_aero_sw_wo_diagnostics_k(
 
       // lw =0 and sw =1
       Real dryvol, wetvol, watervol = {};
+      // NOTE: The following logic exists only in MAM4xx,
+      // it doesn't exists in Fortan MAM4. This logic is added
+      // to deal with very small (essentially zero) 
+      // negative values for dryvol
+      dryvol = zero;
+      for (int ispec = 0; ispec < nspec; ++ispec) {
+          dryvol += specvol[ispec];
+      }
+      if (dryvol < zero && dryvol > neg_small_value_16) {
+        // if dryvol is negative and a very small number, 
+        //set all optical properties to zero
+        // and continue to next iteration
+        tauxar(mm, isw) = zero;
+        wa(mm, isw) = zero;
+        ga(mm, isw) = zero;
+        fa(mm, isw) = zero;
+        continue; //continue to next isw
+      }
+
       Kokkos::complex<Real> crefin = {};
       Real refr, refi = {};
 
@@ -718,8 +737,8 @@ KOKKOS_INLINE_FUNCTION void modal_aero_sw_wo_diagnostics_k(
       fa(mm, isw) = dopaer * palb * pasm * pasm;
 
     } // isw
-  }   // k
-} // k
+  }   // mm
+} // modal_aero_sw_wo_diagnostics_k ends
 
 inline int get_work_len_aerosol_optics() {
   // tauxar, wa, ga, fa

--- a/src/mam4xx/modal_aer_opt.hpp
+++ b/src/mam4xx/modal_aer_opt.hpp
@@ -7,7 +7,6 @@
 #include <mam4xx/modal_aero_calcsize.hpp>
 #include <mam4xx/ndrop.hpp>
 #include <mam4xx/water_uptake.hpp>
-#include <ekat/util/ekat_math_utils.hpp>
 
 namespace mam4 {
 namespace modal_aer_opt {


### PR DESCRIPTION
For very high-resolution runs, we occasionally encounter small negative values for aerosol dry volume in some grid cells. Although these values are close to zero, they can lead to extremely large results during mathematical operations like division or exponentiation. To prevent this, we introduced a condition that detects small negative dry volumes and skips the subsequent calculations. In such cases, we set all optical parameters to zero.

Another `if` condition is fixed, and an `abs` is added to mimic the original MAM4 Fortran code.

This fix enabled stable long-term CIME simulations at high resolutions, such as ne120 and ne256.

[NBFB]
 