### PR TITLE
Expose the activation fractions to make them settable from E3SM.

### DIFF
--- a/src/mam4xx/aero_model.hpp
+++ b/src/mam4xx/aero_model.hpp
@@ -631,8 +631,9 @@ void define_act_frac(const int lphase, const int imode,
                      const Real scav_fraction_in_cloud_strat,
                      const Real scav_fraction_in_cloud_conv,
                      const Real scav_fraction_below_cloud_strat,
-                     const Real activation_fraction_in_cloud_conv, Real &sol_facti,
-                     Real &sol_factic, Real &sol_factb, Real &f_act_conv) {
+                     const Real activation_fraction_in_cloud_conv,
+                     Real &sol_facti, Real &sol_factic, Real &sol_factb,
+                     Real &f_act_conv) {
   // clang-format off
   // -----------------------------------------------------------------------
   //  define sol_factb and sol_facti values, and f_act_conv

--- a/src/mam4xx/aero_model.hpp
+++ b/src/mam4xx/aero_model.hpp
@@ -627,7 +627,11 @@ inline void modal_aero_bcscavcoef_init(
 
 // =============================================================================
 KOKKOS_INLINE_FUNCTION
-void define_act_frac(const int lphase, const int imode, Real &sol_facti,
+void define_act_frac(const int lphase, const int imode,
+                     const Real sol_facti_cloud_borne,
+                     const Real sol_factic_cloud_borne,
+                     const Real sol_factb_below_cloud,
+                     const Real f_act_conv_below_cloud, Real &sol_facti,
                      Real &sol_factic, Real &sol_factb, Real &f_act_conv) {
   // clang-format off
   // -----------------------------------------------------------------------
@@ -668,7 +672,6 @@ void define_act_frac(const int lphase, const int imode, Real &sol_facti,
   */
   // clang-format on
   const int modeptr_pcarbon = static_cast<int>(mam4::ModeIndex::PrimaryCarbon);
-  const Real sol_facti_cloud_borne = 1.0;
   if (lphase == 1) { // interstial aerosol
     sol_facti = 0.0; // strat in-cloud scav totally OFF for institial
     // if modal aero convproc is turned on for aerosols, then
@@ -677,13 +680,13 @@ void define_act_frac(const int lphase, const int imode, Real &sol_facti,
     // and turn off the outfld SFWET, SFSIC, SFSID, SFSEC, and SFSED calls
     // for (stratiform)-cloudborne aerosols, convective wet removal
     // (all forms) is zero, so no action is needed
-    sol_factic = 0.0;
+    sol_factic = sol_factic_cloud_borne;
     // all below-cloud scav ON (0.1 "tuning factor")
-    sol_factb = 0.03;
+    sol_factb = sol_factb_below_cloud;
     if (imode == modeptr_pcarbon)
       f_act_conv = 0.0;
     else
-      f_act_conv = 0.4;
+      f_act_conv = f_act_conv_below_cloud;
 
   } else {
     // cloud-borne aerosol (borne by stratiform cloud drops)

--- a/src/mam4xx/aero_model.hpp
+++ b/src/mam4xx/aero_model.hpp
@@ -628,10 +628,10 @@ inline void modal_aero_bcscavcoef_init(
 // =============================================================================
 KOKKOS_INLINE_FUNCTION
 void define_act_frac(const int lphase, const int imode,
-                     const Real sol_facti_cloud_borne,
-                     const Real sol_factic_cloud_borne,
-                     const Real sol_factb_below_cloud,
-                     const Real f_act_conv_below_cloud, Real &sol_facti,
+                     const Real scav_fraction_in_cloud_strat,
+                     const Real scav_fraction_in_cloud_conv,
+                     const Real scav_fraction_below_cloud_strat,
+                     const Real activation_fraction_in_cloud_conv, Real &sol_facti,
                      Real &sol_factic, Real &sol_factb, Real &f_act_conv) {
   // clang-format off
   // -----------------------------------------------------------------------
@@ -680,20 +680,20 @@ void define_act_frac(const int lphase, const int imode,
     // and turn off the outfld SFWET, SFSIC, SFSID, SFSEC, and SFSED calls
     // for (stratiform)-cloudborne aerosols, convective wet removal
     // (all forms) is zero, so no action is needed
-    sol_factic = sol_factic_cloud_borne;
+    sol_factic = scav_fraction_in_cloud_conv;
     // all below-cloud scav ON (0.1 "tuning factor")
-    sol_factb = sol_factb_below_cloud;
+    sol_factb = scav_fraction_below_cloud_strat;
     if (imode == modeptr_pcarbon)
       f_act_conv = 0.0;
     else
-      f_act_conv = f_act_conv_below_cloud;
+      f_act_conv = activation_fraction_in_cloud_conv;
 
   } else {
     // cloud-borne aerosol (borne by stratiform cloud drops)
     // all below-cloud scav OFF (anything cloud-borne is located "in-cloud")
     sol_factb = 0.0;
     // strat  in-cloud scav totally ON for cloud-borne
-    sol_facti = haero::min(0.6, sol_facti_cloud_borne);
+    sol_facti = haero::min(0.6, scav_fraction_in_cloud_strat);
     // conv   in-cloud scav OFF (having this on would mean
     // that conv precip collects strat droplets)
     sol_factic = 0.0;

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1305,10 +1305,16 @@ KOKKOS_INLINE_FUNCTION
 void define_act_frac(const ThreadTeam &team, const View1D &sol_facti,
                      const View1D &sol_factic, const View1D &sol_factb,
                      const View1D &f_act_conv, const int lphase,
-                     const int imode, const int nlev) {
+                     const int imode, const int nlev,
+                     const Real sol_facti_cloud_borne,
+                     const Real sol_factic_cloud_borne,
+                     const Real sol_factb_below_cloud,
+                     const Real f_act_conv_below_cloud) {
   Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int k) {
-    aero_model::define_act_frac(lphase, imode, sol_facti[k], sol_factic[k],
-                                sol_factb[k], f_act_conv[k]);
+    aero_model::define_act_frac(lphase, imode, sol_facti_cloud_borne,
+                                sol_factic_cloud_borne, sol_factb_below_cloud,
+                                f_act_conv_below_cloud, sol_facti[k],
+                                sol_factic[k], sol_factb[k], f_act_conv[k]);
   });
 }
 
@@ -1564,7 +1570,9 @@ int get_aero_model_wetdep_work_len() {
 KOKKOS_INLINE_FUNCTION
 void aero_model_wetdep(
     const ThreadTeam &team, const Atmosphere &atm, Prognostics &progs,
-    Tendencies &tends, const Real dt,
+    Tendencies &tends, const Real dt, const Real sol_facti_cloud_borne,
+    const Real sol_factic_cloud_borne, const Real sol_factb_below_cloud,
+    const Real f_act_conv_below_cloud,
     // inputs
     const haero::ConstColumnView &cldt, const haero::ConstColumnView &rprdsh,
     const haero::ConstColumnView &rprddp, const haero::ConstColumnView &evapcdp,
@@ -1963,7 +1971,8 @@ void aero_model_wetdep(
             // outputs
             sol_facti, sol_factic, sol_factb, f_act_conv,
             // inputs
-            lphase, imode, nlev);
+            lphase, imode, nlev, sol_facti_cloud_borne, sol_factic_cloud_borne,
+            sol_factb_below_cloud, f_act_conv_below_cloud);
 
         // REASTER 08/12/2015 - changed ordering (mass then number) for
         // prevap resuspend to coarse loop over number + chem constituents +

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1306,14 +1306,14 @@ void define_act_frac(const ThreadTeam &team, const View1D &sol_facti,
                      const View1D &sol_factic, const View1D &sol_factb,
                      const View1D &f_act_conv, const int lphase,
                      const int imode, const int nlev,
-                     const Real sol_facti_cloud_borne,
-                     const Real sol_factic_cloud_borne,
-                     const Real sol_factb_below_cloud,
-                     const Real f_act_conv_below_cloud) {
+                     const Real scav_fraction_in_cloud_strat,
+                     const Real scav_fraction_in_cloud_conv,
+                     const Real scav_fraction_below_cloud_strat,
+                     const Real activation_fraction_in_cloud_conv) {
   Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int k) {
-    aero_model::define_act_frac(lphase, imode, sol_facti_cloud_borne,
-                                sol_factic_cloud_borne, sol_factb_below_cloud,
-                                f_act_conv_below_cloud, sol_facti[k],
+    aero_model::define_act_frac(lphase, imode, scav_fraction_in_cloud_strat,
+                                scav_fraction_in_cloud_conv, scav_fraction_below_cloud_strat,
+                                activation_fraction_in_cloud_conv, sol_facti[k],
                                 sol_factic[k], sol_factb[k], f_act_conv[k]);
   });
 }
@@ -1570,9 +1570,9 @@ int get_aero_model_wetdep_work_len() {
 KOKKOS_INLINE_FUNCTION
 void aero_model_wetdep(
     const ThreadTeam &team, const Atmosphere &atm, Prognostics &progs,
-    Tendencies &tends, const Real dt, const Real sol_facti_cloud_borne,
-    const Real sol_factic_cloud_borne, const Real sol_factb_below_cloud,
-    const Real f_act_conv_below_cloud,
+    Tendencies &tends, const Real dt, const Real scav_fraction_in_cloud_strat,
+    const Real scav_fraction_in_cloud_conv, const Real scav_fraction_below_cloud_strat,
+    const Real activation_fraction_in_cloud_conv,
     // inputs
     const haero::ConstColumnView &cldt, const haero::ConstColumnView &rprdsh,
     const haero::ConstColumnView &rprddp, const haero::ConstColumnView &evapcdp,
@@ -1971,8 +1971,8 @@ void aero_model_wetdep(
             // outputs
             sol_facti, sol_factic, sol_factb, f_act_conv,
             // inputs
-            lphase, imode, nlev, sol_facti_cloud_borne, sol_factic_cloud_borne,
-            sol_factb_below_cloud, f_act_conv_below_cloud);
+            lphase, imode, nlev, scav_fraction_in_cloud_strat, scav_fraction_in_cloud_conv,
+            scav_fraction_below_cloud_strat, activation_fraction_in_cloud_conv);
 
         // REASTER 08/12/2015 - changed ordering (mass then number) for
         // prevap resuspend to coarse loop over number + chem constituents +

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -1312,7 +1312,8 @@ void define_act_frac(const ThreadTeam &team, const View1D &sol_facti,
                      const Real activation_fraction_in_cloud_conv) {
   Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int k) {
     aero_model::define_act_frac(lphase, imode, scav_fraction_in_cloud_strat,
-                                scav_fraction_in_cloud_conv, scav_fraction_below_cloud_strat,
+                                scav_fraction_in_cloud_conv,
+                                scav_fraction_below_cloud_strat,
                                 activation_fraction_in_cloud_conv, sol_facti[k],
                                 sol_factic[k], sol_factb[k], f_act_conv[k]);
   });
@@ -1571,7 +1572,8 @@ KOKKOS_INLINE_FUNCTION
 void aero_model_wetdep(
     const ThreadTeam &team, const Atmosphere &atm, Prognostics &progs,
     Tendencies &tends, const Real dt, const Real scav_fraction_in_cloud_strat,
-    const Real scav_fraction_in_cloud_conv, const Real scav_fraction_below_cloud_strat,
+    const Real scav_fraction_in_cloud_conv,
+    const Real scav_fraction_below_cloud_strat,
     const Real activation_fraction_in_cloud_conv,
     // inputs
     const haero::ConstColumnView &cldt, const haero::ConstColumnView &rprdsh,
@@ -1971,8 +1973,9 @@ void aero_model_wetdep(
             // outputs
             sol_facti, sol_factic, sol_factb, f_act_conv,
             // inputs
-            lphase, imode, nlev, scav_fraction_in_cloud_strat, scav_fraction_in_cloud_conv,
-            scav_fraction_below_cloud_strat, activation_fraction_in_cloud_conv);
+            lphase, imode, nlev, scav_fraction_in_cloud_strat,
+            scav_fraction_in_cloud_conv, scav_fraction_below_cloud_strat,
+            activation_fraction_in_cloud_conv);
 
         // REASTER 08/12/2015 - changed ordering (mass then number) for
         // prevap resuspend to coarse loop over number + chem constituents +

--- a/src/validation/aero_model/aero_model_wetdep.cpp
+++ b/src/validation/aero_model/aero_model_wetdep.cpp
@@ -181,17 +181,23 @@ void aero_model_wetdep(Ensemble *ensemble) {
               });
           team.team_barrier();
 
-          wetdep::aero_model_wetdep(team, atm, progs_in, tends_in, dt,
-                                    // inputs
-                                    cldt, rprdsh, rprddp, evapcdp, evapcsh,
-                                    dp_frac, sh_frac, icwmrdp, icwmrsh, evapr,
-                                    // outputs
-                                    dlf, prain, scavimptblnum, scavimptblvol,
-                                    cal_data, wet_geometric_mean_diameter_i,
-                                    dry_geometric_mean_diameter_i, qaerwat,
-                                    wetdens,
-                                    // output
-                                    aerdepwetis, aerdepwetcw, work, isprx);
+          const Real sol_facti_cloud_borne = 1.00;
+          const Real sol_factic_cloud_borne = 0.00;
+          const Real sol_factb_below_cloud = 0.03;
+          const Real f_act_conv_below_cloud = 0.40;
+          wetdep::aero_model_wetdep(
+              team, atm, progs_in, tends_in, dt, sol_facti_cloud_borne,
+              sol_factic_cloud_borne, sol_factb_below_cloud,
+              f_act_conv_below_cloud,
+              // inputs
+              cldt, rprdsh, rprddp, evapcdp, evapcsh, dp_frac, sh_frac, icwmrdp,
+              icwmrsh, evapr,
+              // outputs
+              dlf, prain, scavimptblnum, scavimptblvol, cal_data,
+              wet_geometric_mean_diameter_i, dry_geometric_mean_diameter_i,
+              qaerwat, wetdens,
+              // output
+              aerdepwetis, aerdepwetcw, work, isprx);
 
           team.team_barrier();
           Kokkos::parallel_for(

--- a/src/validation/aero_model/aero_model_wetdep.cpp
+++ b/src/validation/aero_model/aero_model_wetdep.cpp
@@ -181,14 +181,14 @@ void aero_model_wetdep(Ensemble *ensemble) {
               });
           team.team_barrier();
 
-          const Real sol_facti_cloud_borne = 1.00;
-          const Real sol_factic_cloud_borne = 0.00;
-          const Real sol_factb_below_cloud = 0.03;
-          const Real f_act_conv_below_cloud = 0.40;
+          const Real scav_fraction_in_cloud_strat = 1.00;
+          const Real scav_fraction_in_cloud_conv = 0.00;
+          const Real cav_fraction_below_cloud_strat = 0.03;
+          const Real activation_fraction_in_cloud_conv = 0.40;
           wetdep::aero_model_wetdep(
-              team, atm, progs_in, tends_in, dt, sol_facti_cloud_borne,
-              sol_factic_cloud_borne, sol_factb_below_cloud,
-              f_act_conv_below_cloud,
+              team, atm, progs_in, tends_in, dt, scav_fraction_in_cloud_strat,
+              scav_fraction_in_cloud_conv, cav_fraction_below_cloud_strat,
+              activation_fraction_in_cloud_conv,
               // inputs
               cldt, rprdsh, rprddp, evapcdp, evapcsh, dp_frac, sh_frac, icwmrdp,
               icwmrsh, evapr,


### PR DESCRIPTION
Yet another change to a function signature in order to be able to set these values form the E3SM input.