### PR TITLE
Auto format build-type string

### DIFF
--- a/build-haero.sh
+++ b/build-haero.sh
@@ -64,6 +64,8 @@ if [[ "$PRECISION" != "single" && "$PRECISION" != "double" ]]; then
   echo "Invalid precision specified: $PRECISION (must be single or double)"
   exit
 fi
+# This should format the string as required (first letter capitalized)
+BUILD_TYPE="${BUILD_TYPE^}"
 if [[ "$BUILD_TYPE" != "Debug" && "$BUILD_TYPE" != "Release" ]]; then
   echo "Invalid optimization specified: $BUILD_TYPE"
   echo "Must be Debug or Release (case-sensitive)"


### PR DESCRIPTION
This is so minor as to be trivial, yet... I still forget every once in a while to capitalize `Debug` or `Release`. This fixes that so first-letter capitalized or lowercase are both accepted. Goofy options, however, like `dEbUG` are not handled, so you are on your own for those 🙂