### PR TITLE
ff mam x validation for new compare script

### DIFF
--- a/.github/workflows/gh_gcc-cpu.yml
+++ b/.github/workflows/gh_gcc-cpu.yml
@@ -75,7 +75,7 @@ jobs:
         # to get the array instead of a string, need the fromJSON()
         build-type: ${{ fromJSON(needs.define_matrix.outputs.build_type) }}
         fp-precision: ${{ fromJSON(needs.define_matrix.outputs.precision) }}
-
+    name: gcc-cpu / ${{ matrix.build-type }} - ${{ matrix.fp-precision }}
     runs-on: ${{ matrix.os }}
 
     # Environment variables

--- a/src/validation/aero_emissions/CMakeLists.txt
+++ b/src/validation/aero_emissions/CMakeLists.txt
@@ -71,12 +71,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} aero_emissions_driver ${AERO_EMISSIONS_VALIDATION_DIR}/${input}.yaml)
-  set_tests_properties(run_${input} PROPERTIES LABELS "${TestLabel}")
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
   set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/aero_model/CMakeLists.txt
+++ b/src/validation/aero_model/CMakeLists.txt
@@ -33,24 +33,25 @@ set(TEST_LIST
     modal_aero_bcscavcoef_init_ts_0
     aero_model_wetdep_ts_379
     stand_aero_model_calcsize_water_uptake_dr_ts_379
-    baseline_aero_model_wetdep_ts_379 
+    baseline_aero_model_wetdep_ts_379
     )
 
-set(DEFAULT_TOL 1e-11)
 set(DEFAULT_TOL_BASELINE 1e-13)
 
 set(ERROR_THRESHOLDS  
-   5e-8
-   ${DEFAULT_TOL}
-   2e-4
-   2e-5
-   2e-5
-   ${DEFAULT_TOL_BASELINE}
+   5e-8                    # calc_1_impact_rate_ts_0
+   1e-11                   # modal_aero_bcscavcoef_get_ts_355
+   2e-4                    # modal_aero_bcscavcoef_init_ts_0
+   2e-5                    # aero_model_wetdep_ts_379
+   1e-9                    # stand_aero_model_calcsize_water_uptake_dr_ts_379
+   ${DEFAULT_TOL_BASELINE} # baseline_aero_model_wetdep_ts_379
    )
+
+set(TestLabel "aero_model")
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
-  
+
   configure_file(
     ${AERO_MODEL_VALIDATION_DIR}/mam_${input}.py
     ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
@@ -59,11 +60,14 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} aero_model_driver ${AERO_MODEL_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 
 endforeach()

--- a/src/validation/aerosol_optics/CMakeLists.txt
+++ b/src/validation/aerosol_optics/CMakeLists.txt
@@ -57,24 +57,26 @@ set(TEST_LIST
     )
 # # matching the tests and errors, just for convenience
 
-set(DEFAULT_TOL 1e-13)
 set(ERROR_THRESHOLDS
-   2e-10
-   ${DEFAULT_TOL}
-   3e-10
-   3e-10
-   3e-10
-   2e-8
-   2e-8
-   6e-9
-   7e-11
-   2e-11
-   1e-12
-   7e-11
-   8e-11
-   8e-11
-   1e-14
+   2e-10 # binterp_ts_355
+   1e-13 # calc_diag_spec_ts_355
+   3e-10 # calc_refin_complex_ts_355_lw
+   3e-10 # calc_refin_complex_ts_355_sw
+   3e-10 # calc_volc_ext_ts_355
+   2e-8  # modal_size_parameters_ts_355_ismethod2_false
+   2e-8  # modal_size_parameters_ts_355_ismethod2_true
+   6e-9  # modal_aero_sw_ts_355
+   7e-11 # modal_aero_lw_ts_355
+   2e-11 # calc_parameterized_ts_355
+   1e-12 # update_aod_spec_ts_355
+   7e-11 # aer_rad_props_lw_ts_355
+   8e-11 # aer_rad_props_sw_ts_355
+   8e-11 # volcanic_cmip_sw_ts_355
+   1e-14 # data_transfer_state_q_qqwc_to_prog
    )
+
+set(TestLabel "aerosol_optics")
+
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
 
@@ -86,10 +88,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} aerosol_optics_driver ${AEROSOL_OPTICS_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/aging/CMakeLists.txt
+++ b/src/validation/aging/CMakeLists.txt
@@ -29,13 +29,13 @@ set(TEST_LIST
     pcarbon_aging_1subarea
     )
 
-#set(DEFAULT_TOL 1e-9)
-
 set(ERROR_THRESHOLDS 8e-5 4e-4)
+
+set(TestLabel "aging")
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place; is the skywalker file produced by fortran code?
-  
+
   configure_file(
     ${AGING_VALIDATION_DIR}/mam_${input}.py
     ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
@@ -44,12 +44,14 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} aging_driver ${AGING_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
    # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 
 endforeach()
-

--- a/src/validation/calcsize/CMakeLists.txt
+++ b/src/validation/calcsize/CMakeLists.txt
@@ -43,19 +43,20 @@ set(TEST_LIST
     )
 # # matching the tests and errors, just for convenience
 
-set(DEFAULT_TOL 2e-6)
+set(DEFAULT_TOL 1e-12)
 set(ERROR_THRESHOLDS
-    1e-12
-    1e-12
-    2e-6
-    2e-6
-    1e-12
-    1e-12
-    5e-11
-    3e-5
-    1.5e-3
+    ${DEFAULT_TOL} # adjust_num_sizes_case1
+    ${DEFAULT_TOL} # adjust_num_sizes_case2
+    2e-6           # calcsize_e3sm
+    2e-6           # calcsize_sub
+    ${DEFAULT_TOL} # aitken_accum_exchange_case1
+    ${DEFAULT_TOL} # calcsize_compute_dry_volume
+    5e-11          # stand_modal_aero_calcsize_sub
+    3e-5           # stand_modal_aero_calcsize_sub_update_ptend
+    1.5e-3         # stand_calcsize_aero_model_wetdep_ts_379
    )
 
+set(TestLabel "calcsize")
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
@@ -68,10 +69,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} calcsize_driver ${CALCSIZE_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/coagulation/CMakeLists.txt
+++ b/src/validation/coagulation/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(coagulation_driver
                coag_1subarea.cpp
                getcoags.cpp
                getcoags_wrapper_f.cpp
-               coag_aer_update.cpp 
+               coag_aer_update.cpp
                coag_num_update.cpp )
 target_link_libraries(coagulation_driver skywalker;validation;haero)
 
@@ -27,6 +27,8 @@ foreach(script
 endforeach()
 
 # Run the driver in several configurations to produce datasets.
+
+set(TestLabel "coagulation")
 
 # Aging
 foreach (input
@@ -46,9 +48,9 @@ foreach (input
 
   # add a test to run the skywalker driver
   add_test(run_${input} coagulation_driver ${COAGULATION_VALIDATION_DIR}/${input}.yaml)
-  
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
+
   # add a test to validate mam4xx's results against the baseline.
   add_test(validate_${input} python3 compare_coag_validation.py mam4xx_${input}.py mam_${input}.py)
-  endforeach() 
-
-
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
+  endforeach()

--- a/src/validation/convproc/CMakeLists.txt
+++ b/src/validation/convproc/CMakeLists.txt
@@ -47,6 +47,8 @@ endforeach()
 
 # Run the driver in several configurations to produce datasets.
 
+set(TestLabel "convproc")
+
 # convproc
 foreach (input
          update_tendency_final
@@ -87,22 +89,25 @@ foreach (input
 
   # add a test to run the skywalker driver
   add_test(run_${input} convproc_driver ${CONVPROC_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # Conservative approach: At the time of this commit, threshold error=2e-6.
-  # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error> 
-  if (${input} STREQUAL compute_activation_tend_do_act_true) 
+  # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
+  if (${input} STREQUAL compute_activation_tend_do_act_true)
     set(TOL 6e-6)
-  elseif (${input} STREQUAL ma_activate_convproc_54) 
+  elseif (${input} STREQUAL ma_activate_convproc_54)
     set(TOL 6e-5)
-  elseif (${input} STREQUAL ma_convproc_tend) 
+  elseif (${input} STREQUAL ma_convproc_tend)
     set(TOL 1e-4)
-  elseif (${input} STREQUAL compute_updraft_mixing_ratio) 
+  elseif (${input} STREQUAL compute_updraft_mixing_ratio)
     set(TOL 2e-4)
   else ()
     set(TOL 2e-6)
   endif ()
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${TOL})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/drydep/CMakeLists.txt
+++ b/src/validation/drydep/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(drydep_driver skywalker;validation;haero)
      COPYONLY
    )
 
+set(TestLabel "drydep")
 # Run the driver in several configurations to produce datasets.
 function(add_drydep_test input_name)
   string(REPLACE "_input_" "_output_"  output_name ${input_name})
@@ -39,21 +40,24 @@ function(add_drydep_test input_name)
   configure_file(${DRYDEP_VALIDATION_DIR}/${output_name}.py ${CMAKE_CURRENT_BINARY_DIR}/${output_name}.py COPYONLY)
   # add a test to run the skywalker driver
   add_test(run_${test_name} drydep_driver ${DRYDEP_VALIDATION_DIR}/${input_name}.yaml)
+  set_tests_properties(run_${test_name} PROPERTIES LABELS "${TestLabel}")
   # add a test to validate mam4xx's results against the baseline.
   add_test(validate_${test_name} python3 compare_drydep.py mam4xx_${input_name}.py ${output_name}.py)
+  set_property(TEST validate_${test_name} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${test_name} PROPERTIES DEPENDS run_${test_name})
+  set_tests_properties(validate_${test_name} PROPERTIES LABELS ${TestLabel})
 endfunction()
 
 foreach (input
-          gravit_settling_velocity
-          air_dynamic_viscosity
-          air_kinematic_viscosity
-          radius_for_moment
-          schmidt_number
-          slip_correction_factor
-          )
+         gravit_settling_velocity
+         air_dynamic_viscosity
+         air_kinematic_viscosity
+         radius_for_moment
+         schmidt_number
+         slip_correction_factor
+         )
   add_drydep_test(${input})
-endforeach() 
+endforeach()
 
 
 foreach (test_name
@@ -62,8 +66,8 @@ foreach (test_name
     depvel_part
     )
     foreach (ts
-	#1381 1382 1383 1384 1385 1386 1387 1388 1389 1390 1391 1392 
-       1393 #1394 1395 1396 1397 1398 1399 1400 1401 1402 1403 1404 
+	     #1381 1382 1383 1384 1385 1386 1387 1388 1389 1390 1391 1392
+       1393 #1394 1395 1396 1397 1398 1399 1400 1401 1402 1403 1404
        #1405 1406 1407 1408 1409 1410 1411 1412 1413 1414 1415 1416
         )
         foreach (jvlc 3 4)
@@ -72,36 +76,34 @@ foreach (test_name
             set(imode No_mode)
             set(input modal_aero_${test_name}_input_ts_${ts}_jvlc_${jvlc}_imnt_${imnt}_imode_${imode})
 	    add_drydep_test(${input})
-        endforeach() 
+        endforeach()
 
         foreach (jvlc 1 2)
 	    math(EXPR imnt "3 * ( ${jvlc} - 1)")
             foreach (imode 1 2 3 4)
                 set(input modal_aero_${test_name}_input_ts_${ts}_jvlc_${jvlc}_imnt_${imnt}_imode_${imode})
 	        add_drydep_test(${input})
-            endforeach() 
-        endforeach() 
-    endforeach() 
-endforeach() 
+            endforeach()
+        endforeach()
+    endforeach()
+endforeach()
 
 foreach (ts 1400 1401 1402 1403)# 1404 1405 1406 1407 1408 1409 1410 1411 1412 1413 1414 1415 1416)
     set(input calcram_input_ts_${ts})
     add_drydep_test(${input})
-endforeach() 
+endforeach()
 
 foreach (ts
-    1381 1382 1383 1384 1385 1386 1387 1388 1389 1390 1391 1392 
-#   1393 1394 1395 1396 1397 1398 1399 1400 1401 1402 1403 1404 
+    1381 1382 1383 1384 1385 1386 1387 1388 1389 1390 1391 1392
+#   1393 1394 1395 1396 1397 1398 1399 1400 1401 1402 1403 1404
 #   1405 1406 1407 1408 1409 1410 1411 1412 1413 1414 1415 1416
           )
     set(test_name drydep)
     set(input aero_model_${test_name}_input_ts_${ts})
     add_drydep_test(${input})
-endforeach() 
+endforeach()
 
 set(test_name drydep)
 set(ts compute_tendencies)
 set(input aero_model_${test_name}_input_${ts})
 add_drydep_test(${input})
-
-

--- a/src/validation/gas_chem/CMakeLists.txt
+++ b/src/validation/gas_chem/CMakeLists.txt
@@ -8,10 +8,10 @@ set(GAS_CHEM_VALIDATION_SCRIPTS_DIR ${MAM_X_VALIDATION_DIR}/scripts)
 include_directories(${PROJECT_BINARY_DIR}/validation)
 
 # We use a single driver for all gas_chem-related parameterizations.
-add_executable(gas_chem_driver  
+add_executable(gas_chem_driver
                gas_chem_driver.cpp
                linmat.cpp
-               nlnmat.cpp 
+               nlnmat.cpp
                indprd.cpp
                imp_prod_loss.cpp
                newton_raphson_iter.cpp
@@ -50,22 +50,24 @@ set(TEST_LIST
 set(DEFAULT_TOL 1e-12)
 # gas_chem
 
-set(ERROR_THRESHOLDS  
-   ${DEFAULT_TOL}
-   ${DEFAULT_TOL}
-   ${DEFAULT_TOL}
-   ${DEFAULT_TOL}
-   7e-11
-   ${DEFAULT_TOL}
-   ${DEFAULT_TOL}
-   ${DEFAULT_TOL}
-   ${DEFAULT_TOL}
-   ${DEFAULT_TOL}
+set(ERROR_THRESHOLDS
+   ${DEFAULT_TOL} # indprd_ts_355
+   ${DEFAULT_TOL} # linmat_ts_355
+   ${DEFAULT_TOL} # nlnmat_ts_355
+   ${DEFAULT_TOL} # imp_prod_loss_ts_355
+   7e-11          # newton_raphson_iter_ts_355
+   ${DEFAULT_TOL} # imp_sol_ts_355
+   ${DEFAULT_TOL} # adjrxt_ts_1400
+   ${DEFAULT_TOL} # setrxt_ts_1400
+   ${DEFAULT_TOL} # usrrxt_merged
+   ${DEFAULT_TOL} # usrrxt_ts_1416
    )
+
+set(TestLabel "gas_chem")
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
-  
+
   configure_file(
     ${GAS_CHEM_VALIDATION_DIR}/mam_${input}.py
     ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
@@ -74,11 +76,14 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} gas_chem_driver ${GAS_CHEM_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 
 endforeach()

--- a/src/validation/hetfrz/CMakeLists.txt
+++ b/src/validation/hetfrz/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(hetfrz_driver
                hetfrz_calculate_collkernel_sub.cpp
                hetfrz_collkernel.cpp
                hetfrz_get_Aimm.cpp
-               hetfrz_get_dg0imm.cpp 
+               hetfrz_get_dg0imm.cpp
                hetfrz_get_form_factor.cpp
                hetfrz_calculate_hetfrz_contact_nucleation.cpp
                hetfrz_calculate_hetfrz_deposition_nucleation.cpp
@@ -40,6 +40,8 @@ target_link_libraries(hetfrz_driver skywalker;validation;haero)
      ${CMAKE_CURRENT_BINARY_DIR}/compare_hetfzr.py
      COPYONLY
    )
+
+ set(TestLabel "hetfrz")
 
 # Run the driver in several configurations to produce datasets.
 
@@ -78,10 +80,11 @@ foreach (input
 
   # add a test to run the skywalker driver
   add_test(run_${input} hetfrz_driver ${HETFRZ_VALIDATION_DIR}/${input}.yaml)
-  
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
+
   # add a test to validate mam4xx's results against the baseline.
   add_test(validate_${input} python3 compare_hetfzr.py mam4xx_${input}.py ${input}.py)
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
-endforeach() 
-
-
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
+endforeach()

--- a/src/validation/lin_strat_chem/CMakeLists.txt
+++ b/src/validation/lin_strat_chem/CMakeLists.txt
@@ -38,15 +38,17 @@ set(TEST_LIST
     )
 # # matching the tests and errors, just for convenience
 
-set(DEFAULT_TOL 1e-13)
 set(ERROR_THRESHOLDS
-    6e-11
-    ${DEFAULT_TOL}
-    6e-13
-    2e-9
-    6e-9
-    9e-7
+    6e-11 # lin_strat_chem_solve_ts_1415
+    1e-13 # lin_strat_sfcsink_ts_1415_multicol
+    6e-13 # lin_strat_sfcsinkmulticol_merged
+    2e-9  # lin_strat_chem_solve_merged
+    6e-9  # lin_strat_chem_solve_ts_1415_multicol
+    9e-7  # lin_strat_chem_solvemulticol_merged
    )
+
+set(TestLabel "lin_strat_chem")
+
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
 
@@ -58,10 +60,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} lin_strat_chem_driver ${LIN_STRAT_CHEM_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/micro_gasaerexch/CMakeLists.txt
+++ b/src/validation/micro_gasaerexch/CMakeLists.txt
@@ -33,16 +33,17 @@ set(TEST_LIST
     )
 # # matching the tests and errors, just for convenience
 
-set(DEFAULT_TOL 1e-13)
 set(ERROR_THRESHOLDS
     2e-10
-    ${DEFAULT_TOL}
+    1e-13
     4e-10
    )
 
+set(TestLabel "micro_gasaerexch")
+
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
-  
+
   configure_file(
     ${MICRO_GASAEREXCH_DIR}/mam_${input}.py
     ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
@@ -51,11 +52,14 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} micro_gasaerexch_driver ${MICRO_GASAEREXCH_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 
 endforeach()

--- a/src/validation/mo_chm_diags/CMakeLists.txt
+++ b/src/validation/mo_chm_diags/CMakeLists.txt
@@ -31,13 +31,15 @@ set(TEST_LIST
     het_diags_ts_355
     chm_diags_ts_355
     )
-# # matching the tests and errors, just for convenience
+# matching the tests and errors, just for convenience
 
-set(DEFAULT_TOL 1e-13)
 set(ERROR_THRESHOLDS
    9e-2
    1.3e-5
    )
+
+set(TestLabel "mo_chm_diags")
+
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
 
@@ -49,10 +51,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} mo_chm_diags_driver ${MO_CHM_DIAGS_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/mo_drydep/CMakeLists.txt
+++ b/src/validation/mo_drydep/CMakeLists.txt
@@ -63,7 +63,7 @@ set(ERROR_THRESHOLDS
     ${DEFAULT_TOL} # calculate_uustar
     1e-9           # drydep_xactive
     ${DEFAULT_TOL} # calculate_gas_drydep_vlc_and_flux
-    0 # find_season_index
+    0              # find_season_index
    )
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
@@ -82,6 +82,7 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
   set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabels})
 endforeach()

--- a/src/validation/mo_photo/CMakeLists.txt
+++ b/src/validation/mo_photo/CMakeLists.txt
@@ -53,6 +53,9 @@ set(ERROR_THRESHOLDS
     8e-6
     2e-6
    )
+
+set(TestLabel "mo_photo")
+
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
 
@@ -64,12 +67,15 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} mo_photo_driver ${MO_PHOTO_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()
 
 # Test set_ub_col separately, since we're only computing O3 "densities" and not
@@ -88,9 +94,12 @@ configure_file(
 
 # add a test to run the skywalker driver
 add_test(run_${input} mo_photo_driver ${MO_PHOTO_VALIDATION_DIR}/${input}.yaml)
+set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
 # add a test to validate mam4xx's results against the baseline.
 # Select a threshold error slightly bigger than the largest relative error for the threshold error.
 # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
 add_test(validate_${input} python3 compare_set_ub_col_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
 set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})

--- a/src/validation/mo_setext/CMakeLists.txt
+++ b/src/validation/mo_setext/CMakeLists.txt
@@ -35,6 +35,9 @@ set(DEFAULT_TOL 1e-13)
 set(ERROR_THRESHOLDS
 9e-10
    )
+
+set(TestLabel "mo_setext")
+
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
 
@@ -46,10 +49,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} setext_driver ${SETEXT_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/mo_sethet/CMakeLists.txt
+++ b/src/validation/mo_sethet/CMakeLists.txt
@@ -41,12 +41,15 @@ set(TEST_LIST
 
 set(DEFAULT_TOL 1e-13)
 set(ERROR_THRESHOLDS
-    9e-8 # calc_het_rates, this is due to using a more specific value for mass_h2o
-    ${DEFAULT_TOL} # calc_precip_rescale
-    ${DEFAULT_TOL} # find_ktop, output is an int
-    9e-8 # gas_washout
-    9e-7 # sethet
+    9e-8           # calc_het_rates_merged, this is due to using a more specific value for mass_h2o
+    ${DEFAULT_TOL} # calc_precip_rescale_merged
+    ${DEFAULT_TOL} # find_ktop_merged, output is an int
+    9e-8           # gas_washout_merged
+    9e-7           # sethet_merged
    )
+
+set(TestLabel "mo_sethet")
+
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
 
@@ -58,10 +61,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} sethet_driver ${SETHET_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/mo_setinv/CMakeLists.txt
+++ b/src/validation/mo_setinv/CMakeLists.txt
@@ -39,6 +39,8 @@ set(ERROR_THRESHOLDS
     ${DEFAULT_TOL}
    )
 
+set(TestLabel "mo_setinv")
+
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
 
@@ -50,10 +52,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} mo_setinv_driver ${MO_SETINV_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/mo_setsox/CMakeLists.txt
+++ b/src/validation/mo_setsox/CMakeLists.txt
@@ -41,12 +41,14 @@ set(TEST_LIST
 set(DEFAULT_TOL 1e-11)
 
 set(ERROR_THRESHOLDS
-    ${DEFAULT_TOL} # setsox_test
-    ${DEFAULT_TOL} # setsox_test_nlev
-    ${DEFAULT_TOL} # calc_ph_values
-    ${DEFAULT_TOL} # calc_sox_aqueous
-    ${DEFAULT_TOL} # calc_ynetpos
+    ${DEFAULT_TOL} # setsox_ts_355_merged
+    ${DEFAULT_TOL} # setsox_ts_355_nlev
+    ${DEFAULT_TOL} # calc_ph_values_ts_355
+    ${DEFAULT_TOL} # calc_sox_aqueous_ts_355_merged
+    ${DEFAULT_TOL} # calc_ynetpos_ts_355
    )
+
+set(TestLabel "mo_setsox")
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
@@ -59,10 +61,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} mo_setsox_driver ${MO_SETSOX_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/modal_aero_amicphys_subareas/CMakeLists.txt
+++ b/src/validation/modal_aero_amicphys_subareas/CMakeLists.txt
@@ -75,12 +75,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} amicphys_subareas_driver ${AMICPHYS_SUBAREAS_DRIVER_VALIDATION_DIR}/${input}.yaml)
-  set_tests_properties(run_${input} PROPERTIES LABELS "${TestLabel}")
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
   set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/ndrop/CMakeLists.txt
+++ b/src/validation/ndrop/CMakeLists.txt
@@ -85,28 +85,28 @@ set(DEFAULT_TOL 1e-11)
 set(DEFAULT_TOL_DROPMIXNUC 6.8e-4)
 
 set(ERROR_THRESHOLDS
-    4e-8  #    loadaertype1_merged
-    4e-8  #    loadaertype2_merged
-    6e-8  #    loadaertype3_merged
-    7e-5  #    activate_modal_ts_1400_type1
-    2e-10 #    explmix1417_actmm_merged
-    1e-9  #    explmix1417_mm_merged
-    5e-5  #    stand_get_activate_frac_ts_1417
-    1e-5  #    activate_modal_ts_1417_type2
-    5e-6  #    stand_activate_modal_ts_1417_type2
-    2e-3  #    activate_modal_merged
-    2e-3  #    ccncalc_merged
-    1e-3  #    ccncalc_loop_ts_1417
-    5e-5  #    ccncalc_ts_1400
-    ${DEFAULT_TOL} #    maxsattype1_merged
-    ${DEFAULT_TOL} #    maxsattype2_merged
-    2e-9  #    update_from_newcld_iact0_merged
-    1e-3  #    update_from_newcld_iact1_merged
-    ${DEFAULT_TOL} #    update_from_newcld_iact2_merged
-    9e-3  #    update_from_cldn_profile_iact1_merged
-    1e-12 #    update_from_cldn_profile_iact2_merged
-    5e-5  #    stand_dropmixnuc_ts_1407
-    ${DEFAULT_TOL_DROPMIXNUC} #    dropmixnuc_ts_14
+    4e-8                      # loadaertype1_merged
+    4e-8                      # loadaertype2_merged
+    6e-8                      # loadaertype3_merged
+    7e-5                      # activate_modal_ts_1400_type1
+    2e-10                     # explmix1417_actmm_merged
+    1e-9                      # explmix1417_mm_merged
+    5e-5                      # stand_get_activate_frac_ts_1417
+    1e-5                      # activate_modal_ts_1417_type2
+    5e-6                      # stand_activate_modal_ts_1417_type2
+    2e-3                      # activate_modal_merged
+    2e-3                      # ccncalc_merged
+    1e-3                      # ccncalc_loop_ts_1417
+    5e-5                      # ccncalc_ts_1400
+    ${DEFAULT_TOL}            # maxsattype1_merged
+    ${DEFAULT_TOL}            # maxsattype2_merged
+    2e-9                      # update_from_newcld_iact0_merged
+    1e-3                      # update_from_newcld_iact1_merged
+    ${DEFAULT_TOL}            # update_from_newcld_iact2_merged
+    9e-3                      # update_from_cldn_profile_iact1_merged
+    1e-12                     # update_from_cldn_profile_iact2_merged
+    5e-5                      # stand_dropmixnuc_ts_1407
+    ${DEFAULT_TOL_DROPMIXNUC} # dropmixnuc_ts_14
     ${DEFAULT_TOL_DROPMIXNUC}
     ${DEFAULT_TOL_DROPMIXNUC}
     ${DEFAULT_TOL_DROPMIXNUC}
@@ -124,8 +124,10 @@ set(ERROR_THRESHOLDS
     ${DEFAULT_TOL_DROPMIXNUC}
     ${DEFAULT_TOL_DROPMIXNUC}
     ${DEFAULT_TOL_DROPMIXNUC}
-    9e-8 #    update_from_explmix_merged
+    9e-8                      # update_from_explmix_merged
    )
+
+set(TestLabel "ndrop")
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
@@ -138,10 +140,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} ndrop_driver ${NDROP_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/nucleate_ice/CMakeLists.txt
+++ b/src/validation/nucleate_ice/CMakeLists.txt
@@ -36,6 +36,8 @@ set(ERROR_THRESHOLDS 1.5e-5 ${DEFAULT_TOL} ${DEFAULT_TOL} 3e-9 ${DEFAULT_TOL})
 
 # Run the driver in several configurations to produce datasets.
 
+set(TestLabel "nucleate_ice")
+
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place; is the skywalker file produced by fortran code?
   configure_file(
@@ -46,10 +48,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} nucleate_ice_driver ${NUCLEATE_ICE_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/nucleation/CMakeLists.txt
+++ b/src/validation/nucleation/CMakeLists.txt
@@ -26,6 +26,8 @@ foreach(script
   )
 endforeach()
 
+set(TestLabel "nucleation")
+
 # Run the driver in several configurations to produce datasets.
 
 # Nucleation rate
@@ -51,6 +53,7 @@ foreach (input
 
   # add a test to validate mam4xx's results against the baseline.
   add_test(validate_${input} python3 compare_nucleation_rate.py mam4xx_${input}.py mam_${input}.py)
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
 endforeach()
 
@@ -69,14 +72,16 @@ foreach (input
 
   # add a test to run the skywalker driver
   add_test(run_${input} nucleation_driver ${NUC_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   add_test(validate_${input} python3 compare_particle_growth.py mam4xx_${input}.py mam_${input}.py)
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()
 
 # additional tests added for integration
-set(TestLabel "nuc_tests_new")
 
 set(NUCLEATION_VALIDATION_SCRIPTS_DIR ${MAM_X_VALIDATION_DIR}/scripts)
 
@@ -113,12 +118,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} nucleation_driver ${NUC_VALIDATION_DIR}/${input}.yaml)
-  set_tests_properties(run_${input} PROPERTIES LABELS "${TestLabel}")
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
   set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/rename/CMakeLists.txt
+++ b/src/validation/rename/CMakeLists.txt
@@ -37,16 +37,18 @@ set(TEST_LIST
 set(DEFAULT_TOL 1e-11)
 # rename
 
-set(ERROR_THRESHOLDS 
+set(ERROR_THRESHOLDS
    7e-11
    7e-10
    2e-8
-   ${DEFAULT_TOL} 
+   ${DEFAULT_TOL}
    ${DEFAULT_TOL})
+
+set(TestLabel "rename")
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
-  
+
   configure_file(
     ${RENAME_VALIDATION_DIR}/mam_${input}.py
     ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
@@ -55,11 +57,14 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} rename_driver ${RENAME_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 
 endforeach()

--- a/src/validation/tracer_data/CMakeLists.txt
+++ b/src/validation/tracer_data/CMakeLists.txt
@@ -31,14 +31,16 @@ set(TEST_LIST
     vert_interp_col_ts_300
     rebin_ts_300
     )
+
 set(DEFAULT_TOL 1e-12)
 
-
 set(ERROR_THRESHOLDS
-   ${DEFAULT_TOL}
-   ${DEFAULT_TOL}
-   2e-9
-   )
+    ${DEFAULT_TOL}
+    ${DEFAULT_TOL}
+    2e-9
+    )
+
+set(TestLabel "tracer_data")
 
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
@@ -51,11 +53,14 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} tracer_data_driver ${TRACER_DATA_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 
 endforeach()

--- a/src/validation/tropopause/CMakeLists.txt
+++ b/src/validation/tropopause/CMakeLists.txt
@@ -41,6 +41,9 @@ set(ERROR_THRESHOLDS
    9e-4
    ${DEFAULT_TOL}  # Output is an integer.
    )
+
+set(TestLabel "tropopause")
+
 foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
   # copy the baseline file into place.
 
@@ -52,10 +55,13 @@ foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
 
   # add a test to run the skywalker driver
   add_test(run_${input} tropopause_driver ${TROPOPAUSE_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
 
   # add a test to validate mam4xx's results against the baseline.
   # Select a threshold error slightly bigger than the largest relative error for the threshold error.
   # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
   add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
   set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
 endforeach()

--- a/src/validation/water_uptake/CMakeLists.txt
+++ b/src/validation/water_uptake/CMakeLists.txt
@@ -32,6 +32,8 @@ target_link_libraries(water_uptake_driver skywalker;validation;haero)
 
 # Run the driver in several configurations to produce datasets.
 
+set(TestLabel "water_uptake")
+
 foreach (input
           find_real_solution
           makoh_quartic
@@ -54,7 +56,9 @@ foreach (input
 
   # add a test to run the skywalker driver
    add_test(run_${input} water_uptake_driver ${WATER_UPTAKE_VALIDATION_DIR}/${input}.yaml)
-  
+   set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
+
   # add a test to validate mam4xx's results against the baseline.
   add_test(validate_${input} python3 compare_water_uptake.py mam4xx_${input}.py ${input}.py)
-endforeach() 
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
+endforeach()

--- a/src/validation/wetdep/CMakeLists.txt
+++ b/src/validation/wetdep/CMakeLists.txt
@@ -1,9 +1,13 @@
 set(WETDEP_VALIDATION_DIR ${MAM_X_VALIDATION_DIR}/wetdep)
-set(WETDEP_VALIDATION_TOOLS_DIR ${MAM_X_VALIDATION_DIR}/tools)
+set(WETDEP_VALIDATION_SCRIPTS_DIR ${MAM_X_VALIDATION_DIR}/scripts)
 
-include_directories(${PROJECT_BINARY_DIR}/haero)
+
+# These subdirectories contain Skywalker drivers for MAM4 parameterizations.
+# Include directory for .mod files.
+
 include_directories(${PROJECT_BINARY_DIR}/validation)
 
+# We use a single driver for all wetdep-related parameterizations.
 add_executable(wetdep_driver
                wetdep_driver.cpp
                wetdep_clddiag.cpp
@@ -17,47 +21,91 @@ add_executable(wetdep_driver
                calculate_cloudy_volume.cpp
                local_precip_production.cpp
                wetdep_resusp.cpp
-               wetdepa_v2.cpp
-              )
+               wetdepa_v2.cpp)
 target_link_libraries(wetdep_driver skywalker;validation;haero)
 
-foreach (TEST_NAME
-         clddiag
-	 update_scavenging_0
-	 update_scavenging_130
-	 update_scavenging_230
-	 wetdep_prevap_130
-	 wetdep_prevap_230
-	 wetdep_resusp_nonlinear_130
-	 wetdep_resusp_nonlinear_230
-	 wetdep_resusp_noprecip_130
-	 wetdep_resusp_noprecip_230
-	 wetdep_scavenging_true
-	 wetdep_scavenging_false
-	 compute_evap_frac
-	 rain_mix_ratio
-	 calculate_cloudy_volume
-	 local_precip_production
-	 wetdep_resusp_130
-	 wetdep_resusp_230
-	 wetdepa_v2_0
-	 wetdepa_v2_130
-	 wetdepa_v2_230
-	)
-  set(SKYWALKER_RESULT ${TEST_NAME}_output_ts_355)
+# Copy some Python scripts from mam_x_validation to our binary directory.
+foreach(script
+        compare_mam4xx_mam4.py)
   configure_file(
-     ${WETDEP_VALIDATION_DIR}/${SKYWALKER_RESULT}.py
-     ${CMAKE_CURRENT_BINARY_DIR}/${SKYWALKER_RESULT}_ref.py
-     COPYONLY)
-
-  add_test(wetdep_validation_${TEST_NAME} wetdep_driver
-    ${WETDEP_VALIDATION_DIR}/${TEST_NAME}_input_ts_355.yaml)
-
-  set(MAM4XX_WETDEP_RESULT mam4xx_${TEST_NAME}_input_ts_355)
-  # Just use skywalker diff since cmake compare is too specific
-  add_test(NAME wetdep_compare_${TEST_NAME}_output
-    COMMAND python3 ${MAM_X_VALIDATION_DIR}/scripts/compare_mam4xx_mam4.py ${MAM4XX_WETDEP_RESULT} ${SKYWALKER_RESULT}_ref
+    ${WETDEP_VALIDATION_SCRIPTS_DIR}/${script}
+    ${CMAKE_CURRENT_BINARY_DIR}/${script}
+    COPYONLY
   )
-  set_tests_properties(wetdep_compare_${TEST_NAME}_output
-    PROPERTIES DEPENDS wetdep_validation_{TEST_NAME})
+endforeach()
+
+# Run the driver in several configurations to produce datasets.
+set(TEST_LIST
+    clddiag
+    update_scavenging_0
+    update_scavenging_130
+    update_scavenging_230
+    wetdep_prevap_130
+    wetdep_prevap_230
+    wetdep_resusp_nonlinear_130
+    wetdep_resusp_nonlinear_230
+    wetdep_resusp_noprecip_130
+    wetdep_resusp_noprecip_230
+    wetdep_scavenging_true
+    wetdep_scavenging_false
+    compute_evap_frac
+    rain_mix_ratio
+    calculate_cloudy_volume
+    local_precip_production
+    wetdep_resusp_130
+    wetdep_resusp_230
+    wetdepa_v2_0
+    wetdepa_v2_130
+    wetdepa_v2_230
+    )
+
+set(DEFAULT_TOL 1e-6)
+
+set(ERROR_THRESHOLDS
+    ${DEFAULT_TOL} # clddiag
+    ${DEFAULT_TOL} # update_scavenging_0
+    ${DEFAULT_TOL} # update_scavenging_130
+    ${DEFAULT_TOL} # update_scavenging_230
+    ${DEFAULT_TOL} # wetdep_prevap_130
+    3e-6           # wetdep_prevap_230
+    ${DEFAULT_TOL} # wetdep_resusp_nonlinear_130
+    ${DEFAULT_TOL} # wetdep_resusp_nonlinear_230
+    ${DEFAULT_TOL} # wetdep_resusp_noprecip_130
+    ${DEFAULT_TOL} # wetdep_resusp_noprecip_230
+    1e-10          # wetdep_scavenging_true
+    1e-10          # wetdep_scavenging_false
+    ${DEFAULT_TOL} # compute_evap_frac
+    ${DEFAULT_TOL} # rain_mix_ratio
+    ${DEFAULT_TOL} # calculate_cloudy_volume
+    ${DEFAULT_TOL} # local_precip_production
+    ${DEFAULT_TOL} # wetdep_resusp_130
+    ${DEFAULT_TOL} # wetdep_resusp_230
+    ${DEFAULT_TOL} # wetdepa_v2_0
+    ${DEFAULT_TOL} # wetdepa_v2_130
+    ${DEFAULT_TOL} # wetdepa_v2_230
+    )
+
+set(TestLabel "wetdep")
+
+foreach(input tol IN ZIP_LISTS TEST_LIST ERROR_THRESHOLDS)
+  # copy the baseline file into place.
+
+  configure_file(
+    ${WETDEP_VALIDATION_DIR}/mam_${input}.py
+    ${CMAKE_CURRENT_BINARY_DIR}/mam_${input}.py
+    COPYONLY
+  )
+
+  # add a test to run the skywalker driver
+  add_test(run_${input} wetdep_driver ${WETDEP_VALIDATION_DIR}/${input}.yaml)
+  set_tests_properties(run_${input} PROPERTIES LABELS ${TestLabel})
+
+  # add a test to validate mam4xx's results against the baseline.
+  # Select a threshold error slightly bigger than the largest relative error for the threshold error.
+  # compare_mam4xx_mam4.py <module1.py> <module2.py> <check_norms> <threshold error>
+  add_test(validate_${input} python3 compare_mam4xx_mam4.py mam4xx_${input}.py mam_${input}.py True ${tol})
+  set_property(TEST validate_${input} PROPERTY SKIP_REGULAR_EXPRESSION "regex_fail_rel_tol")
+  set_tests_properties(validate_${input} PROPERTIES DEPENDS run_${input})
+  set_tests_properties(validate_${input} PROPERTIES LABELS ${TestLabel})
+
 endforeach()


### PR DESCRIPTION
Brings in the new python script for validation test comparison. Employs relative error for pass/fail criteria and adds optional args for extra debug info.

The important details are:

- There are quite a few tests that fail based on relative error, and I've included a list below.
  - The convention is `Tol <old-abs-tol> -> <new-rel-tol-for-passing>  - <test number>   -   <test name>`
  - Some tests are showing very high levels of relative error, indicating there may be major issues with the associated code.
    - I have denoted those with `***asterisks***`
- This presents a tricky issue given the following, somewhat competing goals:
  1. Merging PRs should not have failing tests.
  2. We would like to maintain the previous results, based on absolute error, as a form of regression checking.
  3. The tests that fail based on relative error should give clear output indicating as such--something like a **_warning_** rather than an **_error_**.
    - My reasoning on this final point is that relative error contains strictly more information than absolute error, and we currently have tests passing based on absolute error tolerances that are not meaningful.
    - Given this, when the time is appropriate, we should adjust tolerances to align with the relative error values.
    - Additionally, there are some tests that exhibit relative error values of 1, indicating that the calculated quantity is in total error (the magnitude of the error is the same as the magnitude of the quantity).
      - I have not had the chance to look into these.
      - It is possible that this is not a huge issue for example $q_{\text{ref}} = 0,\ q_{\text{calculated}} = 10^{-14}, \mathcal{E}_{\text{rel}} = 1$, though I believe I have addressed this particular corner case.
- My approach to addressing the 3 factors above is to use CTest's `SKIP_REGULAR_EXPRESSION` functionality.
  - CTest is not actually that flexible, and this seemed to be the best option.
  - This feature looks for a particular return string, and when it is found, denotes the test as **_skipped_**, and the list of skipped tests appears at the bottom of the `make test` output, and all of the generated output is still printed to log.
  - While this is a bit of a misnomer, I think it's the best option because seeing the output is unavoidable and will keep it front-of-mind for devs to look into while still maintaining the previous pass/fail behavior with the previous absolute tolerance levels.

<details>

<summary>
<b>Tests failing based on relative error, and tolerance adjustments</b>
</summary>

Tol    2e-11  -> 4e-11   -   48  - validate_mer07_veh02_nuc_mosaic_1box
Tol    1e-12  -> 2e-10   -   60  - validate_calcsize_compute_dry_volume
Tol    5e-11  -> 5e-8    -   62  - validate_stand_modal_aero_calcsize_sub
Tol    2e-6   -> 2e-1    -   74  - validate_ma_precpprod
***Tol 2e-6   -> 1.5e0   -   90  - validate_compute_massflux_small***
Tol    4e-4   -> 3e-2    -   134 - validate_pcarbon_aging_1subarea
Tol    5e-8   -> 2.5e-6  -   202 - validate_calc_1_impact_rate_ts_0
Tol    1e-11  -> 1e-9    -   204 - validate_modal_aero_bcscavcoef_get_ts_355
Tol    1e-9   -> 5e-7    -   210 - validate_stand_aero_model_calcsize_water_uptake_dr_ts_379
Tol    1e-13  -> 1e-9    -   212 - validate_baseline_aero_model_wetdep_ts_379
Tol    1e-6   -> 1e-5    -   214 - validate_clddiag
Tol    1e-6   -> 2e-1    -   222 - validate_wetdep_prevap_130
Tol    1e-6   -> 3e-6    -   224 - validate_wetdep_prevap_230
***Tol 1e-6   -> 1.5e0   -   234 - validate_wetdep_scavenging_true***
***Tol 1e-6   -> 1.5e0   -   236 - validate_wetdep_scavenging_false***
Tol    1e-6   -> 6e-6    -   240 - validate_rain_mix_ratio
Tol    1e-6   -> 4e-1    -   246 - validate_wetdep_resusp_130
Tol    1e-6   -> 4e-1    -   248 - validate_wetdep_resusp_230
Tol    1e-12  -> 3e-10   -   364 - validate_linmat_ts_355
Tol    1e-12  -> 4e-10   -   366 - validate_nlnmat_ts_355
Tol    1e-12  -> 3e-10   -   368 - validate_imp_prod_loss_ts_355
***Tol 7e-11  -> 1e0     -   370 - validate_newton_raphson_iter_ts_355*** (only max_delta)
Tol    1e-11  -> 3e-10   -   408 - validate_maxsattype1_merged
Tol    1e-11  -> 3e-10   -   410 - validate_maxsattype2_merged
Tol    6e-11  -> 1e-10   -   498 - validate_lin_strat_chem_solve_ts_1415
Tol    1e-13  -> 3e-10   -   500 - validate_lin_strat_sfcsink_ts_1415_multicol
Tol    6e-13  -> 5e-10   -   502 - validate_lin_strat_sfcsinkmulticol_merged
***Tol 1.3e-5 -> 1.5e0   -   512 - validate_chm_diags_ts_355***
Tol    9e-8   -> 5e-5    -   538 - validate_calc_het_rates_merged
Tol    1e-13  -> 1.5e-10 -   540 - validate_calc_precip_rescale_merged
Tol    9e-7   -> 1.5e-5  -   546 - validate_sethet_merged
Tol    1e-11  -> 1.5e-9  -   554 - validate_calc_sox_aqueous_ts_355_merged
Tol    1e-13  -> 1.5e-10 -   566 - validate_calc_diag_spec_ts_355
Tol    7e-11  -> 1.5e-10 -   580 - validate_modal_aero_lw_ts_355
Tol    1e-12  -> 3.5e-10 -   584 - validate_update_aod_spec_ts_355
Tol    7e-11  -> 1.5e-10 -   586 - validate_aer_rad_props_lw_ts_355
Tol    8e-11  -> 3e-10   -   588 - validate_aer_rad_props_sw_ts_355
Tol    8e-11  -> 3e-10   -   590 - validate_volcanic_cmip_sw_ts_355
***Tol 2e-10  -> 5e-2    -   616 - validate_mam_soaexch_1subarea_ts_379***
Tol    1e-13  -> 2e-11   -   618 - validate_gas_aer_uptkrates_1box1gas_ts_379
***Tol 4e-10  -> 5e-4    -   620 - validate_mam_gasaerexch_1subarea_ts_379***
Tol    1e-12  -> 5e-11   -   622 - validate_vert_interp_ts_300
Tol    1e-12  -> 1e-10   -   624 - validate_vert_interp_col_ts_300

</details>