### PR TITLE
Testing out new EKAT install in standalone mam4xx for Luca.

### DIFF
--- a/.github/workflows/at2_gcc-cuda.yml
+++ b/.github/workflows/at2_gcc-cuda.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           repository: E3SM-Project/EKAT
           submodules: recursive
+          ref: bartgol/fetch-content-fixes
           path: ${{ github.workspace }}/ekat_src
       - name: Show action trigger
         uses: ./.github/actions/show-workflow-trigger

--- a/.github/workflows/gh_gcc-cpu.yml
+++ b/.github/workflows/gh_gcc-cpu.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           repository: E3SM-Project/EKAT
           submodules: recursive
+          ref: bartgol/fetch-content-fixes
           path: ${{ github.workspace }}/ekat_src
 
       - name: Configuring MAM4xx (${{ matrix.build-type }}, ${{ matrix.fp-precision }} precision)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,8 @@ if (MAM4XX_STANDALONE)
   FetchContent_Declare(
     EKAT
     GIT_REPOSITORY https://github.com/E3SM-Project/EKAT.git
-    GIT_TAG        5617d52dc4ef9be171580bf95bcd8df335fdb8e6  # 2026/03/23
+    GIT_TAG        bartgol/fetch-content-fixes
+    #GIT_TAG        5617d52dc4ef9be171580bf95bcd8df335fdb8e6  # 2026/03/23
   )
   list(APPEND mam4xx_tpls EKAT)
 


### PR DESCRIPTION
EKAT is switching to use FetchContent for some of its dependencies. This PR is just a test of these changes to EKAT's installation procedures to make sure it still works for mam4xx. It won't be merged.