### PR TITLE
Make n_so4_monolayers_pcage a parameter instead of hardcoded to 8.

### DIFF
--- a/src/mam4xx/aging.hpp
+++ b/src/mam4xx/aging.hpp
@@ -24,7 +24,7 @@ public:
     // Number of so4(+nh4) monolayers needed to "age" a carbon particle.
     // In E3SM this is read in from an input file and would be 8.
     // In mam_refactor it is defined in phys_control.F90 as 3.
-    Real n_so4_monolayers_pcage = 8.0;
+    unsigned n_so4_monolayers_pcage = 8;
   };
 
 private:
@@ -64,7 +64,7 @@ namespace aging {
 // change due to condenstion and coagulation
 KOKKOS_INLINE_FUNCTION
 void mam_pcarbon_aging_frac(
-    const Real n_so4_monolayers_pcage,
+    const unsigned n_so4_monolayers_pcage,
     const Real dgn_a[AeroConfig::num_modes()], // dry geometric mean diameter of
                                                // number distribution [m]
     const Real qaer_cur[AeroConfig::num_aerosol_ids()]
@@ -153,6 +153,7 @@ void mam_pcarbon_aging_frac(
   const Real xferfrac_tmp1 = vol_shell * dgn_a[imom_pc] * fac_volsfc;
 
   // use 1 mol (bi-)sulfate = 65 cm^3 --> 1 molecule = (4.76e-10 m)^3
+  // BAD CONSTANT, BAAAD CONSTANT
   const Real dr_so4_monolayers_pcage = n_so4_monolayers_pcage * 4.76e-10;
   const Real xferfrac_tmp2 =
       haero::max(6.0 * dr_so4_monolayers_pcage * vol_core, 0.0);
@@ -231,7 +232,7 @@ void transfer_cond_coag_mass_to_accum(
 
 KOKKOS_INLINE_FUNCTION
 void mam_pcarbon_aging_1subarea(
-    const Real n_so4_monolayers_pcage,
+    const unsigned n_so4_monolayers_pcage,
     const Real dgn_a[AeroConfig::num_modes()], // dry geometric mean diameter of
                                                // number distribution [m]
     Real qnum_cur[AeroConfig::num_modes()],    // aerosol number mixing ratio

--- a/src/mam4xx/mam4_amicphys.hpp
+++ b/src/mam4xx/mam4_amicphys.hpp
@@ -1129,7 +1129,7 @@ void mam_amicphys_1subarea(
     const int newnuc_h2so4_conc_optaa, const int gaexch_h2so4_uptake_optaa,
     const bool do_cond_sub, const bool do_rename_sub, const bool do_newnuc_sub,
     const bool do_coag_sub, const Real deltat, const int jsubarea,
-    const bool iscldy_subarea, const Real n_so4_monolayers_pcage,
+    const bool iscldy_subarea, const unsigned n_so4_monolayers_pcage,
     const Real afracsub, const Real temp, const Real pmid, const Real pdel,
     const Real zmid, const Real pblh, const Real relhumsub,
     const Real (&dgn_a)[num_modes], const Real (&dgn_awet)[num_modes],
@@ -1701,7 +1701,7 @@ void mam_amicphys_1gridcell(
     // in
     const AmicPhysConfig &config, const Real deltat, const int nsubarea,
     const int ncldy_subarea, const bool (&iscldy_subarea)[maxsubarea()],
-    const Real (&afracsub)[maxsubarea()], const Real n_so4_monolayers_pcage,
+    const Real (&afracsub)[maxsubarea()], const unsigned n_so4_monolayers_pcage,
     const Real temp, const Real pmid, const Real pdel, const Real zmid,
     const Real pblh, const Real (&relhumsub)[maxsubarea()],
     const Real (&dgn_a)[num_modes], const Real (&dgn_awet)[num_modes],
@@ -2121,7 +2121,7 @@ KOKKOS_INLINE_FUNCTION
 void modal_aero_amicphys_intr(
     // in
     const AmicPhysConfig &config, const Real deltat,
-    const Real n_so4_monolayers_pcage, const Real temp, const Real pmid,
+    const unsigned n_so4_monolayers_pcage, const Real temp, const Real pmid,
     const Real pdel, const Real zm, const Real pblh, const Real qv,
     const Real cld,
     // in/out

--- a/src/mam4xx/mo_gas_phase_chemdr.hpp
+++ b/src/mam4xx/mo_gas_phase_chemdr.hpp
@@ -154,7 +154,7 @@ struct LinozConf {
 KOKKOS_INLINE_FUNCTION
 void perform_atmospheric_chemistry_and_microphysics(
     const ThreadTeam &team, const Real dt, const Real rlats,
-    const Real n_so4_monolayers_pcage, const Real sfc_temp,
+    const unsigned n_so4_monolayers_pcage, const Real sfc_temp,
     const Real pressure_sfc, const Real wind_speed, const Real rain,
     const Real solar_flux, const View1D cnst_offline_icol[num_tracer_cnst],
     const Forcing *forcings_in, const haero::Atmosphere &atm,

--- a/src/tests/mam4_aging_unit_tests.cpp
+++ b/src/tests/mam4_aging_unit_tests.cpp
@@ -259,7 +259,7 @@ TEST_CASE("mam4_pcarbon_aging_1subarea", "mam4_aging_process") {
       qaer_del_coag_in[ispec][imode] = 0.0;
     }
   }
-  const Real n_so4_monolayers_pcage = 8;
+  const unsigned n_so4_monolayers_pcage = 8;
   aging::mam_pcarbon_aging_1subarea(
       n_so4_monolayers_pcage, dgn_a, qnum_cur, qnum_del_cond, qnum_del_coag,
       qaer_cur, qaer_del_cond, qaer_del_coag, qaer_del_coag_in);

--- a/src/validation/aging/mam_pcarbon_aging_1subarea.cpp
+++ b/src/validation/aging/mam_pcarbon_aging_1subarea.cpp
@@ -89,7 +89,7 @@ void mam_pcarbon_aging_1subarea(Ensemble *ensemble) {
         n += 1;
       }
     }
-    const Real n_so4_monolayers_pcage = 8;
+    const unsigned n_so4_monolayers_pcage = 8;
     aging::mam_pcarbon_aging_1subarea(
         n_so4_monolayers_pcage, dgn_a_f.data(), qnum_cur_f.data(),
         qnum_del_cond_f.data(), qnum_del_coag_f.data(), qaer_cur_c,

--- a/src/validation/aging/mam_pcarbon_aging_frac.cpp
+++ b/src/validation/aging/mam_pcarbon_aging_frac.cpp
@@ -67,7 +67,7 @@ void mam_pcarbon_aging_frac(Ensemble *ensemble) {
     Real xferfrac_pcage;
     Real frac_cond;
     Real frac_coag;
-    const Real n_so4_monolayers_pcage = 8;
+    const unsigned n_so4_monolayers_pcage = 8;
     aging::mam_pcarbon_aging_frac(
         n_so4_monolayers_pcage, dgn_a_f.data(), qaer_cur_c, qaer_del_cond_c,
         qaer_del_coag_in_c, xferfrac_pcage, frac_cond, frac_coag);


### PR DESCRIPTION
This PR should be merged and EAMxx modified to support the reading of n_so4_monolayers_pcage from an input file. BFB since the default is 8.

[BFB]