### PR TITLE
Changes to expose diagnostic quantities to EAMxx (`*_sfgaex1, *_sfgaex2, *_sfnnuc, *_sfcoag`)

### DIFF
--- a/src/mam4xx/mam4_amicphys.hpp
+++ b/src/mam4xx/mam4_amicphys.hpp
@@ -2071,8 +2071,7 @@ void get_gcm_tend_diags_from_subareas(
     const Real (&qsub_tendaa)[gas_pcnst][nqtendaa()][maxsubarea()],
     const Real (&qqcwsub_tendaa)[gas_pcnst][nqqcwtendaa()][maxsubarea()],
     // out
-    const View2D &qgcm_tendaa,
-    const View2D &qqcwgcm_tendaa) {
+    const View2D &qgcm_tendaa, const View2D &qqcwgcm_tendaa) {
   // nsubarea: # of active subareas
   // ncldy_subarea: # of cloudy subareas
   // afracsub(maxsubarea): area fraction of subareas [unitless]
@@ -2118,11 +2117,9 @@ void modal_aero_amicphys_intr(
     const Real (&q_pregaschem)[gas_pcnst],
     const Real (&q_precldchem)[gas_pcnst],
     const Real (&qqcw_precldchem)[gas_pcnst], const Real (&dgncur_a)[num_modes],
-    const Real (&dgncur_awet)[num_modes],
-    const Real (&wetdens_host)[num_modes],
+    const Real (&dgncur_awet)[num_modes], const Real (&wetdens_host)[num_modes],
     // out
-    const View2D &qgcm_tendaa,
-    const View2D &qqcwgcm_tendaa) {
+    const View2D &qgcm_tendaa, const View2D &qqcwgcm_tendaa) {
   // deltat: time step
   // qq(ncol,pver,pcnst): current tracer mixing ratios (TMRs)
   //                           these values are updated (so out /= in)

--- a/src/mam4xx/mo_gas_phase_chemdr.hpp
+++ b/src/mam4xx/mo_gas_phase_chemdr.hpp
@@ -153,8 +153,7 @@ void perform_atmospheric_chemistry_and_microphysics(
     Real dvel[gas_pcnst], // deposition velocity [cm/s]
     Real dflx[gas_pcnst],
     // out
-    const View3D &qgcm_tendaa,
-    const View3D &qqcwgcm_tendaa,
+    const View3D &qgcm_tendaa, const View3D &qqcwgcm_tendaa,
     mam4::Prognostics &progs) {
 
   const int nlev = mam4::nlev;

--- a/src/validation/gas_chem/CMakeLists.txt
+++ b/src/validation/gas_chem/CMakeLists.txt
@@ -8,10 +8,10 @@ set(GAS_CHEM_VALIDATION_SCRIPTS_DIR ${MAM_X_VALIDATION_DIR}/scripts)
 include_directories(${PROJECT_BINARY_DIR}/validation)
 
 # We use a single driver for all gas_chem-related parameterizations.
-add_executable(gas_chem_driver  
+add_executable(gas_chem_driver
                gas_chem_driver.cpp
                linmat.cpp
-               nlnmat.cpp 
+               nlnmat.cpp
                indprd.cpp
                imp_prod_loss.cpp
                newton_raphson_iter.cpp
@@ -22,6 +22,7 @@ add_executable(gas_chem_driver
                )
 target_link_libraries(gas_chem_driver skywalker;validation;${HAERO_LIBRARIES})
 
+set(TestLabel "gas_chem")
 
 # Copy some Python scripts from mam_x_validation to our binary directory.
 foreach(script
@@ -50,7 +51,7 @@ set(TEST_LIST
 set(DEFAULT_TOL 1e-12)
 # gas_chem
 
-set(ERROR_THRESHOLDS  
+set(ERROR_THRESHOLDS
    ${DEFAULT_TOL}
    ${DEFAULT_TOL}
    ${DEFAULT_TOL}
@@ -65,7 +66,7 @@ set(ERROR_THRESHOLDS
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
-  
+
   configure_file(
     ${GAS_CHEM_VALIDATION_DIR}/mam_${input}.py
     ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
@@ -74,11 +75,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} gas_chem_driver ${GAS_CHEM_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS "${TestLabel}")
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 
 endforeach()


### PR DESCRIPTION
Nothing too exciting here--mainly plumbing.

I changed the arrays into views, since it seemed a bit tidier to do so.

I'll admit I'm not fully up to date on our best practices for passing variables around, so please let me know about any of this that might be inefficient or ugly.