### PR TITLE
Use uniform include header guard macro names.

### DIFF
--- a/src/mam4xx/mam4_types.hpp
+++ b/src/mam4xx/mam4_types.hpp
@@ -3,8 +3,8 @@
 // National Technology & Engineering Solutions of Sandia, LLC (NTESS)
 // SPDX-License-Identifier: BSD-3-Clause
 
-#ifndef MAM4_TYPES_HPP
-#define MAM4_TYPES_HPP
+#ifndef MAM4XX_TYPES_HPP
+#define MAM4XX_TYPES_HPP
 
 #include <mam4xx/mam4_config.hpp>
 

--- a/src/tests/mam4_test_config.hpp.in
+++ b/src/tests/mam4_test_config.hpp.in
@@ -1,5 +1,5 @@
-#ifndef MAM4_TEST_CONFIG_HPP
-#define MAM4_TEST_CONFIG_HPP
+#ifndef MAM4XX_TEST_CONFIG_HPP
+#define MAM4XX_TEST_CONFIG_HPP
 
 // clang-format off
 #define MAM4_TEST_DATA_DIR "@CMAKE_CURRENT_SOURCE_DIR@/data"


### PR DESCRIPTION
Make MAM4XX_ the initial macro name characters for the #ifndef at the top of mam4xx header files. There were only a couple of header files that did not use this mam4xx standard.