### PR TITLE
Replaces broken C++ code formatting workflow.

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,17 +1,14 @@
 name: clang-format Check
-
 on:
   workflow_call
-
 jobs:
   formatting-check:
-    name: C++ formatting check
+    name: C++ code formatting check
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
-    - uses: actions/checkout@v3
-    - name: Check C++ formatting
-      uses: jidicula/clang-format-action@v4.9.0
+    - uses: actions/checkout@v4
+    - uses: DoozyX/clang-format-lint-action@v0.20
       with:
-        clang-format-version: '14'
-        check-path: 'src'
+        source: 'src'
+        extensions: 'hpp,cpp'
+        clangFormatVersion: 14


### PR DESCRIPTION
This format checker is better maintained and nicer than the one we use. It actually shows you a diff between the improper and proper formatting. I use it in another project with folks who sometimes prefer to manually format.