### PR TITLE
Removing single loops for photo table.

### DIFF
--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -18,6 +18,7 @@ constexpr int phtcnt = 1;
 
 using View5D = DeviceType::view_ND<Real, 5>;
 using View4D = DeviceType::view_ND<Real, 4>;
+using View3D = DeviceType::view_ND<Real, 3>;
 using View2D = DeviceType::view_2d<Real>;
 using View1D = DeviceType::view_1d<Real>;
 using ConstView1D = DeviceType::view_1d<const Real>;
@@ -101,9 +102,9 @@ inline PhotoTableData create_photo_table_data(int nw, int nt, int np_xs,
 struct PhotoTableWorkArrays {
   View2D lng_prates;
   View2D rsf;
-  View2D xswk;
-  View1D psum_l;
-  View1D psum_u;
+  View3D xswk;   // per-level scratch: (pver, numj, nw)
+  View2D psum_l; // per-level scratch: (pver, nw)
+  View2D psum_u; // per-level scratch: (pver, nw)
 
   View1D parg;
   View1D eff_alb;
@@ -112,10 +113,10 @@ struct PhotoTableWorkArrays {
   View1D work_cloud_mod;
 };
 inline int get_photo_table_work_len(const PhotoTableData &photo_table_data) {
-  return pver * photo_table_data.numj +                /*lng_prates*/
-         pver * photo_table_data.nw +                  /*rsf*/
-         photo_table_data.numj * photo_table_data.nw + /*xswk*/
-         2 * photo_table_data.nw /*psum_l + psum_u*/ +
+  return pver * photo_table_data.numj +                        /*lng_prates*/
+         pver * photo_table_data.nw +                          /*rsf*/
+         pver * photo_table_data.numj * photo_table_data.nw + /*xswk*/
+         2 * pver * photo_table_data.nw /*psum_l + psum_u*/ +
          8 * nlev /*parg + eff_alb + cld_mult + work_cloud_mod*/;
 } // get_photo_table_work_len
 KOKKOS_INLINE_FUNCTION
@@ -129,12 +130,12 @@ void set_photo_table_work_arrays(const PhotoTableData &photo_table_data,
   photo_table_work.rsf = View2D(work_ptr, photo_table_data.nw, pver);
   work_ptr += pver * photo_table_data.nw;
   photo_table_work.xswk =
-      View2D(work_ptr, photo_table_data.numj, photo_table_data.nw);
-  work_ptr += photo_table_data.numj * photo_table_data.nw;
-  photo_table_work.psum_l = View1D(work_ptr, photo_table_data.nw);
-  work_ptr += photo_table_data.nw;
-  photo_table_work.psum_u = View1D(work_ptr, photo_table_data.nw);
-  work_ptr += photo_table_data.nw;
+      View3D(work_ptr, pver, photo_table_data.numj, photo_table_data.nw);
+  work_ptr += pver * photo_table_data.numj * photo_table_data.nw;
+  photo_table_work.psum_l = View2D(work_ptr, pver, photo_table_data.nw);
+  work_ptr += pver * photo_table_data.nw;
+  photo_table_work.psum_u = View2D(work_ptr, pver, photo_table_data.nw);
+  work_ptr += pver * photo_table_data.nw;
   photo_table_work.parg = View1D(work_ptr, nlev);
   work_ptr += nlev;
   photo_table_work.eff_alb = View1D(work_ptr, nlev);
@@ -453,14 +454,16 @@ void calc_sum_wght(const Real dels[3], const Real wrk0, // in
                    const int ial,         // in
                    const View5D &rsf_tab, // in
                    const int nw,
-                   const View1D &psum) // out
+                   const View2D &psum, // out
+                   const int kk)
 {
 
   // @param[in]   dels(3)
   // @param[in]   wrk0
   // @param[in]  iz, is, iv, ial
   // @param[in]   nw// wavelengths >200nm
-  // @param[in/out] psum(:)
+  // @param[in]   kk     level index
+  // @param[out]  psum(:,:)  per-level work array; row kk is written
   const int isp1 = is + 1;
   const int ivp1 = iv + 1;
   const int ialp1 = ial + 1;
@@ -481,7 +484,7 @@ void calc_sum_wght(const Real dels[3], const Real wrk0, // in
 
   for (int wn = 0; wn < nw; wn++) {
 
-    psum[wn] = wght_0_0_0 * rsf_tab(wn, iz, is, iv, ial) +
+    psum(kk, wn) = wght_0_0_0 * rsf_tab(wn, iz, is, iv, ial) +
                wght_0_0_1 * rsf_tab(wn, iz, is, iv, ialp1) +
                wght_0_1_0 * rsf_tab(wn, iz, is, ivp1, ial) +
                wght_0_1_1 * rsf_tab(wn, iz, is, ivp1, ialp1) +
@@ -506,8 +509,8 @@ void interpolate_rsf(const ThreadTeam &team, const View1D &alb_in,
                      const int nw, const int nump, const int numsza,
                      const int numcolo3, const int numalb,
                      const View2D &rsf, // out
-                     // work array
-                     const View1D &psum_l, const View1D &psum_u) {
+                     // per-level work arrays (indexed by level kk)
+                     const View2D &psum_l, const View2D &psum_u) {
   /*----------------------------------------------------------------------
           ... interpolate table rsf to model variables
   ----------------------------------------------------------------------*/
@@ -541,111 +544,106 @@ void interpolate_rsf(const ThreadTeam &team, const View1D &alb_in,
   const Real one = 1;
   const Real zero = 0;
 
-  // NOTE: psum_l and psum_u are not dimensioned by the number of levels, kk, so
-  // they cannot be parallelized over kk
-  Kokkos::single(Kokkos::PerTeam(team), [=]() {
+  // Each level's computation is independent. is, dels[0], and wrk0 are
+  // level-invariant and computed redundantly per thread (same result, race-free).
+  // The izl warm-start is removed; each thread starts the pressure search from
+  // iz=1, yielding the identical pind since press is monotone.
+  Kokkos::parallel_for(
+      Kokkos::TeamVectorRange(team, kbot), [&](const int kk) {
     int is = 0;
-    find_index(sza, numsza, sza_in, // in
-               is);                 // ! out
+    find_index(sza, numsza, sza_in, is);
 
     Real dels[3] = {};
     dels[0] = utils::min_max_bound(zero, one, (sza_in - sza[is]) * del_sza[is]);
     const Real wrk0 = one - dels[0];
-    int izl = 2; //   may change in the level_loop
-    for (int kk = kbot - 1; kk > -1; kk--) {
-      /*----------------------------------------------------------------------
-         ... find albedo indicies
-       ----------------------------------------------------------------------*/
-      int albind = 0;
-      find_index(alb, numalb, alb_in[kk], //  & ! in
-                 albind);                 // ! out
-      /*----------------------------------------------------------------------
-           ... find pressure level indicies
-      ----------------------------------------------------------------------*/
-      int pind = 0;
-      Real wght1 = 0;
-      if (p_in[kk] > press[0]) {
-        pind = 1;
-        wght1 = one;
 
-        // Fortran to C++ indexing
-      } else if (p_in[kk] <= press[nump - 1]) {
-        // Fortran to C++ indexing
-        pind = nump - 1;
-        wght1 = zero;
-      } else {
-        int iz = 0;
-        // Fortran to C++ indexing
-        for (iz = izl - 1; iz < nump; iz++) {
-          if (press[iz] < p_in[kk]) {
-            izl = iz;
-            break;
-          } // end if
-        }   // end for iz
-        // Fortran to C++ indexing
-        pind = mam4::max(mam4::min(iz, nump - 1), 1);
-        wght1 = utils::min_max_bound(
-            zero, one, (p_in[kk] - press[pind]) * del_p[pind - 1]);
-      } // end if
+    /*----------------------------------------------------------------------
+       ... find albedo indicies
+     ----------------------------------------------------------------------*/
+    int albind = 0;
+    find_index(alb, numalb, alb_in[kk], albind);
+    /*----------------------------------------------------------------------
+         ... find pressure level indicies
+    ----------------------------------------------------------------------*/
+    int pind = 0;
+    Real wght1 = 0;
+    if (p_in[kk] > press[0]) {
+      pind = 1;
+      wght1 = one;
+      // Fortran to C++ indexing
+    } else if (p_in[kk] <= press[nump - 1]) {
+      // Fortran to C++ indexing
+      pind = nump - 1;
+      wght1 = zero;
+    } else {
+      int iz = 0;
+      // Fortran to C++ indexing; start from iz=1 (equivalent to izl-1 with
+      // initial izl=2; BFB with original since press is monotone)
+      for (iz = 1; iz < nump; iz++) {
+        if (press[iz] < p_in[kk]) {
+          break;
+        } // end if
+      }   // end for iz
+      // Fortran to C++ indexing
+      iz = iz < nump - 1 ? iz : nump - 1;
+      pind = iz > 1 ? iz : 1;
+      wght1 = utils::min_max_bound(
+          zero, one, (p_in[kk] - press[pind]) * del_p[pind - 1]);
+    } // end if
 
-      /*----------------------------------------------------------------------
-           ... find "o3 ratios"
-      ----------------------------------------------------------------------*/
+    /*----------------------------------------------------------------------
+         ... find "o3 ratios"
+    ----------------------------------------------------------------------*/
 
-      const Real v3ratu = colo3_in[kk] / colo3[pind - 1];
-      int ratindu = 0;
-      find_index(o3rat, numcolo3, v3ratu, //  in
-                 ratindu);                // out
+    const Real v3ratu = colo3_in[kk] / colo3[pind - 1];
+    int ratindu = 0;
+    find_index(o3rat, numcolo3, v3ratu, ratindu);
 
-      Real v3ratl = zero;
-      int ratindl = 0;
-      if (colo3[pind] != zero) {
-        v3ratl = colo3_in[kk] / colo3[pind];
-        find_index(o3rat, numcolo3, v3ratl, // in
-                   ratindl);                // ! out
-      } else {
-        ratindl = ratindu;
-        v3ratl = o3rat[ratindu];
-      } // end if colo3[pind] != zero
+    Real v3ratl = zero;
+    int ratindl = 0;
+    if (colo3[pind] != zero) {
+      v3ratl = colo3_in[kk] / colo3[pind];
+      find_index(o3rat, numcolo3, v3ratl, ratindl);
+    } else {
+      ratindl = ratindu;
+      v3ratl = o3rat[ratindu];
+    } // end if colo3[pind] != zero
 
-      /*----------------------------------------------------------------------
-              ... compute the weigths
-      ----------------------------------------------------------------------*/
+    /*----------------------------------------------------------------------
+            ... compute the weigths
+    ----------------------------------------------------------------------*/
 
-      int ial = albind;
+    int ial = albind;
 
-      dels[2] = utils::min_max_bound(zero, one,
-                                     (alb_in[kk] - alb[ial]) * del_alb[ial]);
+    dels[2] = utils::min_max_bound(zero, one,
+                                   (alb_in[kk] - alb[ial]) * del_alb[ial]);
 
-      int iv = ratindl;
-      dels[1] =
-          utils::min_max_bound(zero, one, (v3ratl - o3rat[iv]) * del_o3rat[iv]);
-      calc_sum_wght(dels, wrk0,        // in
-                    pind, is, iv, ial, // in
-                    rsf_tab, nw,
-                    psum_l); // out
+    int iv = ratindl;
+    dels[1] =
+        utils::min_max_bound(zero, one, (v3ratl - o3rat[iv]) * del_o3rat[iv]);
+    calc_sum_wght(dels, wrk0,        // in
+                  pind, is, iv, ial, // in
+                  rsf_tab, nw,
+                  psum_l, kk); // out
 
-      iv = ratindu;
-      dels[1] =
-          utils::min_max_bound(zero, one, (v3ratu - o3rat[iv]) * del_o3rat[iv]);
-      calc_sum_wght(dels, wrk0,            // in
-                    pind - 1, is, iv, ial, // in
-                    rsf_tab, nw,
-                    psum_u); //  inout
+    iv = ratindu;
+    dels[1] =
+        utils::min_max_bound(zero, one, (v3ratu - o3rat[iv]) * del_o3rat[iv]);
+    calc_sum_wght(dels, wrk0,            // in
+                  pind - 1, is, iv, ial, // in
+                  rsf_tab, nw,
+                  psum_u, kk); //  inout
 
-      for (int wn = 0; wn < nw; wn++)
-        rsf(wn, kk) = psum_l[wn] + wght1 * (psum_u[wn] - psum_l[wn]);
-
-      /*------------------------------------------------------------------------------
-          etfphot comes in as photons/cm^2/sec/nm  (rsf includes the wlintv
-       factor
-       -- nm)
-         ... --> convert to photons/cm^2/s
-       ------------------------------------------------------------------------------*/
-      for (int wn = 0; wn < nw; wn++)
-        rsf(wn, kk) *= etfphot[wn];
-    } // loop over kk
-  }); // Kokkos::single
+    /*------------------------------------------------------------------------------
+        etfphot comes in as photons/cm^2/sec/nm  (rsf includes the wlintv
+     factor
+     -- nm)
+       ... --> convert to photons/cm^2/s
+     ------------------------------------------------------------------------------*/
+    for (int wn = 0; wn < nw; wn++)
+      rsf(wn, kk) = (psum_l(kk, wn) + wght1 * (psum_u(kk, wn) - psum_l(kk, wn)))
+                    * etfphot[wn];
+  }); // TeamVectorRange over kbot levels
 } // interpolate_rsf
 //======================================================================================
 KOKKOS_INLINE_FUNCTION
@@ -661,8 +659,8 @@ void jlong(const ThreadTeam &team, const Real sza_in, const View1D &alb_in,
            const int numj,
            const View2D &j_long, // output
            // work arrays
-           const View2D &rsf, const View2D &xswk, const View1D &psum_l,
-           const View1D &psum_u)
+           const View2D &rsf, const View3D &xswk, const View2D &psum_l,
+           const View2D &psum_u)
 // out
 {
 
@@ -734,69 +732,67 @@ void jlong(const ThreadTeam &team, const Real sza_in, const View1D &alb_in,
   ------------------------------------------------------------------------------*/
   // To avoid the 'pver is undefined' error during CUDA code compilation.
   constexpr int pver_local = pver;
-  // xswk is not dimentioned by number of levels so can not parallelize over
-  // levels.
-  Kokkos::single(Kokkos::PerTeam(team), [=]() {
-    for (int kk = 0; kk < pver_local; ++kk) {
-      /*----------------------------------------------------------------------
-        ... get index into xsqy
-       ----------------------------------------------------------------------*/
+  // Each level is processed independently; xswk is now per-level (View3D).
+  Kokkos::parallel_for(
+      Kokkos::TeamVectorRange(team, pver_local), [&](const int kk) {
+    /*----------------------------------------------------------------------
+      ... get index into xsqy
+     ----------------------------------------------------------------------*/
 
-      // Fortran indexing to C++ indexing
-      // number of temperatures in xsection table
-      // BAD CONSTANT for 201 and 148.5
-      const int t_index = mam4::min(201, mam4::max(t_in[kk] - 148.5, 1)) - 1;
+    // Fortran indexing to C++ indexing
+    // number of temperatures in xsection table
+    // BAD CONSTANT for 201 and 148.5
+    const int t_index = mam4::min(201, mam4::max(t_in[kk] - 148.5, 1)) - 1;
 
-      /*----------------------------------------------------------------------
-                 ... find pressure level
-       ----------------------------------------------------------------------*/
-      const Real ptarget = p_in[kk];
-      if (ptarget >= prs[0]) {
-        for (int wn = 0; wn < nw; wn++) {
-          for (int i = 0; i < numj; i++) {
-            xswk(i, wn) = xsqy(i, wn, t_index, 0);
-          } // end for i
-        }   // end for wn
-        // Fortran to C++ indexing conversion
-      } else if (ptarget <= prs[np_xs - 1]) {
-        for (int wn = 0; wn < nw; wn++) {
-          for (int i = 0; i < numj; i++) {
-            // Fortran to C++ indexing conversion
-            xswk(i, wn) = xsqy(i, wn, t_index, np_xs - 1);
-          } // end for i
-        }   // end for wn
+    /*----------------------------------------------------------------------
+               ... find pressure level
+     ----------------------------------------------------------------------*/
+    const Real ptarget = p_in[kk];
+    if (ptarget >= prs[0]) {
+      for (int wn = 0; wn < nw; wn++) {
+        for (int i = 0; i < numj; i++) {
+          xswk(kk, i, wn) = xsqy(i, wn, t_index, 0);
+        } // end for i
+      }   // end for wn
+      // Fortran to C++ indexing conversion
+    } else if (ptarget <= prs[np_xs - 1]) {
+      for (int wn = 0; wn < nw; wn++) {
+        for (int i = 0; i < numj; i++) {
+          // Fortran to C++ indexing conversion
+          xswk(kk, i, wn) = xsqy(i, wn, t_index, np_xs - 1);
+        } // end for i
+      }   // end for wn
 
-      } else {
-        Real delp = zero;
-        int pndx = 0;
-        // Question: delp is not initialized in fortran code. What if the
-        // following code does not satify this if condition: ptarget >=
-        // prs[km] Conversion indexing from Fortran to C++
-        for (int km = 1; km < np_xs; km++) {
-          if (ptarget >= prs[km]) {
-            pndx = km - 1;
-            delp = (prs[pndx] - ptarget) * dprs[pndx];
-            break;
-          } // end if
-        }   // end for km
-        for (int wn = 0; wn < nw; wn++) {
-          for (int i = 0; i < numj; i++) {
-            xswk(i, wn) = xsqy(i, wn, t_index, pndx) +
-                          delp * (xsqy(i, wn, t_index, pndx + 1) -
-                                  xsqy(i, wn, t_index, pndx));
+    } else {
+      Real delp = zero;
+      int pndx = 0;
+      // Question: delp is not initialized in fortran code. What if the
+      // following code does not satify this if condition: ptarget >=
+      // prs[km] Conversion indexing from Fortran to C++
+      for (int km = 1; km < np_xs; km++) {
+        if (ptarget >= prs[km]) {
+          pndx = km - 1;
+          delp = (prs[pndx] - ptarget) * dprs[pndx];
+          break;
+        } // end if
+      }   // end for km
+      for (int wn = 0; wn < nw; wn++) {
+        for (int i = 0; i < numj; i++) {
+          xswk(kk, i, wn) = xsqy(i, wn, t_index, pndx) +
+                        delp * (xsqy(i, wn, t_index, pndx + 1) -
+                                xsqy(i, wn, t_index, pndx));
 
-          } // end for i
-        }   // end for wn
-      }     // end if
-      for (int i = 0; i < numj; ++i) {
-        Real suma = zero;
-        for (int wn = 0; wn < nw; wn++) {
-          suma += xswk(i, wn) * rsf(wn, kk);
-        }
-        j_long(i, kk) = suma;
-      } // i
-    };  // end kk
-  });   // end single
+        } // end for i
+      }   // end for wn
+    }     // end if
+    for (int i = 0; i < numj; ++i) {
+      Real suma = zero;
+      for (int wn = 0; wn < nw; wn++) {
+        suma += xswk(kk, i, wn) * rsf(wn, kk);
+      }
+      j_long(i, kk) = suma;
+    } // i
+  }); // end TeamVectorRange
 } // jlong
 
 // FIXME: note the use of ConstColumnView for views we get from the

--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -4,6 +4,7 @@
 #include "mam4_math.hpp"
 #include "mam4_types.hpp"
 #include "utils.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace mam4 {
 
@@ -454,8 +455,8 @@ void calc_sum_wght(const Real dels[3], const Real wrk0, // in
                    const int ial,         // in
                    const View5D &rsf_tab, // in
                    const int nw,
-                   const View2D &psum, // out
-                   const int kk) {
+                   const View1D &psum // out
+) {
 
   // @param[in]   dels(3)
   // @param[in]   wrk0
@@ -483,14 +484,14 @@ void calc_sum_wght(const Real dels[3], const Real wrk0, // in
 
   for (int wn = 0; wn < nw; wn++) {
 
-    psum(kk, wn) = wght_0_0_0 * rsf_tab(wn, iz, is, iv, ial) +
-                   wght_0_0_1 * rsf_tab(wn, iz, is, iv, ialp1) +
-                   wght_0_1_0 * rsf_tab(wn, iz, is, ivp1, ial) +
-                   wght_0_1_1 * rsf_tab(wn, iz, is, ivp1, ialp1) +
-                   wght_1_0_0 * rsf_tab(wn, iz, isp1, iv, ial) +
-                   wght_1_0_1 * rsf_tab(wn, iz, isp1, iv, ialp1) +
-                   wght_1_1_0 * rsf_tab(wn, iz, isp1, ivp1, ial) +
-                   wght_1_1_1 * rsf_tab(wn, iz, isp1, ivp1, ialp1);
+    psum(wn) = wght_0_0_0 * rsf_tab(wn, iz, is, iv, ial) +
+               wght_0_0_1 * rsf_tab(wn, iz, is, iv, ialp1) +
+               wght_0_1_0 * rsf_tab(wn, iz, is, ivp1, ial) +
+               wght_0_1_1 * rsf_tab(wn, iz, is, ivp1, ialp1) +
+               wght_1_0_0 * rsf_tab(wn, iz, isp1, iv, ial) +
+               wght_1_0_1 * rsf_tab(wn, iz, isp1, iv, ialp1) +
+               wght_1_1_0 * rsf_tab(wn, iz, isp1, ivp1, ial) +
+               wght_1_1_1 * rsf_tab(wn, iz, isp1, ivp1, ialp1);
   } // end wn
 } // calc_sum_wght
 
@@ -619,16 +620,16 @@ void interpolate_rsf(const ThreadTeam &team, const View1D &alb_in,
     int iv = ratindl;
     dels[1] =
         utils::min_max_bound(zero, one, (v3ratl - o3rat[iv]) * del_o3rat[iv]);
-    calc_sum_wght(dels, wrk0,               // in
-                  pind, is, iv, ial,        // in
-                  rsf_tab, nw, psum_l, kk); // out
+    calc_sum_wght(dels, wrk0,                              // in
+                  pind, is, iv, ial,                       // in
+                  rsf_tab, nw, ekat::subview(psum_l, kk)); // out
 
     iv = ratindu;
     dels[1] =
         utils::min_max_bound(zero, one, (v3ratu - o3rat[iv]) * del_o3rat[iv]);
-    calc_sum_wght(dels, wrk0,               // in
-                  pind - 1, is, iv, ial,    // in
-                  rsf_tab, nw, psum_u, kk); //  inout
+    calc_sum_wght(dels, wrk0,                              // in
+                  pind - 1, is, iv, ial,                   // in
+                  rsf_tab, nw, ekat::subview(psum_u, kk)); //  inout
 
     /*------------------------------------------------------------------------------
         etfphot comes in as photons/cm^2/sec/nm  (rsf includes the wlintv

--- a/src/mam4xx/mo_photo.hpp
+++ b/src/mam4xx/mo_photo.hpp
@@ -113,8 +113,8 @@ struct PhotoTableWorkArrays {
   View1D work_cloud_mod;
 };
 inline int get_photo_table_work_len(const PhotoTableData &photo_table_data) {
-  return pver * photo_table_data.numj +                        /*lng_prates*/
-         pver * photo_table_data.nw +                          /*rsf*/
+  return pver * photo_table_data.numj +                       /*lng_prates*/
+         pver * photo_table_data.nw +                         /*rsf*/
          pver * photo_table_data.numj * photo_table_data.nw + /*xswk*/
          2 * pver * photo_table_data.nw /*psum_l + psum_u*/ +
          8 * nlev /*parg + eff_alb + cld_mult + work_cloud_mod*/;
@@ -455,8 +455,7 @@ void calc_sum_wght(const Real dels[3], const Real wrk0, // in
                    const View5D &rsf_tab, // in
                    const int nw,
                    const View2D &psum, // out
-                   const int kk)
-{
+                   const int kk) {
 
   // @param[in]   dels(3)
   // @param[in]   wrk0
@@ -485,13 +484,13 @@ void calc_sum_wght(const Real dels[3], const Real wrk0, // in
   for (int wn = 0; wn < nw; wn++) {
 
     psum(kk, wn) = wght_0_0_0 * rsf_tab(wn, iz, is, iv, ial) +
-               wght_0_0_1 * rsf_tab(wn, iz, is, iv, ialp1) +
-               wght_0_1_0 * rsf_tab(wn, iz, is, ivp1, ial) +
-               wght_0_1_1 * rsf_tab(wn, iz, is, ivp1, ialp1) +
-               wght_1_0_0 * rsf_tab(wn, iz, isp1, iv, ial) +
-               wght_1_0_1 * rsf_tab(wn, iz, isp1, iv, ialp1) +
-               wght_1_1_0 * rsf_tab(wn, iz, isp1, ivp1, ial) +
-               wght_1_1_1 * rsf_tab(wn, iz, isp1, ivp1, ialp1);
+                   wght_0_0_1 * rsf_tab(wn, iz, is, iv, ialp1) +
+                   wght_0_1_0 * rsf_tab(wn, iz, is, ivp1, ial) +
+                   wght_0_1_1 * rsf_tab(wn, iz, is, ivp1, ialp1) +
+                   wght_1_0_0 * rsf_tab(wn, iz, isp1, iv, ial) +
+                   wght_1_0_1 * rsf_tab(wn, iz, isp1, iv, ialp1) +
+                   wght_1_1_0 * rsf_tab(wn, iz, isp1, ivp1, ial) +
+                   wght_1_1_1 * rsf_tab(wn, iz, isp1, ivp1, ialp1);
   } // end wn
 } // calc_sum_wght
 
@@ -545,11 +544,10 @@ void interpolate_rsf(const ThreadTeam &team, const View1D &alb_in,
   const Real zero = 0;
 
   // Each level's computation is independent. is, dels[0], and wrk0 are
-  // level-invariant and computed redundantly per thread (same result, race-free).
-  // The izl warm-start is removed; each thread starts the pressure search from
-  // iz=1, yielding the identical pind since press is monotone.
-  Kokkos::parallel_for(
-      Kokkos::TeamVectorRange(team, kbot), [&](const int kk) {
+  // level-invariant and computed redundantly per thread (same result,
+  // race-free). The izl warm-start is removed; each thread starts the pressure
+  // search from iz=1, yielding the identical pind since press is monotone.
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, kbot), [&](const int kk) {
     int is = 0;
     find_index(sza, numsza, sza_in, is);
 
@@ -587,8 +585,8 @@ void interpolate_rsf(const ThreadTeam &team, const View1D &alb_in,
       // Fortran to C++ indexing
       iz = iz < nump - 1 ? iz : nump - 1;
       pind = iz > 1 ? iz : 1;
-      wght1 = utils::min_max_bound(
-          zero, one, (p_in[kk] - press[pind]) * del_p[pind - 1]);
+      wght1 = utils::min_max_bound(zero, one,
+                                   (p_in[kk] - press[pind]) * del_p[pind - 1]);
     } // end if
 
     /*----------------------------------------------------------------------
@@ -615,24 +613,22 @@ void interpolate_rsf(const ThreadTeam &team, const View1D &alb_in,
 
     int ial = albind;
 
-    dels[2] = utils::min_max_bound(zero, one,
-                                   (alb_in[kk] - alb[ial]) * del_alb[ial]);
+    dels[2] =
+        utils::min_max_bound(zero, one, (alb_in[kk] - alb[ial]) * del_alb[ial]);
 
     int iv = ratindl;
     dels[1] =
         utils::min_max_bound(zero, one, (v3ratl - o3rat[iv]) * del_o3rat[iv]);
-    calc_sum_wght(dels, wrk0,        // in
-                  pind, is, iv, ial, // in
-                  rsf_tab, nw,
-                  psum_l, kk); // out
+    calc_sum_wght(dels, wrk0,               // in
+                  pind, is, iv, ial,        // in
+                  rsf_tab, nw, psum_l, kk); // out
 
     iv = ratindu;
     dels[1] =
         utils::min_max_bound(zero, one, (v3ratu - o3rat[iv]) * del_o3rat[iv]);
-    calc_sum_wght(dels, wrk0,            // in
-                  pind - 1, is, iv, ial, // in
-                  rsf_tab, nw,
-                  psum_u, kk); //  inout
+    calc_sum_wght(dels, wrk0,               // in
+                  pind - 1, is, iv, ial,    // in
+                  rsf_tab, nw, psum_u, kk); //  inout
 
     /*------------------------------------------------------------------------------
         etfphot comes in as photons/cm^2/sec/nm  (rsf includes the wlintv
@@ -641,8 +637,9 @@ void interpolate_rsf(const ThreadTeam &team, const View1D &alb_in,
        ... --> convert to photons/cm^2/s
      ------------------------------------------------------------------------------*/
     for (int wn = 0; wn < nw; wn++)
-      rsf(wn, kk) = (psum_l(kk, wn) + wght1 * (psum_u(kk, wn) - psum_l(kk, wn)))
-                    * etfphot[wn];
+      rsf(wn, kk) =
+          (psum_l(kk, wn) + wght1 * (psum_u(kk, wn) - psum_l(kk, wn))) *
+          etfphot[wn];
   }); // TeamVectorRange over kbot levels
 } // interpolate_rsf
 //======================================================================================
@@ -735,64 +732,64 @@ void jlong(const ThreadTeam &team, const Real sza_in, const View1D &alb_in,
   // Each level is processed independently; xswk is now per-level (View3D).
   Kokkos::parallel_for(
       Kokkos::TeamVectorRange(team, pver_local), [&](const int kk) {
-    /*----------------------------------------------------------------------
-      ... get index into xsqy
-     ----------------------------------------------------------------------*/
+        /*----------------------------------------------------------------------
+          ... get index into xsqy
+         ----------------------------------------------------------------------*/
 
-    // Fortran indexing to C++ indexing
-    // number of temperatures in xsection table
-    // BAD CONSTANT for 201 and 148.5
-    const int t_index = mam4::min(201, mam4::max(t_in[kk] - 148.5, 1)) - 1;
+        // Fortran indexing to C++ indexing
+        // number of temperatures in xsection table
+        // BAD CONSTANT for 201 and 148.5
+        const int t_index = mam4::min(201, mam4::max(t_in[kk] - 148.5, 1)) - 1;
 
-    /*----------------------------------------------------------------------
-               ... find pressure level
-     ----------------------------------------------------------------------*/
-    const Real ptarget = p_in[kk];
-    if (ptarget >= prs[0]) {
-      for (int wn = 0; wn < nw; wn++) {
-        for (int i = 0; i < numj; i++) {
-          xswk(kk, i, wn) = xsqy(i, wn, t_index, 0);
-        } // end for i
-      }   // end for wn
-      // Fortran to C++ indexing conversion
-    } else if (ptarget <= prs[np_xs - 1]) {
-      for (int wn = 0; wn < nw; wn++) {
-        for (int i = 0; i < numj; i++) {
+        /*----------------------------------------------------------------------
+                   ... find pressure level
+         ----------------------------------------------------------------------*/
+        const Real ptarget = p_in[kk];
+        if (ptarget >= prs[0]) {
+          for (int wn = 0; wn < nw; wn++) {
+            for (int i = 0; i < numj; i++) {
+              xswk(kk, i, wn) = xsqy(i, wn, t_index, 0);
+            } // end for i
+          }   // end for wn
           // Fortran to C++ indexing conversion
-          xswk(kk, i, wn) = xsqy(i, wn, t_index, np_xs - 1);
-        } // end for i
-      }   // end for wn
+        } else if (ptarget <= prs[np_xs - 1]) {
+          for (int wn = 0; wn < nw; wn++) {
+            for (int i = 0; i < numj; i++) {
+              // Fortran to C++ indexing conversion
+              xswk(kk, i, wn) = xsqy(i, wn, t_index, np_xs - 1);
+            } // end for i
+          }   // end for wn
 
-    } else {
-      Real delp = zero;
-      int pndx = 0;
-      // Question: delp is not initialized in fortran code. What if the
-      // following code does not satify this if condition: ptarget >=
-      // prs[km] Conversion indexing from Fortran to C++
-      for (int km = 1; km < np_xs; km++) {
-        if (ptarget >= prs[km]) {
-          pndx = km - 1;
-          delp = (prs[pndx] - ptarget) * dprs[pndx];
-          break;
-        } // end if
-      }   // end for km
-      for (int wn = 0; wn < nw; wn++) {
-        for (int i = 0; i < numj; i++) {
-          xswk(kk, i, wn) = xsqy(i, wn, t_index, pndx) +
-                        delp * (xsqy(i, wn, t_index, pndx + 1) -
-                                xsqy(i, wn, t_index, pndx));
+        } else {
+          Real delp = zero;
+          int pndx = 0;
+          // Question: delp is not initialized in fortran code. What if the
+          // following code does not satify this if condition: ptarget >=
+          // prs[km] Conversion indexing from Fortran to C++
+          for (int km = 1; km < np_xs; km++) {
+            if (ptarget >= prs[km]) {
+              pndx = km - 1;
+              delp = (prs[pndx] - ptarget) * dprs[pndx];
+              break;
+            } // end if
+          }   // end for km
+          for (int wn = 0; wn < nw; wn++) {
+            for (int i = 0; i < numj; i++) {
+              xswk(kk, i, wn) = xsqy(i, wn, t_index, pndx) +
+                                delp * (xsqy(i, wn, t_index, pndx + 1) -
+                                        xsqy(i, wn, t_index, pndx));
 
-        } // end for i
-      }   // end for wn
-    }     // end if
-    for (int i = 0; i < numj; ++i) {
-      Real suma = zero;
-      for (int wn = 0; wn < nw; wn++) {
-        suma += xswk(kk, i, wn) * rsf(wn, kk);
-      }
-      j_long(i, kk) = suma;
-    } // i
-  }); // end TeamVectorRange
+            } // end for i
+          }   // end for wn
+        }     // end if
+        for (int i = 0; i < numj; ++i) {
+          Real suma = zero;
+          for (int wn = 0; wn < nw; wn++) {
+            suma += xswk(kk, i, wn) * rsf(wn, kk);
+          }
+          j_long(i, kk) = suma;
+        } // i
+      }); // end TeamVectorRange
 } // jlong
 
 // FIXME: note the use of ConstColumnView for views we get from the

--- a/src/tests/mam4_photo_setcol.cpp
+++ b/src/tests/mam4_photo_setcol.cpp
@@ -112,7 +112,8 @@ TEST_CASE("compute_o3_column_density", "mo_photo") {
 
   for (int k = 0; k < pver; ++k) {
     const Real raw_diff = o3_col_dens_host(k) - o3_col_dens_ref(k);
-    const Real diff = (raw_diff > 0 ? raw_diff : -raw_diff) / o3_col_dens_ref(k);
+    const Real diff =
+        (raw_diff > 0 ? raw_diff : -raw_diff) / o3_col_dens_ref(k);
     if (diff >= tol) {
       std::ostringstream ss;
       ss << "diff : [ ";
@@ -133,30 +134,32 @@ TEST_CASE("compute_o3_column_density", "mo_photo") {
 // using namespace mam4;
 
 // Table dimensions — compile-time constants required inside device lambdas.
-constexpr int test_nw       = 4;
-constexpr int test_numj     = 1;
-constexpr int test_nump     = 5;
-constexpr int test_numsza   = 3;
+constexpr int test_nw = 4;
+constexpr int test_numj = 1;
+constexpr int test_nump = 5;
+constexpr int test_numsza = 3;
 constexpr int test_numcolo3 = 4;
-constexpr int test_numalb   = 3;
-constexpr int test_nt       = 201;
-constexpr int test_np_xs    = 4;
-constexpr Real test_sza_in  = 30.0; // degrees, well within daylight range
+constexpr int test_numalb = 3;
+constexpr int test_nt = 201;
+constexpr int test_np_xs = 4;
+constexpr Real test_sza_in = 30.0; // degrees, well within daylight range
 
 // Build a small PhotoTableData with synthetic monotone lookup arrays.
 static mam4::mo_photo::PhotoTableData build_test_photo_table() {
   using HostView1D = Kokkos::View<Real *, Kokkos::HostSpace>;
 
   auto photo_table = mam4::mo_photo::create_photo_table_data(
-      test_nw, test_nt, test_np_xs, test_numj,
-      test_nump, test_numsza, test_numcolo3, test_numalb);
+      test_nw, test_nt, test_np_xs, test_numj, test_nump, test_numsza,
+      test_numcolo3, test_numalb);
 
   std::default_random_engine gen(54321);
   std::uniform_real_distribution<Real> pos(1e-6, 1.0);
 
   // sza [degrees]: monotone increasing
   auto sza_h = Kokkos::create_mirror_view(photo_table.sza);
-  sza_h(0) = 0.0; sza_h(1) = 45.0; sza_h(2) = 88.0;
+  sza_h(0) = 0.0;
+  sza_h(1) = 45.0;
+  sza_h(2) = 88.0;
   Kokkos::deep_copy(photo_table.sza, sza_h);
 
   auto del_sza_h = Kokkos::create_mirror_view(photo_table.del_sza);
@@ -166,7 +169,9 @@ static mam4::mo_photo::PhotoTableData build_test_photo_table() {
 
   // alb: monotone increasing
   auto alb_h = Kokkos::create_mirror_view(photo_table.alb);
-  alb_h(0) = 0.0; alb_h(1) = 0.3; alb_h(2) = 0.8;
+  alb_h(0) = 0.0;
+  alb_h(1) = 0.3;
+  alb_h(2) = 0.8;
   Kokkos::deep_copy(photo_table.alb, alb_h);
 
   auto del_alb_h = Kokkos::create_mirror_view(photo_table.del_alb);
@@ -176,8 +181,11 @@ static mam4::mo_photo::PhotoTableData build_test_photo_table() {
 
   // press [hPa]: monotone decreasing (surface first)
   auto press_h = Kokkos::create_mirror_view(photo_table.press);
-  press_h(0) = 1000.0; press_h(1) = 500.0; press_h(2) = 100.0;
-  press_h(3) =   50.0; press_h(4) =  10.0;
+  press_h(0) = 1000.0;
+  press_h(1) = 500.0;
+  press_h(2) = 100.0;
+  press_h(3) = 50.0;
+  press_h(4) = 10.0;
   Kokkos::deep_copy(photo_table.press, press_h);
 
   auto del_p_h = Kokkos::create_mirror_view(photo_table.del_p);
@@ -187,13 +195,19 @@ static mam4::mo_photo::PhotoTableData build_test_photo_table() {
 
   // colo3: decreasing with altitude
   auto colo3_h = Kokkos::create_mirror_view(photo_table.colo3);
-  colo3_h(0) = 5e17; colo3_h(1) = 4e17; colo3_h(2) = 3e17;
-  colo3_h(3) = 2e17; colo3_h(4) = 1e17;
+  colo3_h(0) = 5e17;
+  colo3_h(1) = 4e17;
+  colo3_h(2) = 3e17;
+  colo3_h(3) = 2e17;
+  colo3_h(4) = 1e17;
   Kokkos::deep_copy(photo_table.colo3, colo3_h);
 
   // o3rat: monotone increasing
   auto o3rat_h = Kokkos::create_mirror_view(photo_table.o3rat);
-  o3rat_h(0) = 0.5; o3rat_h(1) = 1.0; o3rat_h(2) = 1.5; o3rat_h(3) = 2.0;
+  o3rat_h(0) = 0.5;
+  o3rat_h(1) = 1.0;
+  o3rat_h(2) = 1.5;
+  o3rat_h(3) = 2.0;
   Kokkos::deep_copy(photo_table.o3rat, o3rat_h);
 
   auto del_o3rat_h = Kokkos::create_mirror_view(photo_table.del_o3rat);
@@ -209,17 +223,20 @@ static mam4::mo_photo::PhotoTableData build_test_photo_table() {
 
   // rsf_tab(nw, nump, numsza, numcolo3, numalb): random positive
   auto rsf_tab_h = Kokkos::create_mirror_view(photo_table.rsf_tab);
-  for (int w  = 0; w  < test_nw;       ++w)
-  for (int ip = 0; ip < test_nump;     ++ip)
-  for (int is = 0; is < test_numsza;   ++is)
-  for (int iv = 0; iv < test_numcolo3; ++iv)
-  for (int ia = 0; ia < test_numalb;   ++ia)
-    rsf_tab_h(w, ip, is, iv, ia) = pos(gen);
+  for (int w = 0; w < test_nw; ++w)
+    for (int ip = 0; ip < test_nump; ++ip)
+      for (int is = 0; is < test_numsza; ++is)
+        for (int iv = 0; iv < test_numcolo3; ++iv)
+          for (int ia = 0; ia < test_numalb; ++ia)
+            rsf_tab_h(w, ip, is, iv, ia) = pos(gen);
   Kokkos::deep_copy(photo_table.rsf_tab, rsf_tab_h);
 
   // prs [hPa]: monotone decreasing
   auto prs_h = Kokkos::create_mirror_view(photo_table.prs);
-  prs_h(0) = 500.0; prs_h(1) = 100.0; prs_h(2) = 10.0; prs_h(3) = 1.0;
+  prs_h(0) = 500.0;
+  prs_h(1) = 100.0;
+  prs_h(2) = 10.0;
+  prs_h(3) = 1.0;
   Kokkos::deep_copy(photo_table.prs, prs_h);
 
   auto dprs_h = Kokkos::create_mirror_view(photo_table.dprs);
@@ -228,7 +245,8 @@ static mam4::mo_photo::PhotoTableData build_test_photo_table() {
   Kokkos::deep_copy(photo_table.dprs, dprs_h);
 
   auto pam_h = Kokkos::create_mirror_view(photo_table.pht_alias_mult_1);
-  pam_h(0) = 1.0; pam_h(1) = 0.0;
+  pam_h(0) = 1.0;
+  pam_h(1) = 0.0;
   Kokkos::deep_copy(photo_table.pht_alias_mult_1, pam_h);
 
   auto li_h = Kokkos::create_mirror_view(photo_table.lng_indexer);
@@ -237,15 +255,14 @@ static mam4::mo_photo::PhotoTableData build_test_photo_table() {
 
   // xsqy(numj, nw, nt, np_xs): random positive
   auto xsqy_h = Kokkos::create_mirror_view(photo_table.xsqy);
-  for (int j  = 0; j  < test_numj;  ++j)
-  for (int w  = 0; w  < test_nw;    ++w)
-  for (int it = 0; it < test_nt;    ++it)
-  for (int ip = 0; ip < test_np_xs; ++ip)
-    xsqy_h(j, w, it, ip) = pos(gen);
+  for (int j = 0; j < test_numj; ++j)
+    for (int w = 0; w < test_nw; ++w)
+      for (int it = 0; it < test_nt; ++it)
+        for (int ip = 0; ip < test_np_xs; ++ip)
+          xsqy_h(j, w, it, ip) = pos(gen);
   Kokkos::deep_copy(photo_table.xsqy, xsqy_h);
 
   return photo_table;
- 
 }
 
 // ============================================================================
@@ -256,17 +273,17 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
   ekat::logger::Logger<> logger("interpolate_rsf tests",
                                 ekat::logger::LogLevel::debug, comm);
 
-  constexpr int pver     = mam4::nlev;
-  constexpr Real Pa2mb   = 1e-2;
-  constexpr Real tol     = 0.0;//PrecisionTolerance<Real>::tol;
+  constexpr int pver = mam4::nlev;
+  constexpr Real Pa2mb = 1e-2;
+  constexpr Real tol = PrecisionTolerance<Real>::tol;
 
   auto photo_table = build_test_photo_table();
 
-  mam4::Atmosphere atm =
-      mam4::init_atm_const_tv_lapse_rate(pver, 1000.0, 300.0, 0.01, 0.015, 7.5e-4);
+  mam4::Atmosphere atm = mam4::init_atm_const_tv_lapse_rate(
+      pver, 1000.0, 300.0, 0.01, 0.015, 7.5e-4);
 
-  using View1D     = mam4::mo_photo::View1D;
-  using View2D     = mam4::mo_photo::View2D;
+  using View1D = mam4::mo_photo::View1D;
+  using View2D = mam4::mo_photo::View2D;
   using View1DHost = Kokkos::View<Real *, Kokkos::HostSpace>;
   using View2DHost = Kokkos::View<Real **, Kokkos::HostSpace>;
 
@@ -277,29 +294,40 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
   auto pressure_host = Kokkos::create_mirror_view(atm.pressure);
   Kokkos::deep_copy(pressure_host, atm.pressure);
   for (int k = 0; k < pver; ++k) {
-    alb_in_host(k)   = 0.15;
-    p_in_host(k)     = pressure_host(k) * Pa2mb;
+    alb_in_host(k) = 0.15;
+    p_in_host(k) = pressure_host(k) * Pa2mb;
     colo3_in_host(k) = 3e17;
   }
   View1D alb_in_d("alb_in", pver);
   View1D p_in_d("p_in", pver);
   View1D colo3_in_d("colo3_in", pver);
   Kokkos::deep_copy(alb_in_d, alb_in_host);
-  Kokkos::deep_copy(p_in_d,   p_in_host);
+  Kokkos::deep_copy(p_in_d, p_in_host);
   Kokkos::deep_copy(colo3_in_d, colo3_in_host);
 
   // Mirror table arrays onto host for serial reference
-  auto sza_h       = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.sza);
-  auto del_sza_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_sza);
-  auto alb_h       = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.alb);
-  auto press_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.press);
-  auto del_p_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_p);
-  auto colo3_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.colo3);
-  auto o3rat_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.o3rat);
-  auto del_alb_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_alb);
-  auto del_o3rat_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_o3rat);
-  auto etfphot_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.etfphot);
-  auto rsf_tab_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.rsf_tab);
+  auto sza_h =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.sza);
+  auto del_sza_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                       photo_table.del_sza);
+  auto alb_h =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.alb);
+  auto press_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                     photo_table.press);
+  auto del_p_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                     photo_table.del_p);
+  auto colo3_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                     photo_table.colo3);
+  auto o3rat_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                     photo_table.o3rat);
+  auto del_alb_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                       photo_table.del_alb);
+  auto del_o3rat_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                         photo_table.del_o3rat);
+  auto etfphot_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                       photo_table.etfphot);
+  auto rsf_tab_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                       photo_table.rsf_tab);
 
   // helper: find_index on host
   auto find_idx_h = [](const auto &arr, int len, Real val) {
@@ -322,7 +350,7 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
   // find zenith angle index and dels[0] — same for all levels
   int is_h = find_idx_h(sza_h, test_numsza, test_sza_in);
   Real dels0 = bound(0.0, 1.0, (test_sza_in - sza_h(is_h)) * del_sza_h(is_h));
-  Real wrk0  = 1.0 - dels0;
+  Real wrk0 = 1.0 - dels0;
 
   for (int kk = 0; kk < pver; ++kk) {
     int albind = find_idx_h(alb_h, test_numalb, alb_in_host(kk));
@@ -330,96 +358,104 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
     int pind = 0;
     Real wght1 = 0;
     if (p_in_host(kk) > press_h(0)) {
-      pind = 1; wght1 = 1.0;
+      pind = 1;
+      wght1 = 1.0;
     } else if (p_in_host(kk) <= press_h(test_nump - 1)) {
-      pind = test_nump - 1; wght1 = 0.0;
+      pind = test_nump - 1;
+      wght1 = 0.0;
     } else {
       int iz = 1;
       for (; iz < test_nump; ++iz)
-        if (press_h(iz) < p_in_host(kk)) break;
-      iz    = iz < test_nump - 1 ? iz : test_nump - 1;
-      pind  = iz > 1 ? iz : 1;
-      wght1 = bound(0.0, 1.0, (p_in_host(kk) - press_h(pind)) * del_p_h(pind - 1));
+        if (press_h(iz) < p_in_host(kk))
+          break;
+      iz = iz < test_nump - 1 ? iz : test_nump - 1;
+      pind = iz > 1 ? iz : 1;
+      wght1 =
+          bound(0.0, 1.0, (p_in_host(kk) - press_h(pind)) * del_p_h(pind - 1));
     }
 
     Real v3ratu = colo3_in_host(kk) / colo3_h(pind - 1);
     int ratindu = find_idx_h(o3rat_h, test_numcolo3, v3ratu);
 
-    Real v3ratl; int ratindl;
+    Real v3ratl;
+    int ratindl;
     if (colo3_h(pind) != 0.0) {
-      v3ratl  = colo3_in_host(kk) / colo3_h(pind);
+      v3ratl = colo3_in_host(kk) / colo3_h(pind);
       ratindl = find_idx_h(o3rat_h, test_numcolo3, v3ratl);
     } else {
       ratindl = ratindu;
-      v3ratl  = o3rat_h(ratindu);
+      v3ratl = o3rat_h(ratindu);
     }
 
-    Real dels2 = bound(0.0, 1.0, (alb_in_host(kk) - alb_h(albind)) * del_alb_h(albind));
+    Real dels2 =
+        bound(0.0, 1.0, (alb_in_host(kk) - alb_h(albind)) * del_alb_h(albind));
 
     // calc_sum_wght for psum_l
     auto calc_psum = [&](int iz_c, int iv_c, Real v3rat) {
       Real dels1 = bound(0.0, 1.0, (v3rat - o3rat_h(iv_c)) * del_o3rat_h(iv_c));
       int is_c = is_h, isp1 = is_c + 1, ivp1 = iv_c + 1, ialp1 = albind + 1;
       Real wk = (1.0 - dels1) * (1.0 - dels2);
-      Real w000 = wrk0 * wk,  w100 = dels0 * wk;
+      Real w000 = wrk0 * wk, w100 = dels0 * wk;
       wk = (1.0 - dels1) * dels2;
-      Real w001 = wrk0 * wk,  w101 = dels0 * wk;
+      Real w001 = wrk0 * wk, w101 = dels0 * wk;
       wk = dels1 * (1.0 - dels2);
-      Real w010 = wrk0 * wk,  w110 = dels0 * wk;
+      Real w010 = wrk0 * wk, w110 = dels0 * wk;
       wk = dels1 * dels2;
-      Real w011 = wrk0 * wk,  w111 = dels0 * wk;
+      Real w011 = wrk0 * wk, w111 = dels0 * wk;
       Real psum[test_nw] = {};
       for (int wn = 0; wn < test_nw; ++wn)
-        psum[wn] =
-          w000 * rsf_tab_h(wn, iz_c, is_c, iv_c,  albind)  +
-          w001 * rsf_tab_h(wn, iz_c, is_c, iv_c,  ialp1)   +
-          w010 * rsf_tab_h(wn, iz_c, is_c, ivp1,  albind)  +
-          w011 * rsf_tab_h(wn, iz_c, is_c, ivp1,  ialp1)   +
-          w100 * rsf_tab_h(wn, iz_c, isp1, iv_c,  albind)  +
-          w101 * rsf_tab_h(wn, iz_c, isp1, iv_c,  ialp1)   +
-          w110 * rsf_tab_h(wn, iz_c, isp1, ivp1, albind)   +
-          w111 * rsf_tab_h(wn, iz_c, isp1, ivp1, ialp1);
+        psum[wn] = w000 * rsf_tab_h(wn, iz_c, is_c, iv_c, albind) +
+                   w001 * rsf_tab_h(wn, iz_c, is_c, iv_c, ialp1) +
+                   w010 * rsf_tab_h(wn, iz_c, is_c, ivp1, albind) +
+                   w011 * rsf_tab_h(wn, iz_c, is_c, ivp1, ialp1) +
+                   w100 * rsf_tab_h(wn, iz_c, isp1, iv_c, albind) +
+                   w101 * rsf_tab_h(wn, iz_c, isp1, iv_c, ialp1) +
+                   w110 * rsf_tab_h(wn, iz_c, isp1, ivp1, albind) +
+                   w111 * rsf_tab_h(wn, iz_c, isp1, ivp1, ialp1);
       // Copy into a fixed-size array for return by value
-      struct PsumArr { Real v[test_nw]; };
+      struct PsumArr {
+        Real v[test_nw];
+      };
       PsumArr ret{};
-      for (int wn = 0; wn < test_nw; ++wn) ret.v[wn] = psum[wn];
+      for (int wn = 0; wn < test_nw; ++wn)
+        ret.v[wn] = psum[wn];
       return ret;
     };
-    auto psum_l = calc_psum(pind,     ratindl, v3ratl);
+    auto psum_l = calc_psum(pind, ratindl, v3ratl);
     auto psum_u = calc_psum(pind - 1, ratindu, v3ratu);
 
     for (int wn = 0; wn < test_nw; ++wn)
-      rsf_ref(wn, kk) =
-          (psum_l.v[wn] + wght1 * (psum_u.v[wn] - psum_l.v[wn])) * etfphot_h(wn);
+      rsf_ref(wn, kk) = (psum_l.v[wn] + wght1 * (psum_u.v[wn] - psum_l.v[wn])) *
+                        etfphot_h(wn);
   }
 
   // ===== PARALLEL IMPLEMENTATION =====
   View2D rsf_par("rsf_par", test_nw, pver);
   {
-    const auto sza_d       = photo_table.sza;
-    const auto del_sza_d   = photo_table.del_sza;
-    const auto alb_d       = photo_table.alb;
-    const auto press_d     = photo_table.press;
-    const auto del_p_d     = photo_table.del_p;
-    const auto colo3_d     = photo_table.colo3;
-    const auto o3rat_d     = photo_table.o3rat;
-    const auto del_alb_d   = photo_table.del_alb;
+    const auto sza_d = photo_table.sza;
+    const auto del_sza_d = photo_table.del_sza;
+    const auto alb_d = photo_table.alb;
+    const auto press_d = photo_table.press;
+    const auto del_p_d = photo_table.del_p;
+    const auto colo3_d = photo_table.colo3;
+    const auto o3rat_d = photo_table.o3rat;
+    const auto del_alb_d = photo_table.del_alb;
     const auto del_o3rat_d = photo_table.del_o3rat;
-    const auto etfphot_d   = photo_table.etfphot;
-    const auto rsf_tab_d   = photo_table.rsf_tab;
+    const auto etfphot_d = photo_table.etfphot;
+    const auto rsf_tab_d = photo_table.rsf_tab;
     View2D psum_l_d("psum_l", pver, test_nw);
     View2D psum_u_d("psum_u", pver, test_nw);
 
     Kokkos::parallel_for(
         "interpolate_rsf_par", mam4::ThreadTeamPolicy(1, Kokkos::AUTO),
         KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
-      mam4::mo_photo::interpolate_rsf(
-          team, alb_in_d, test_sza_in, p_in_d, colo3_in_d, pver,
-          sza_d, del_sza_d, alb_d, press_d, del_p_d, colo3_d,
-          o3rat_d, del_alb_d, del_o3rat_d, etfphot_d, rsf_tab_d,
-          test_nw, test_nump, test_numsza, test_numcolo3, test_numalb,
-          rsf_par, psum_l_d, psum_u_d);
-    });
+          mam4::mo_photo::interpolate_rsf(
+              team, alb_in_d, test_sza_in, p_in_d, colo3_in_d, pver, sza_d,
+              del_sza_d, alb_d, press_d, del_p_d, colo3_d, o3rat_d, del_alb_d,
+              del_o3rat_d, etfphot_d, rsf_tab_d, test_nw, test_nump,
+              test_numsza, test_numcolo3, test_numalb, rsf_par, psum_l_d,
+              psum_u_d);
+        });
     Kokkos::fence();
   }
 
@@ -435,36 +471,34 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
       const Real diff = aref != 0.0 ? adiff / aref : adiff;
       if (diff > tol) {
         std::ostringstream ss;
-        ss << "RSF mismatch wn=" << wn << " k=" << k
-           << " parallel=" << par << " serial=" << ref
-           << " diff=" << diff;
+        ss << "RSF mismatch wn=" << wn << " k=" << k << " parallel=" << par
+           << " serial=" << ref << " diff=" << diff;
         logger.debug(ss.str());
       }
       REQUIRE(diff <= tol);
     }
   }
 }
-#if 1
 // ============================================================================
 // Test: jlong — host serial reference vs parallel implementation
 // ============================================================================
 TEST_CASE("jlong", "mo_photo") {
   ekat::Comm comm;
-  ekat::logger::Logger<> logger("jlong tests",
-                                ekat::logger::LogLevel::debug, comm);
+  ekat::logger::Logger<> logger("jlong tests", ekat::logger::LogLevel::debug,
+                                comm);
 
-  constexpr int pver   = mam4::nlev;
+  constexpr int pver = mam4::nlev;
   constexpr Real Pa2mb = 1e-2;
-  constexpr Real tol   = 0.0;//PrecisionTolerance<Real>::tol;
+  constexpr Real tol = PrecisionTolerance<Real>::tol;
 
   auto photo_table = build_test_photo_table();
 
-  mam4::Atmosphere atm =
-      mam4::init_atm_const_tv_lapse_rate(pver, 1000.0, 300.0, 0.01, 0.015, 7.5e-4);
+  mam4::Atmosphere atm = mam4::init_atm_const_tv_lapse_rate(
+      pver, 1000.0, 300.0, 0.01, 0.015, 7.5e-4);
 
-  using View1D     = mam4::mo_photo::View1D;
-  using View2D     = mam4::mo_photo::View2D;
-  using View3D     = mam4::mo_photo::View3D;
+  using View1D = mam4::mo_photo::View1D;
+  using View2D = mam4::mo_photo::View2D;
+  using View3D = mam4::mo_photo::View3D;
   using View1DHost = Kokkos::View<Real *, Kokkos::HostSpace>;
   using View2DHost = Kokkos::View<Real **, Kokkos::HostSpace>;
 
@@ -476,32 +510,46 @@ TEST_CASE("jlong", "mo_photo") {
   auto temper_host = Kokkos::create_mirror_view(atm.temperature);
   Kokkos::deep_copy(temper_host, atm.temperature);
   for (int k = 0; k < pver; ++k) {
-    alb_in_host(k)   = 0.15;
-    p_in_host(k)     = pressure_host(k) * Pa2mb;
+    alb_in_host(k) = 0.15;
+    p_in_host(k) = pressure_host(k) * Pa2mb;
     colo3_in_host(k) = 3e17;
   }
   View1D alb_in_d("alb_in", pver);
   View1D p_in_d("p_in", pver);
   View1D colo3_in_d("colo3_in", pver);
-  Kokkos::deep_copy(alb_in_d,   alb_in_host);
-  Kokkos::deep_copy(p_in_d,     p_in_host);
+  Kokkos::deep_copy(alb_in_d, alb_in_host);
+  Kokkos::deep_copy(p_in_d, p_in_host);
   Kokkos::deep_copy(colo3_in_d, colo3_in_host);
 
   // Mirror table onto host
-  auto sza_h       = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.sza);
-  auto del_sza_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_sza);
-  auto alb_h       = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.alb);
-  auto press_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.press);
-  auto del_p_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_p);
-  auto colo3_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.colo3);
-  auto o3rat_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.o3rat);
-  auto del_alb_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_alb);
-  auto del_o3rat_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_o3rat);
-  auto etfphot_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.etfphot);
-  auto rsf_tab_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.rsf_tab);
-  auto xsqy_h      = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.xsqy);
-  auto prs_h       = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.prs);
-  auto dprs_h      = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.dprs);
+  auto sza_h =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.sza);
+  auto del_sza_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                       photo_table.del_sza);
+  auto alb_h =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.alb);
+  auto press_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                     photo_table.press);
+  auto del_p_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                     photo_table.del_p);
+  auto colo3_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                     photo_table.colo3);
+  auto o3rat_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                     photo_table.o3rat);
+  auto del_alb_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                       photo_table.del_alb);
+  auto del_o3rat_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                         photo_table.del_o3rat);
+  auto etfphot_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                       photo_table.etfphot);
+  auto rsf_tab_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                       photo_table.rsf_tab);
+  auto xsqy_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                    photo_table.xsqy);
+  auto prs_h =
+      Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.prs);
+  auto dprs_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{},
+                                                    photo_table.dprs);
 
   auto find_idx_h = [](const auto &arr, int len, Real val) {
     int idx = 0;
@@ -520,67 +568,76 @@ TEST_CASE("jlong", "mo_photo") {
   // ===== SERIAL REFERENCE =====
   // Step 1: compute rsf_ref using same logic as interpolate_rsf
   View2DHost rsf_ref("rsf_ref", test_nw, pver);
-  int is_h  = find_idx_h(sza_h, test_numsza, test_sza_in);
+  int is_h = find_idx_h(sza_h, test_numsza, test_sza_in);
   Real dels0 = bound(0.0, 1.0, (test_sza_in - sza_h(is_h)) * del_sza_h(is_h));
-  Real wrk0  = 1.0 - dels0;
+  Real wrk0 = 1.0 - dels0;
 
   for (int kk = 0; kk < pver; ++kk) {
     int albind = find_idx_h(alb_h, test_numalb, alb_in_host(kk));
-    int pind = 0; Real wght1 = 0;
+    int pind = 0;
+    Real wght1 = 0;
     if (p_in_host(kk) > press_h(0)) {
-      pind = 1; wght1 = 1.0;
+      pind = 1;
+      wght1 = 1.0;
     } else if (p_in_host(kk) <= press_h(test_nump - 1)) {
-      pind = test_nump - 1; wght1 = 0.0;
+      pind = test_nump - 1;
+      wght1 = 0.0;
     } else {
       int iz = 1;
       for (; iz < test_nump; ++iz)
-        if (press_h(iz) < p_in_host(kk)) break;
-      iz    = iz < test_nump - 1 ? iz : test_nump - 1;
-      pind  = iz > 1 ? iz : 1;
-      wght1 = bound(0.0, 1.0, (p_in_host(kk) - press_h(pind)) * del_p_h(pind - 1));
+        if (press_h(iz) < p_in_host(kk))
+          break;
+      iz = iz < test_nump - 1 ? iz : test_nump - 1;
+      pind = iz > 1 ? iz : 1;
+      wght1 =
+          bound(0.0, 1.0, (p_in_host(kk) - press_h(pind)) * del_p_h(pind - 1));
     }
     Real v3ratu = colo3_in_host(kk) / colo3_h(pind - 1);
     int ratindu = find_idx_h(o3rat_h, test_numcolo3, v3ratu);
-    Real v3ratl; int ratindl;
+    Real v3ratl;
+    int ratindl;
     if (colo3_h(pind) != 0.0) {
-      v3ratl  = colo3_in_host(kk) / colo3_h(pind);
+      v3ratl = colo3_in_host(kk) / colo3_h(pind);
       ratindl = find_idx_h(o3rat_h, test_numcolo3, v3ratl);
     } else {
-      ratindl = ratindu; v3ratl = o3rat_h(ratindu);
+      ratindl = ratindu;
+      v3ratl = o3rat_h(ratindu);
     }
-    Real dels2 = bound(0.0, 1.0, (alb_in_host(kk) - alb_h(albind)) * del_alb_h(albind));
+    Real dels2 =
+        bound(0.0, 1.0, (alb_in_host(kk) - alb_h(albind)) * del_alb_h(albind));
     int ialp1 = albind + 1;
 
     auto calc_psum = [&](int iz_c, int iv_c, Real v3rat) {
       Real dels1 = bound(0.0, 1.0, (v3rat - o3rat_h(iv_c)) * del_o3rat_h(iv_c));
       int isp1 = is_h + 1, ivp1 = iv_c + 1;
       Real wk = (1.0 - dels1) * (1.0 - dels2);
-      Real w000 = wrk0*wk, w100 = dels0*wk;
+      Real w000 = wrk0 * wk, w100 = dels0 * wk;
       wk = (1.0 - dels1) * dels2;
-      Real w001 = wrk0*wk, w101 = dels0*wk;
+      Real w001 = wrk0 * wk, w101 = dels0 * wk;
       wk = dels1 * (1.0 - dels2);
-      Real w010 = wrk0*wk, w110 = dels0*wk;
+      Real w010 = wrk0 * wk, w110 = dels0 * wk;
       wk = dels1 * dels2;
-      Real w011 = wrk0*wk, w111 = dels0*wk;
-      struct PsArr { Real v[test_nw]; };
+      Real w011 = wrk0 * wk, w111 = dels0 * wk;
+      struct PsArr {
+        Real v[test_nw];
+      };
       PsArr ps{};
       for (int wn = 0; wn < test_nw; ++wn)
-        ps.v[wn] =
-          w000*rsf_tab_h(wn,iz_c,is_h,iv_c, albind) +
-          w001*rsf_tab_h(wn,iz_c,is_h,iv_c, ialp1)  +
-          w010*rsf_tab_h(wn,iz_c,is_h,ivp1, albind) +
-          w011*rsf_tab_h(wn,iz_c,is_h,ivp1, ialp1)  +
-          w100*rsf_tab_h(wn,iz_c,isp1,iv_c, albind) +
-          w101*rsf_tab_h(wn,iz_c,isp1,iv_c, ialp1)  +
-          w110*rsf_tab_h(wn,iz_c,isp1,ivp1,albind)  +
-          w111*rsf_tab_h(wn,iz_c,isp1,ivp1,ialp1);
+        ps.v[wn] = w000 * rsf_tab_h(wn, iz_c, is_h, iv_c, albind) +
+                   w001 * rsf_tab_h(wn, iz_c, is_h, iv_c, ialp1) +
+                   w010 * rsf_tab_h(wn, iz_c, is_h, ivp1, albind) +
+                   w011 * rsf_tab_h(wn, iz_c, is_h, ivp1, ialp1) +
+                   w100 * rsf_tab_h(wn, iz_c, isp1, iv_c, albind) +
+                   w101 * rsf_tab_h(wn, iz_c, isp1, iv_c, ialp1) +
+                   w110 * rsf_tab_h(wn, iz_c, isp1, ivp1, albind) +
+                   w111 * rsf_tab_h(wn, iz_c, isp1, ivp1, ialp1);
       return ps;
     };
-    auto psum_l = calc_psum(pind,     ratindl, v3ratl);
+    auto psum_l = calc_psum(pind, ratindl, v3ratl);
     auto psum_u = calc_psum(pind - 1, ratindu, v3ratu);
     for (int wn = 0; wn < test_nw; ++wn)
-      rsf_ref(wn, kk) =
-          (psum_l.v[wn] + wght1 * (psum_u.v[wn] - psum_l.v[wn])) * etfphot_h(wn);
+      rsf_ref(wn, kk) = (psum_l.v[wn] + wght1 * (psum_u.v[wn] - psum_l.v[wn])) *
+                        etfphot_h(wn);
   }
 
   // Step 2: compute j_long_ref on host
@@ -600,7 +657,8 @@ TEST_CASE("jlong", "mo_photo") {
         for (int i = 0; i < test_numj; ++i)
           xswk_row[wn] = xsqy_h(i, wn, t_index, test_np_xs - 1);
     } else {
-      Real delp = 0; int pndx = 0;
+      Real delp = 0;
+      int pndx = 0;
       for (int km = 1; km < test_np_xs; ++km) {
         if (ptarget >= prs_h(km)) {
           pndx = km - 1;
@@ -611,8 +669,8 @@ TEST_CASE("jlong", "mo_photo") {
       for (int wn = 0; wn < test_nw; ++wn)
         for (int i = 0; i < test_numj; ++i)
           xswk_row[wn] = xsqy_h(i, wn, t_index, pndx) +
-              delp * (xsqy_h(i, wn, t_index, pndx + 1) -
-                      xsqy_h(i, wn, t_index, pndx));
+                         delp * (xsqy_h(i, wn, t_index, pndx + 1) -
+                                 xsqy_h(i, wn, t_index, pndx));
     }
     for (int i = 0; i < test_numj; ++i) {
       Real suma = 0;
@@ -630,35 +688,33 @@ TEST_CASE("jlong", "mo_photo") {
     View2D psum_l_d("psum_l", pver, test_nw);
     View2D psum_u_d("psum_u", pver, test_nw);
 
-    const auto sza_d       = photo_table.sza;
-    const auto del_sza_d   = photo_table.del_sza;
-    const auto alb_d       = photo_table.alb;
-    const auto press_d     = photo_table.press;
-    const auto del_p_d     = photo_table.del_p;
-    const auto colo3_d     = photo_table.colo3;
-    const auto o3rat_d     = photo_table.o3rat;
-    const auto del_alb_d   = photo_table.del_alb;
+    const auto sza_d = photo_table.sza;
+    const auto del_sza_d = photo_table.del_sza;
+    const auto alb_d = photo_table.alb;
+    const auto press_d = photo_table.press;
+    const auto del_p_d = photo_table.del_p;
+    const auto colo3_d = photo_table.colo3;
+    const auto o3rat_d = photo_table.o3rat;
+    const auto del_alb_d = photo_table.del_alb;
     const auto del_o3rat_d = photo_table.del_o3rat;
-    const auto etfphot_d   = photo_table.etfphot;
-    const auto rsf_tab_d   = photo_table.rsf_tab;
-    const auto xsqy_d      = photo_table.xsqy;
-    const auto prs_d       = photo_table.prs;
-    const auto dprs_d      = photo_table.dprs;
-    const auto temper      = atm.temperature;
+    const auto etfphot_d = photo_table.etfphot;
+    const auto rsf_tab_d = photo_table.rsf_tab;
+    const auto xsqy_d = photo_table.xsqy;
+    const auto prs_d = photo_table.prs;
+    const auto dprs_d = photo_table.dprs;
+    const auto temper = atm.temperature;
 
     Kokkos::parallel_for(
         "jlong_par", mam4::ThreadTeamPolicy(1, Kokkos::AUTO),
         KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
-      mam4::mo_photo::jlong(
-          team, test_sza_in, alb_in_d, p_in_d, temper, colo3_in_d,
-          xsqy_d, sza_d, del_sza_d, alb_d, press_d, del_p_d, colo3_d,
-          o3rat_d, del_alb_d, del_o3rat_d, etfphot_d, rsf_tab_d,
-          prs_d, dprs_d,
-          test_nw, test_nump, test_numsza, test_numcolo3, test_numalb,
-          test_np_xs, test_numj,
-          j_long_par,
-          rsf_work, xswk_d, psum_l_d, psum_u_d);
-    });
+          mam4::mo_photo::jlong(
+              team, test_sza_in, alb_in_d, p_in_d, temper, colo3_in_d, xsqy_d,
+              sza_d, del_sza_d, alb_d, press_d, del_p_d, colo3_d, o3rat_d,
+              del_alb_d, del_o3rat_d, etfphot_d, rsf_tab_d, prs_d, dprs_d,
+              test_nw, test_nump, test_numsza, test_numcolo3, test_numalb,
+              test_np_xs, test_numj, j_long_par, rsf_work, xswk_d, psum_l_d,
+              psum_u_d);
+        });
     Kokkos::fence();
   }
 
@@ -667,20 +723,18 @@ TEST_CASE("jlong", "mo_photo") {
   Kokkos::deep_copy(j_par_h, j_long_par);
   for (int i = 0; i < test_numj; ++i) {
     for (int k = 0; k < pver; ++k) {
-      const Real ref  = j_long_ref(i, k);
-      const Real par  = j_par_h(i, k);
+      const Real ref = j_long_ref(i, k);
+      const Real par = j_par_h(i, k);
       const Real aref2 = ref > 0 ? ref : -ref;
       const Real adiff2 = (par - ref) > 0 ? (par - ref) : -(par - ref);
       const Real diff = aref2 != 0.0 ? adiff2 / aref2 : adiff2;
       if (diff > tol) {
         std::ostringstream ss;
         ss << "j_long mismatch reaction=" << i << " k=" << k
-           << " parallel=" << par << " serial=" << ref
-           << " diff=" << diff;
+           << " parallel=" << par << " serial=" << ref << " diff=" << diff;
         logger.debug(ss.str());
       }
       REQUIRE(diff <= tol);
     }
   }
 }
-#endif

--- a/src/tests/mam4_photo_setcol.cpp
+++ b/src/tests/mam4_photo_setcol.cpp
@@ -8,8 +8,6 @@
 
 #include <catch2/catch.hpp>
 #include <ekat_logger.hpp>
-#include <algorithm>
-#include <array>
 #include <random>
 
 // Precision-dependent tolerance traits
@@ -113,8 +111,8 @@ TEST_CASE("compute_o3_column_density", "mo_photo") {
   // Compare serial reference with parallel implementation
 
   for (int k = 0; k < pver; ++k) {
-    const Real diff =
-        std::abs(o3_col_dens_host(k) - o3_col_dens_ref(k)) / o3_col_dens_ref(k);
+    const Real raw_diff = o3_col_dens_host(k) - o3_col_dens_ref(k);
+    const Real diff = (raw_diff > 0 ? raw_diff : -raw_diff) / o3_col_dens_ref(k);
     if (diff >= tol) {
       std::ostringstream ss;
       ss << "diff : [ ";
@@ -132,7 +130,7 @@ TEST_CASE("compute_o3_column_density", "mo_photo") {
 // Helpers shared by interpolate_rsf and jlong tests
 // ============================================================================
 
-using namespace mam4;
+// using namespace mam4;
 
 // Table dimensions — compile-time constants required inside device lambdas.
 constexpr int test_nw       = 4;
@@ -146,10 +144,10 @@ constexpr int test_np_xs    = 4;
 constexpr Real test_sza_in  = 30.0; // degrees, well within daylight range
 
 // Build a small PhotoTableData with synthetic monotone lookup arrays.
-static mo_photo::PhotoTableData build_test_photo_table() {
+static mam4::mo_photo::PhotoTableData build_test_photo_table() {
   using HostView1D = Kokkos::View<Real *, Kokkos::HostSpace>;
 
-  auto photo_table = mo_photo::create_photo_table_data(
+  auto photo_table = mam4::mo_photo::create_photo_table_data(
       test_nw, test_nt, test_np_xs, test_numj,
       test_nump, test_numsza, test_numcolo3, test_numalb);
 
@@ -247,6 +245,7 @@ static mo_photo::PhotoTableData build_test_photo_table() {
   Kokkos::deep_copy(photo_table.xsqy, xsqy_h);
 
   return photo_table;
+ 
 }
 
 // ============================================================================
@@ -257,17 +256,17 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
   ekat::logger::Logger<> logger("interpolate_rsf tests",
                                 ekat::logger::LogLevel::debug, comm);
 
-  constexpr int pver     = nlev;
+  constexpr int pver     = mam4::nlev;
   constexpr Real Pa2mb   = 1e-2;
   constexpr Real tol     = 0.0;//PrecisionTolerance<Real>::tol;
 
   auto photo_table = build_test_photo_table();
 
-  Atmosphere atm =
-      init_atm_const_tv_lapse_rate(pver, 1000.0, 300.0, 0.01, 0.015, 7.5e-4);
+  mam4::Atmosphere atm =
+      mam4::init_atm_const_tv_lapse_rate(pver, 1000.0, 300.0, 0.01, 0.015, 7.5e-4);
 
-  using View1D     = mo_photo::View1D;
-  using View2D     = mo_photo::View2D;
+  using View1D     = mam4::mo_photo::View1D;
+  using View2D     = mam4::mo_photo::View2D;
   using View1DHost = Kokkos::View<Real *, Kokkos::HostSpace>;
   using View2DHost = Kokkos::View<Real **, Kokkos::HostSpace>;
 
@@ -307,7 +306,7 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
     int idx = 0;
     for (int ii = 0; ii < len; ++ii) {
       if (arr(ii) > val) {
-        idx = std::max(std::min(ii, len - 1) - 1, 0);
+        idx = mam4::max(mam4::min(ii, len - 1) - 1, 0);
         break;
       }
     }
@@ -338,8 +337,8 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
       int iz = 1;
       for (; iz < test_nump; ++iz)
         if (press_h(iz) < p_in_host(kk)) break;
-      iz    = std::min(iz, test_nump - 1);
-      pind  = std::max(iz, 1);
+      iz    = iz < test_nump - 1 ? iz : test_nump - 1;
+      pind  = iz > 1 ? iz : 1;
       wght1 = bound(0.0, 1.0, (p_in_host(kk) - press_h(pind)) * del_p_h(pind - 1));
     }
 
@@ -369,7 +368,7 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
       Real w010 = wrk0 * wk,  w110 = dels0 * wk;
       wk = dels1 * dels2;
       Real w011 = wrk0 * wk,  w111 = dels0 * wk;
-      std::array<Real, test_nw> psum{};
+      Real psum[test_nw] = {};
       for (int wn = 0; wn < test_nw; ++wn)
         psum[wn] =
           w000 * rsf_tab_h(wn, iz_c, is_c, iv_c,  albind)  +
@@ -380,14 +379,18 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
           w101 * rsf_tab_h(wn, iz_c, isp1, iv_c,  ialp1)   +
           w110 * rsf_tab_h(wn, iz_c, isp1, ivp1, albind)   +
           w111 * rsf_tab_h(wn, iz_c, isp1, ivp1, ialp1);
-      return psum;
+      // Copy into a fixed-size array for return by value
+      struct PsumArr { Real v[test_nw]; };
+      PsumArr ret{};
+      for (int wn = 0; wn < test_nw; ++wn) ret.v[wn] = psum[wn];
+      return ret;
     };
     auto psum_l = calc_psum(pind,     ratindl, v3ratl);
     auto psum_u = calc_psum(pind - 1, ratindu, v3ratu);
 
     for (int wn = 0; wn < test_nw; ++wn)
       rsf_ref(wn, kk) =
-          (psum_l[wn] + wght1 * (psum_u[wn] - psum_l[wn])) * etfphot_h(wn);
+          (psum_l.v[wn] + wght1 * (psum_u.v[wn] - psum_l.v[wn])) * etfphot_h(wn);
   }
 
   // ===== PARALLEL IMPLEMENTATION =====
@@ -404,14 +407,14 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
     const auto del_o3rat_d = photo_table.del_o3rat;
     const auto etfphot_d   = photo_table.etfphot;
     const auto rsf_tab_d   = photo_table.rsf_tab;
-    mo_photo::View2D psum_l_d("psum_l", pver, test_nw);
-    mo_photo::View2D psum_u_d("psum_u", pver, test_nw);
+    View2D psum_l_d("psum_l", pver, test_nw);
+    View2D psum_u_d("psum_u", pver, test_nw);
 
     Kokkos::parallel_for(
-        "interpolate_rsf_par", ThreadTeamPolicy(1, Kokkos::AUTO),
-        KOKKOS_LAMBDA(const ThreadTeam &team) {
-      mo_photo::interpolate_rsf(
-          team, alb_in_d, test_sza_in, p_in_d, colo3_in_d, nlev,
+        "interpolate_rsf_par", mam4::ThreadTeamPolicy(1, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
+      mam4::mo_photo::interpolate_rsf(
+          team, alb_in_d, test_sza_in, p_in_d, colo3_in_d, pver,
           sza_d, del_sza_d, alb_d, press_d, del_p_d, colo3_d,
           o3rat_d, del_alb_d, del_o3rat_d, etfphot_d, rsf_tab_d,
           test_nw, test_nump, test_numsza, test_numcolo3, test_numalb,
@@ -427,9 +430,9 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
     for (int k = 0; k < pver; ++k) {
       const Real ref = rsf_ref(wn, k);
       const Real par = rsf_par_h(wn, k);
-      const Real diff = ref != 0.0
-                            ? std::abs(par - ref) / std::abs(ref)
-                            : std::abs(par);
+      const Real aref = ref > 0 ? ref : -ref;
+      const Real adiff = (par - ref) > 0 ? (par - ref) : -(par - ref);
+      const Real diff = aref != 0.0 ? adiff / aref : adiff;
       if (diff > tol) {
         std::ostringstream ss;
         ss << "RSF mismatch wn=" << wn << " k=" << k
@@ -441,7 +444,7 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
     }
   }
 }
-
+#if 1
 // ============================================================================
 // Test: jlong — host serial reference vs parallel implementation
 // ============================================================================
@@ -450,18 +453,18 @@ TEST_CASE("jlong", "mo_photo") {
   ekat::logger::Logger<> logger("jlong tests",
                                 ekat::logger::LogLevel::debug, comm);
 
-  constexpr int pver   = nlev;
+  constexpr int pver   = mam4::nlev;
   constexpr Real Pa2mb = 1e-2;
   constexpr Real tol   = 0.0;//PrecisionTolerance<Real>::tol;
 
   auto photo_table = build_test_photo_table();
 
-  Atmosphere atm =
-      init_atm_const_tv_lapse_rate(pver, 1000.0, 300.0, 0.01, 0.015, 7.5e-4);
+  mam4::Atmosphere atm =
+      mam4::init_atm_const_tv_lapse_rate(pver, 1000.0, 300.0, 0.01, 0.015, 7.5e-4);
 
-  using View1D     = mo_photo::View1D;
-  using View2D     = mo_photo::View2D;
-  using View3D     = mo_photo::View3D;
+  using View1D     = mam4::mo_photo::View1D;
+  using View2D     = mam4::mo_photo::View2D;
+  using View3D     = mam4::mo_photo::View3D;
   using View1DHost = Kokkos::View<Real *, Kokkos::HostSpace>;
   using View2DHost = Kokkos::View<Real **, Kokkos::HostSpace>;
 
@@ -504,7 +507,7 @@ TEST_CASE("jlong", "mo_photo") {
     int idx = 0;
     for (int ii = 0; ii < len; ++ii) {
       if (arr(ii) > val) {
-        idx = std::max(std::min(ii, len - 1) - 1, 0);
+        idx = mam4::max(mam4::min(ii, len - 1) - 1, 0);
         break;
       }
     }
@@ -532,8 +535,8 @@ TEST_CASE("jlong", "mo_photo") {
       int iz = 1;
       for (; iz < test_nump; ++iz)
         if (press_h(iz) < p_in_host(kk)) break;
-      iz    = std::min(iz, test_nump - 1);
-      pind  = std::max(iz, 1);
+      iz    = iz < test_nump - 1 ? iz : test_nump - 1;
+      pind  = iz > 1 ? iz : 1;
       wght1 = bound(0.0, 1.0, (p_in_host(kk) - press_h(pind)) * del_p_h(pind - 1));
     }
     Real v3ratu = colo3_in_host(kk) / colo3_h(pind - 1);
@@ -559,9 +562,10 @@ TEST_CASE("jlong", "mo_photo") {
       Real w010 = wrk0*wk, w110 = dels0*wk;
       wk = dels1 * dels2;
       Real w011 = wrk0*wk, w111 = dels0*wk;
-      std::array<Real, test_nw> ps{};
+      struct PsArr { Real v[test_nw]; };
+      PsArr ps{};
       for (int wn = 0; wn < test_nw; ++wn)
-        ps[wn] =
+        ps.v[wn] =
           w000*rsf_tab_h(wn,iz_c,is_h,iv_c, albind) +
           w001*rsf_tab_h(wn,iz_c,is_h,iv_c, ialp1)  +
           w010*rsf_tab_h(wn,iz_c,is_h,ivp1, albind) +
@@ -576,17 +580,17 @@ TEST_CASE("jlong", "mo_photo") {
     auto psum_u = calc_psum(pind - 1, ratindu, v3ratu);
     for (int wn = 0; wn < test_nw; ++wn)
       rsf_ref(wn, kk) =
-          (psum_l[wn] + wght1 * (psum_u[wn] - psum_l[wn])) * etfphot_h(wn);
+          (psum_l.v[wn] + wght1 * (psum_u.v[wn] - psum_l.v[wn])) * etfphot_h(wn);
   }
 
   // Step 2: compute j_long_ref on host
   View2DHost j_long_ref("j_long_ref", test_numj, pver);
   for (int kk = 0; kk < pver; ++kk) {
-    const int t_index =
-        std::min(201, std::max((int)(temper_host(kk) - 148.5), 1)) - 1;
+    const int ti0 = (int)(temper_host(kk) - 148.5);
+    const int t_index = (ti0 < 1 ? 1 : (ti0 > 201 ? 201 : ti0)) - 1;
 
     Real ptarget = p_in_host(kk);
-    std::array<Real, test_nw> xswk_row{};
+    Real xswk_row[test_nw] = {};
     if (ptarget >= prs_h(0)) {
       for (int wn = 0; wn < test_nw; ++wn)
         for (int i = 0; i < test_numj; ++i)
@@ -643,9 +647,9 @@ TEST_CASE("jlong", "mo_photo") {
     const auto temper      = atm.temperature;
 
     Kokkos::parallel_for(
-        "jlong_par", ThreadTeamPolicy(1, Kokkos::AUTO),
-        KOKKOS_LAMBDA(const ThreadTeam &team) {
-      mo_photo::jlong(
+        "jlong_par", mam4::ThreadTeamPolicy(1, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
+      mam4::mo_photo::jlong(
           team, test_sza_in, alb_in_d, p_in_d, temper, colo3_in_d,
           xsqy_d, sza_d, del_sza_d, alb_d, press_d, del_p_d, colo3_d,
           o3rat_d, del_alb_d, del_o3rat_d, etfphot_d, rsf_tab_d,
@@ -665,9 +669,9 @@ TEST_CASE("jlong", "mo_photo") {
     for (int k = 0; k < pver; ++k) {
       const Real ref  = j_long_ref(i, k);
       const Real par  = j_par_h(i, k);
-      const Real diff = ref != 0.0
-                            ? std::abs(par - ref) / std::abs(ref)
-                            : std::abs(par);
+      const Real aref2 = ref > 0 ? ref : -ref;
+      const Real adiff2 = (par - ref) > 0 ? (par - ref) : -(par - ref);
+      const Real diff = aref2 != 0.0 ? adiff2 / aref2 : adiff2;
       if (diff > tol) {
         std::ostringstream ss;
         ss << "j_long mismatch reaction=" << i << " k=" << k
@@ -679,3 +683,4 @@ TEST_CASE("jlong", "mo_photo") {
     }
   }
 }
+#endif

--- a/src/tests/mam4_photo_setcol.cpp
+++ b/src/tests/mam4_photo_setcol.cpp
@@ -8,6 +8,9 @@
 
 #include <catch2/catch.hpp>
 #include <ekat_logger.hpp>
+#include <algorithm>
+#include <array>
+#include <random>
 
 // Precision-dependent tolerance traits
 template <typename T> struct PrecisionTolerance;
@@ -122,5 +125,557 @@ TEST_CASE("compute_o3_column_density", "mo_photo") {
       logger.debug(ss.str());
     }
     REQUIRE(diff <= tol);
+  }
+}
+
+// ============================================================================
+// Helpers shared by interpolate_rsf and jlong tests
+// ============================================================================
+
+using namespace mam4;
+
+// Table dimensions — compile-time constants required inside device lambdas.
+constexpr int test_nw       = 4;
+constexpr int test_numj     = 1;
+constexpr int test_nump     = 5;
+constexpr int test_numsza   = 3;
+constexpr int test_numcolo3 = 4;
+constexpr int test_numalb   = 3;
+constexpr int test_nt       = 201;
+constexpr int test_np_xs    = 4;
+constexpr Real test_sza_in  = 30.0; // degrees, well within daylight range
+
+// Build a small PhotoTableData with synthetic monotone lookup arrays.
+static mo_photo::PhotoTableData build_test_photo_table() {
+  using HostView1D = Kokkos::View<Real *, Kokkos::HostSpace>;
+
+  auto photo_table = mo_photo::create_photo_table_data(
+      test_nw, test_nt, test_np_xs, test_numj,
+      test_nump, test_numsza, test_numcolo3, test_numalb);
+
+  std::default_random_engine gen(54321);
+  std::uniform_real_distribution<Real> pos(1e-6, 1.0);
+
+  // sza [degrees]: monotone increasing
+  auto sza_h = Kokkos::create_mirror_view(photo_table.sza);
+  sza_h(0) = 0.0; sza_h(1) = 45.0; sza_h(2) = 88.0;
+  Kokkos::deep_copy(photo_table.sza, sza_h);
+
+  auto del_sza_h = Kokkos::create_mirror_view(photo_table.del_sza);
+  for (int i = 0; i < test_numsza - 1; ++i)
+    del_sza_h(i) = 1.0 / (sza_h(i + 1) - sza_h(i));
+  Kokkos::deep_copy(photo_table.del_sza, del_sza_h);
+
+  // alb: monotone increasing
+  auto alb_h = Kokkos::create_mirror_view(photo_table.alb);
+  alb_h(0) = 0.0; alb_h(1) = 0.3; alb_h(2) = 0.8;
+  Kokkos::deep_copy(photo_table.alb, alb_h);
+
+  auto del_alb_h = Kokkos::create_mirror_view(photo_table.del_alb);
+  for (int i = 0; i < test_numalb - 1; ++i)
+    del_alb_h(i) = 1.0 / (alb_h(i + 1) - alb_h(i));
+  Kokkos::deep_copy(photo_table.del_alb, del_alb_h);
+
+  // press [hPa]: monotone decreasing (surface first)
+  auto press_h = Kokkos::create_mirror_view(photo_table.press);
+  press_h(0) = 1000.0; press_h(1) = 500.0; press_h(2) = 100.0;
+  press_h(3) =   50.0; press_h(4) =  10.0;
+  Kokkos::deep_copy(photo_table.press, press_h);
+
+  auto del_p_h = Kokkos::create_mirror_view(photo_table.del_p);
+  for (int i = 0; i < test_nump - 1; ++i)
+    del_p_h(i) = 1.0 / (press_h(i) - press_h(i + 1));
+  Kokkos::deep_copy(photo_table.del_p, del_p_h);
+
+  // colo3: decreasing with altitude
+  auto colo3_h = Kokkos::create_mirror_view(photo_table.colo3);
+  colo3_h(0) = 5e17; colo3_h(1) = 4e17; colo3_h(2) = 3e17;
+  colo3_h(3) = 2e17; colo3_h(4) = 1e17;
+  Kokkos::deep_copy(photo_table.colo3, colo3_h);
+
+  // o3rat: monotone increasing
+  auto o3rat_h = Kokkos::create_mirror_view(photo_table.o3rat);
+  o3rat_h(0) = 0.5; o3rat_h(1) = 1.0; o3rat_h(2) = 1.5; o3rat_h(3) = 2.0;
+  Kokkos::deep_copy(photo_table.o3rat, o3rat_h);
+
+  auto del_o3rat_h = Kokkos::create_mirror_view(photo_table.del_o3rat);
+  for (int i = 0; i < test_numcolo3 - 1; ++i)
+    del_o3rat_h(i) = 1.0 / (o3rat_h(i + 1) - o3rat_h(i));
+  Kokkos::deep_copy(photo_table.del_o3rat, del_o3rat_h);
+
+  // etfphot: positive random, size nw
+  auto etfphot_h = Kokkos::create_mirror_view(photo_table.etfphot);
+  for (int w = 0; w < test_nw; ++w)
+    etfphot_h(w) = 1e13 * (0.8 + pos(gen));
+  Kokkos::deep_copy(photo_table.etfphot, etfphot_h);
+
+  // rsf_tab(nw, nump, numsza, numcolo3, numalb): random positive
+  auto rsf_tab_h = Kokkos::create_mirror_view(photo_table.rsf_tab);
+  for (int w  = 0; w  < test_nw;       ++w)
+  for (int ip = 0; ip < test_nump;     ++ip)
+  for (int is = 0; is < test_numsza;   ++is)
+  for (int iv = 0; iv < test_numcolo3; ++iv)
+  for (int ia = 0; ia < test_numalb;   ++ia)
+    rsf_tab_h(w, ip, is, iv, ia) = pos(gen);
+  Kokkos::deep_copy(photo_table.rsf_tab, rsf_tab_h);
+
+  // prs [hPa]: monotone decreasing
+  auto prs_h = Kokkos::create_mirror_view(photo_table.prs);
+  prs_h(0) = 500.0; prs_h(1) = 100.0; prs_h(2) = 10.0; prs_h(3) = 1.0;
+  Kokkos::deep_copy(photo_table.prs, prs_h);
+
+  auto dprs_h = Kokkos::create_mirror_view(photo_table.dprs);
+  for (int i = 0; i < test_np_xs - 1; ++i)
+    dprs_h(i) = 1.0 / (prs_h(i) - prs_h(i + 1));
+  Kokkos::deep_copy(photo_table.dprs, dprs_h);
+
+  auto pam_h = Kokkos::create_mirror_view(photo_table.pht_alias_mult_1);
+  pam_h(0) = 1.0; pam_h(1) = 0.0;
+  Kokkos::deep_copy(photo_table.pht_alias_mult_1, pam_h);
+
+  auto li_h = Kokkos::create_mirror_view(photo_table.lng_indexer);
+  li_h(0) = 0;
+  Kokkos::deep_copy(photo_table.lng_indexer, li_h);
+
+  // xsqy(numj, nw, nt, np_xs): random positive
+  auto xsqy_h = Kokkos::create_mirror_view(photo_table.xsqy);
+  for (int j  = 0; j  < test_numj;  ++j)
+  for (int w  = 0; w  < test_nw;    ++w)
+  for (int it = 0; it < test_nt;    ++it)
+  for (int ip = 0; ip < test_np_xs; ++ip)
+    xsqy_h(j, w, it, ip) = pos(gen);
+  Kokkos::deep_copy(photo_table.xsqy, xsqy_h);
+
+  return photo_table;
+}
+
+// ============================================================================
+// Test: interpolate_rsf — host serial reference vs parallel implementation
+// ============================================================================
+TEST_CASE("interpolate_rsf", "mo_photo") {
+  ekat::Comm comm;
+  ekat::logger::Logger<> logger("interpolate_rsf tests",
+                                ekat::logger::LogLevel::debug, comm);
+
+  constexpr int pver     = nlev;
+  constexpr Real Pa2mb   = 1e-2;
+  constexpr Real tol     = 0.0;//PrecisionTolerance<Real>::tol;
+
+  auto photo_table = build_test_photo_table();
+
+  Atmosphere atm =
+      init_atm_const_tv_lapse_rate(pver, 1000.0, 300.0, 0.01, 0.015, 7.5e-4);
+
+  using View1D     = mo_photo::View1D;
+  using View2D     = mo_photo::View2D;
+  using View1DHost = Kokkos::View<Real *, Kokkos::HostSpace>;
+  using View2DHost = Kokkos::View<Real **, Kokkos::HostSpace>;
+
+  // Build alb_in, p_in, colo3_in inputs
+  View1DHost alb_in_host("alb_in_h", pver);
+  View1DHost p_in_host("p_in_h", pver);
+  View1DHost colo3_in_host("colo3_in_h", pver);
+  auto pressure_host = Kokkos::create_mirror_view(atm.pressure);
+  Kokkos::deep_copy(pressure_host, atm.pressure);
+  for (int k = 0; k < pver; ++k) {
+    alb_in_host(k)   = 0.15;
+    p_in_host(k)     = pressure_host(k) * Pa2mb;
+    colo3_in_host(k) = 3e17;
+  }
+  View1D alb_in_d("alb_in", pver);
+  View1D p_in_d("p_in", pver);
+  View1D colo3_in_d("colo3_in", pver);
+  Kokkos::deep_copy(alb_in_d, alb_in_host);
+  Kokkos::deep_copy(p_in_d,   p_in_host);
+  Kokkos::deep_copy(colo3_in_d, colo3_in_host);
+
+  // Mirror table arrays onto host for serial reference
+  auto sza_h       = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.sza);
+  auto del_sza_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_sza);
+  auto alb_h       = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.alb);
+  auto press_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.press);
+  auto del_p_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_p);
+  auto colo3_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.colo3);
+  auto o3rat_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.o3rat);
+  auto del_alb_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_alb);
+  auto del_o3rat_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_o3rat);
+  auto etfphot_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.etfphot);
+  auto rsf_tab_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.rsf_tab);
+
+  // helper: find_index on host
+  auto find_idx_h = [](const auto &arr, int len, Real val) {
+    int idx = 0;
+    for (int ii = 0; ii < len; ++ii) {
+      if (arr(ii) > val) {
+        idx = std::max(std::min(ii, len - 1) - 1, 0);
+        break;
+      }
+    }
+    return idx;
+  };
+  auto bound = [](Real lo, Real hi, Real v) {
+    return v < lo ? lo : (v > hi ? hi : v);
+  };
+
+  // ===== SERIAL REFERENCE =====
+  View2DHost rsf_ref("rsf_ref", test_nw, pver);
+
+  // find zenith angle index and dels[0] — same for all levels
+  int is_h = find_idx_h(sza_h, test_numsza, test_sza_in);
+  Real dels0 = bound(0.0, 1.0, (test_sza_in - sza_h(is_h)) * del_sza_h(is_h));
+  Real wrk0  = 1.0 - dels0;
+
+  for (int kk = 0; kk < pver; ++kk) {
+    int albind = find_idx_h(alb_h, test_numalb, alb_in_host(kk));
+
+    int pind = 0;
+    Real wght1 = 0;
+    if (p_in_host(kk) > press_h(0)) {
+      pind = 1; wght1 = 1.0;
+    } else if (p_in_host(kk) <= press_h(test_nump - 1)) {
+      pind = test_nump - 1; wght1 = 0.0;
+    } else {
+      int iz = 1;
+      for (; iz < test_nump; ++iz)
+        if (press_h(iz) < p_in_host(kk)) break;
+      iz    = std::min(iz, test_nump - 1);
+      pind  = std::max(iz, 1);
+      wght1 = bound(0.0, 1.0, (p_in_host(kk) - press_h(pind)) * del_p_h(pind - 1));
+    }
+
+    Real v3ratu = colo3_in_host(kk) / colo3_h(pind - 1);
+    int ratindu = find_idx_h(o3rat_h, test_numcolo3, v3ratu);
+
+    Real v3ratl; int ratindl;
+    if (colo3_h(pind) != 0.0) {
+      v3ratl  = colo3_in_host(kk) / colo3_h(pind);
+      ratindl = find_idx_h(o3rat_h, test_numcolo3, v3ratl);
+    } else {
+      ratindl = ratindu;
+      v3ratl  = o3rat_h(ratindu);
+    }
+
+    Real dels2 = bound(0.0, 1.0, (alb_in_host(kk) - alb_h(albind)) * del_alb_h(albind));
+
+    // calc_sum_wght for psum_l
+    auto calc_psum = [&](int iz_c, int iv_c, Real v3rat) {
+      Real dels1 = bound(0.0, 1.0, (v3rat - o3rat_h(iv_c)) * del_o3rat_h(iv_c));
+      int is_c = is_h, isp1 = is_c + 1, ivp1 = iv_c + 1, ialp1 = albind + 1;
+      Real wk = (1.0 - dels1) * (1.0 - dels2);
+      Real w000 = wrk0 * wk,  w100 = dels0 * wk;
+      wk = (1.0 - dels1) * dels2;
+      Real w001 = wrk0 * wk,  w101 = dels0 * wk;
+      wk = dels1 * (1.0 - dels2);
+      Real w010 = wrk0 * wk,  w110 = dels0 * wk;
+      wk = dels1 * dels2;
+      Real w011 = wrk0 * wk,  w111 = dels0 * wk;
+      std::array<Real, test_nw> psum{};
+      for (int wn = 0; wn < test_nw; ++wn)
+        psum[wn] =
+          w000 * rsf_tab_h(wn, iz_c, is_c, iv_c,  albind)  +
+          w001 * rsf_tab_h(wn, iz_c, is_c, iv_c,  ialp1)   +
+          w010 * rsf_tab_h(wn, iz_c, is_c, ivp1,  albind)  +
+          w011 * rsf_tab_h(wn, iz_c, is_c, ivp1,  ialp1)   +
+          w100 * rsf_tab_h(wn, iz_c, isp1, iv_c,  albind)  +
+          w101 * rsf_tab_h(wn, iz_c, isp1, iv_c,  ialp1)   +
+          w110 * rsf_tab_h(wn, iz_c, isp1, ivp1, albind)   +
+          w111 * rsf_tab_h(wn, iz_c, isp1, ivp1, ialp1);
+      return psum;
+    };
+    auto psum_l = calc_psum(pind,     ratindl, v3ratl);
+    auto psum_u = calc_psum(pind - 1, ratindu, v3ratu);
+
+    for (int wn = 0; wn < test_nw; ++wn)
+      rsf_ref(wn, kk) =
+          (psum_l[wn] + wght1 * (psum_u[wn] - psum_l[wn])) * etfphot_h(wn);
+  }
+
+  // ===== PARALLEL IMPLEMENTATION =====
+  View2D rsf_par("rsf_par", test_nw, pver);
+  {
+    const auto sza_d       = photo_table.sza;
+    const auto del_sza_d   = photo_table.del_sza;
+    const auto alb_d       = photo_table.alb;
+    const auto press_d     = photo_table.press;
+    const auto del_p_d     = photo_table.del_p;
+    const auto colo3_d     = photo_table.colo3;
+    const auto o3rat_d     = photo_table.o3rat;
+    const auto del_alb_d   = photo_table.del_alb;
+    const auto del_o3rat_d = photo_table.del_o3rat;
+    const auto etfphot_d   = photo_table.etfphot;
+    const auto rsf_tab_d   = photo_table.rsf_tab;
+    mo_photo::View2D psum_l_d("psum_l", pver, test_nw);
+    mo_photo::View2D psum_u_d("psum_u", pver, test_nw);
+
+    Kokkos::parallel_for(
+        "interpolate_rsf_par", ThreadTeamPolicy(1, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const ThreadTeam &team) {
+      mo_photo::interpolate_rsf(
+          team, alb_in_d, test_sza_in, p_in_d, colo3_in_d, nlev,
+          sza_d, del_sza_d, alb_d, press_d, del_p_d, colo3_d,
+          o3rat_d, del_alb_d, del_o3rat_d, etfphot_d, rsf_tab_d,
+          test_nw, test_nump, test_numsza, test_numcolo3, test_numalb,
+          rsf_par, psum_l_d, psum_u_d);
+    });
+    Kokkos::fence();
+  }
+
+  // ===== COMPARE =====
+  auto rsf_par_h = Kokkos::create_mirror_view(rsf_par);
+  Kokkos::deep_copy(rsf_par_h, rsf_par);
+  for (int wn = 0; wn < test_nw; ++wn) {
+    for (int k = 0; k < pver; ++k) {
+      const Real ref = rsf_ref(wn, k);
+      const Real par = rsf_par_h(wn, k);
+      const Real diff = ref != 0.0
+                            ? std::abs(par - ref) / std::abs(ref)
+                            : std::abs(par);
+      if (diff > tol) {
+        std::ostringstream ss;
+        ss << "RSF mismatch wn=" << wn << " k=" << k
+           << " parallel=" << par << " serial=" << ref
+           << " diff=" << diff;
+        logger.debug(ss.str());
+      }
+      REQUIRE(diff <= tol);
+    }
+  }
+}
+
+// ============================================================================
+// Test: jlong — host serial reference vs parallel implementation
+// ============================================================================
+TEST_CASE("jlong", "mo_photo") {
+  ekat::Comm comm;
+  ekat::logger::Logger<> logger("jlong tests",
+                                ekat::logger::LogLevel::debug, comm);
+
+  constexpr int pver   = nlev;
+  constexpr Real Pa2mb = 1e-2;
+  constexpr Real tol   = 0.0;//PrecisionTolerance<Real>::tol;
+
+  auto photo_table = build_test_photo_table();
+
+  Atmosphere atm =
+      init_atm_const_tv_lapse_rate(pver, 1000.0, 300.0, 0.01, 0.015, 7.5e-4);
+
+  using View1D     = mo_photo::View1D;
+  using View2D     = mo_photo::View2D;
+  using View3D     = mo_photo::View3D;
+  using View1DHost = Kokkos::View<Real *, Kokkos::HostSpace>;
+  using View2DHost = Kokkos::View<Real **, Kokkos::HostSpace>;
+
+  View1DHost alb_in_host("alb_in_h", pver);
+  View1DHost p_in_host("p_in_h", pver);
+  View1DHost colo3_in_host("colo3_in_h", pver);
+  auto pressure_host = Kokkos::create_mirror_view(atm.pressure);
+  Kokkos::deep_copy(pressure_host, atm.pressure);
+  auto temper_host = Kokkos::create_mirror_view(atm.temperature);
+  Kokkos::deep_copy(temper_host, atm.temperature);
+  for (int k = 0; k < pver; ++k) {
+    alb_in_host(k)   = 0.15;
+    p_in_host(k)     = pressure_host(k) * Pa2mb;
+    colo3_in_host(k) = 3e17;
+  }
+  View1D alb_in_d("alb_in", pver);
+  View1D p_in_d("p_in", pver);
+  View1D colo3_in_d("colo3_in", pver);
+  Kokkos::deep_copy(alb_in_d,   alb_in_host);
+  Kokkos::deep_copy(p_in_d,     p_in_host);
+  Kokkos::deep_copy(colo3_in_d, colo3_in_host);
+
+  // Mirror table onto host
+  auto sza_h       = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.sza);
+  auto del_sza_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_sza);
+  auto alb_h       = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.alb);
+  auto press_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.press);
+  auto del_p_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_p);
+  auto colo3_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.colo3);
+  auto o3rat_h     = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.o3rat);
+  auto del_alb_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_alb);
+  auto del_o3rat_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.del_o3rat);
+  auto etfphot_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.etfphot);
+  auto rsf_tab_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.rsf_tab);
+  auto xsqy_h      = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.xsqy);
+  auto prs_h       = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.prs);
+  auto dprs_h      = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace{}, photo_table.dprs);
+
+  auto find_idx_h = [](const auto &arr, int len, Real val) {
+    int idx = 0;
+    for (int ii = 0; ii < len; ++ii) {
+      if (arr(ii) > val) {
+        idx = std::max(std::min(ii, len - 1) - 1, 0);
+        break;
+      }
+    }
+    return idx;
+  };
+  auto bound = [](Real lo, Real hi, Real v) {
+    return v < lo ? lo : (v > hi ? hi : v);
+  };
+
+  // ===== SERIAL REFERENCE =====
+  // Step 1: compute rsf_ref using same logic as interpolate_rsf
+  View2DHost rsf_ref("rsf_ref", test_nw, pver);
+  int is_h  = find_idx_h(sza_h, test_numsza, test_sza_in);
+  Real dels0 = bound(0.0, 1.0, (test_sza_in - sza_h(is_h)) * del_sza_h(is_h));
+  Real wrk0  = 1.0 - dels0;
+
+  for (int kk = 0; kk < pver; ++kk) {
+    int albind = find_idx_h(alb_h, test_numalb, alb_in_host(kk));
+    int pind = 0; Real wght1 = 0;
+    if (p_in_host(kk) > press_h(0)) {
+      pind = 1; wght1 = 1.0;
+    } else if (p_in_host(kk) <= press_h(test_nump - 1)) {
+      pind = test_nump - 1; wght1 = 0.0;
+    } else {
+      int iz = 1;
+      for (; iz < test_nump; ++iz)
+        if (press_h(iz) < p_in_host(kk)) break;
+      iz    = std::min(iz, test_nump - 1);
+      pind  = std::max(iz, 1);
+      wght1 = bound(0.0, 1.0, (p_in_host(kk) - press_h(pind)) * del_p_h(pind - 1));
+    }
+    Real v3ratu = colo3_in_host(kk) / colo3_h(pind - 1);
+    int ratindu = find_idx_h(o3rat_h, test_numcolo3, v3ratu);
+    Real v3ratl; int ratindl;
+    if (colo3_h(pind) != 0.0) {
+      v3ratl  = colo3_in_host(kk) / colo3_h(pind);
+      ratindl = find_idx_h(o3rat_h, test_numcolo3, v3ratl);
+    } else {
+      ratindl = ratindu; v3ratl = o3rat_h(ratindu);
+    }
+    Real dels2 = bound(0.0, 1.0, (alb_in_host(kk) - alb_h(albind)) * del_alb_h(albind));
+    int ialp1 = albind + 1;
+
+    auto calc_psum = [&](int iz_c, int iv_c, Real v3rat) {
+      Real dels1 = bound(0.0, 1.0, (v3rat - o3rat_h(iv_c)) * del_o3rat_h(iv_c));
+      int isp1 = is_h + 1, ivp1 = iv_c + 1;
+      Real wk = (1.0 - dels1) * (1.0 - dels2);
+      Real w000 = wrk0*wk, w100 = dels0*wk;
+      wk = (1.0 - dels1) * dels2;
+      Real w001 = wrk0*wk, w101 = dels0*wk;
+      wk = dels1 * (1.0 - dels2);
+      Real w010 = wrk0*wk, w110 = dels0*wk;
+      wk = dels1 * dels2;
+      Real w011 = wrk0*wk, w111 = dels0*wk;
+      std::array<Real, test_nw> ps{};
+      for (int wn = 0; wn < test_nw; ++wn)
+        ps[wn] =
+          w000*rsf_tab_h(wn,iz_c,is_h,iv_c, albind) +
+          w001*rsf_tab_h(wn,iz_c,is_h,iv_c, ialp1)  +
+          w010*rsf_tab_h(wn,iz_c,is_h,ivp1, albind) +
+          w011*rsf_tab_h(wn,iz_c,is_h,ivp1, ialp1)  +
+          w100*rsf_tab_h(wn,iz_c,isp1,iv_c, albind) +
+          w101*rsf_tab_h(wn,iz_c,isp1,iv_c, ialp1)  +
+          w110*rsf_tab_h(wn,iz_c,isp1,ivp1,albind)  +
+          w111*rsf_tab_h(wn,iz_c,isp1,ivp1,ialp1);
+      return ps;
+    };
+    auto psum_l = calc_psum(pind,     ratindl, v3ratl);
+    auto psum_u = calc_psum(pind - 1, ratindu, v3ratu);
+    for (int wn = 0; wn < test_nw; ++wn)
+      rsf_ref(wn, kk) =
+          (psum_l[wn] + wght1 * (psum_u[wn] - psum_l[wn])) * etfphot_h(wn);
+  }
+
+  // Step 2: compute j_long_ref on host
+  View2DHost j_long_ref("j_long_ref", test_numj, pver);
+  for (int kk = 0; kk < pver; ++kk) {
+    const int t_index =
+        std::min(201, std::max((int)(temper_host(kk) - 148.5), 1)) - 1;
+
+    Real ptarget = p_in_host(kk);
+    std::array<Real, test_nw> xswk_row{};
+    if (ptarget >= prs_h(0)) {
+      for (int wn = 0; wn < test_nw; ++wn)
+        for (int i = 0; i < test_numj; ++i)
+          xswk_row[wn] = xsqy_h(i, wn, t_index, 0);
+    } else if (ptarget <= prs_h(test_np_xs - 1)) {
+      for (int wn = 0; wn < test_nw; ++wn)
+        for (int i = 0; i < test_numj; ++i)
+          xswk_row[wn] = xsqy_h(i, wn, t_index, test_np_xs - 1);
+    } else {
+      Real delp = 0; int pndx = 0;
+      for (int km = 1; km < test_np_xs; ++km) {
+        if (ptarget >= prs_h(km)) {
+          pndx = km - 1;
+          delp = (prs_h(pndx) - ptarget) * dprs_h(pndx);
+          break;
+        }
+      }
+      for (int wn = 0; wn < test_nw; ++wn)
+        for (int i = 0; i < test_numj; ++i)
+          xswk_row[wn] = xsqy_h(i, wn, t_index, pndx) +
+              delp * (xsqy_h(i, wn, t_index, pndx + 1) -
+                      xsqy_h(i, wn, t_index, pndx));
+    }
+    for (int i = 0; i < test_numj; ++i) {
+      Real suma = 0;
+      for (int wn = 0; wn < test_nw; ++wn)
+        suma += xswk_row[wn] * rsf_ref(wn, kk);
+      j_long_ref(i, kk) = suma;
+    }
+  }
+
+  // ===== PARALLEL IMPLEMENTATION =====
+  View2D j_long_par("j_long_par", test_numj, pver);
+  {
+    View2D rsf_work("rsf_work", test_nw, pver);
+    View3D xswk_d("xswk", pver, test_numj, test_nw);
+    View2D psum_l_d("psum_l", pver, test_nw);
+    View2D psum_u_d("psum_u", pver, test_nw);
+
+    const auto sza_d       = photo_table.sza;
+    const auto del_sza_d   = photo_table.del_sza;
+    const auto alb_d       = photo_table.alb;
+    const auto press_d     = photo_table.press;
+    const auto del_p_d     = photo_table.del_p;
+    const auto colo3_d     = photo_table.colo3;
+    const auto o3rat_d     = photo_table.o3rat;
+    const auto del_alb_d   = photo_table.del_alb;
+    const auto del_o3rat_d = photo_table.del_o3rat;
+    const auto etfphot_d   = photo_table.etfphot;
+    const auto rsf_tab_d   = photo_table.rsf_tab;
+    const auto xsqy_d      = photo_table.xsqy;
+    const auto prs_d       = photo_table.prs;
+    const auto dprs_d      = photo_table.dprs;
+    const auto temper      = atm.temperature;
+
+    Kokkos::parallel_for(
+        "jlong_par", ThreadTeamPolicy(1, Kokkos::AUTO),
+        KOKKOS_LAMBDA(const ThreadTeam &team) {
+      mo_photo::jlong(
+          team, test_sza_in, alb_in_d, p_in_d, temper, colo3_in_d,
+          xsqy_d, sza_d, del_sza_d, alb_d, press_d, del_p_d, colo3_d,
+          o3rat_d, del_alb_d, del_o3rat_d, etfphot_d, rsf_tab_d,
+          prs_d, dprs_d,
+          test_nw, test_nump, test_numsza, test_numcolo3, test_numalb,
+          test_np_xs, test_numj,
+          j_long_par,
+          rsf_work, xswk_d, psum_l_d, psum_u_d);
+    });
+    Kokkos::fence();
+  }
+
+  // ===== COMPARE =====
+  auto j_par_h = Kokkos::create_mirror_view(j_long_par);
+  Kokkos::deep_copy(j_par_h, j_long_par);
+  for (int i = 0; i < test_numj; ++i) {
+    for (int k = 0; k < pver; ++k) {
+      const Real ref  = j_long_ref(i, k);
+      const Real par  = j_par_h(i, k);
+      const Real diff = ref != 0.0
+                            ? std::abs(par - ref) / std::abs(ref)
+                            : std::abs(par);
+      if (diff > tol) {
+        std::ostringstream ss;
+        ss << "j_long mismatch reaction=" << i << " k=" << k
+           << " parallel=" << par << " serial=" << ref
+           << " diff=" << diff;
+        logger.debug(ss.str());
+      }
+      REQUIRE(diff <= tol);
+    }
   }
 }

--- a/src/tests/mam4_photo_setcol.cpp
+++ b/src/tests/mam4_photo_setcol.cpp
@@ -146,7 +146,6 @@ constexpr Real test_sza_in = 30.0; // degrees, well within daylight range
 
 // Build a small PhotoTableData with synthetic monotone lookup arrays.
 static mam4::mo_photo::PhotoTableData build_test_photo_table() {
-  using HostView1D = Kokkos::View<Real *, Kokkos::HostSpace>;
 
   auto photo_table = mam4::mo_photo::create_photo_table_data(
       test_nw, test_nt, test_np_xs, test_numj, test_nump, test_numsza,

--- a/src/validation/mo_photo/calc_sum_wght.cpp
+++ b/src/validation/mo_photo/calc_sum_wght.cpp
@@ -39,7 +39,7 @@ void calc_sum_wght(Ensemble *ensemble) {
     auto dels_host = View1DHost((Real *)dels_db.data(), 3);
     Kokkos::deep_copy(dels, dels_host);
 
-    const auto psum = View1D("psum", nw);
+    const auto psum = View2D("psum", 1, nw);
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
@@ -48,12 +48,14 @@ void calc_sum_wght(Ensemble *ensemble) {
                         iz, is, iv, ial,   // in
                         rsf_tab,           // in
                         nw,                //
-                        psum);
+                        psum, 0);          // psum(row=0,:)
         });
     const Real zero = 0;
     std::vector<Real> psum_db(nw, zero);
-    auto psum_host = View1DHost((Real *)psum_db.data(), nw);
+    auto psum_host = Kokkos::create_mirror_view(psum);
     Kokkos::deep_copy(psum_host, psum);
+    for (int w = 0; w < nw; ++w)
+      psum_db[w] = psum_host(0, w);
 
     output.set("psum", psum_db);
   });

--- a/src/validation/mo_photo/calc_sum_wght.cpp
+++ b/src/validation/mo_photo/calc_sum_wght.cpp
@@ -39,7 +39,7 @@ void calc_sum_wght(Ensemble *ensemble) {
     auto dels_host = View1DHost((Real *)dels_db.data(), 3);
     Kokkos::deep_copy(dels, dels_host);
 
-    const auto psum = View2D("psum", 1, nw);
+    const auto psum = View1D("psum", nw);
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(
@@ -48,14 +48,14 @@ void calc_sum_wght(Ensemble *ensemble) {
                         iz, is, iv, ial,   // in
                         rsf_tab,           // in
                         nw,                //
-                        psum, 0);          // psum(row=0,:)
+                        psum);             // psum
         });
     const Real zero = 0;
     std::vector<Real> psum_db(nw, zero);
     auto psum_host = Kokkos::create_mirror_view(psum);
     Kokkos::deep_copy(psum_host, psum);
     for (int w = 0; w < nw; ++w)
-      psum_db[w] = psum_host(0, w);
+      psum_db[w] = psum_host(w);
 
     output.set("psum", psum_db);
   });

--- a/src/validation/mo_photo/interpolate_rsf.cpp
+++ b/src/validation/mo_photo/interpolate_rsf.cpp
@@ -100,8 +100,8 @@ void interpolate_rsf(Ensemble *ensemble) {
     // const auto  = View1D("", );
     // Kokkos::deep_copy(, );
 
-    auto psum_l = View1D("psum_l", nw);
-    auto psum_u = View1D("psum_u", nw);
+    View2D psum_l("psum_l", pver, nw);
+    View2D psum_u("psum_u", pver, nw);
 
     View2D rsf("rsf", nw, pver);
     auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
@@ -113,7 +113,7 @@ void interpolate_rsf(Ensemble *ensemble) {
                           del_alb, del_o3rat, etfphot, rsf_tab, nw, nump,
                           numsza, numcolo3, numalb,
                           rsf, // out
-                          // work array
+                          // per-level work arrays
                           psum_l, psum_u);
         });
 

--- a/src/validation/mo_photo/jlong.cpp
+++ b/src/validation/mo_photo/jlong.cpp
@@ -123,15 +123,15 @@ void jlong(Ensemble *ensemble) {
 
     View2D rsf("rsf", nw, pver);
     View4D xsqy("xsqy", numj, nw, nt, np_xs);
-    View2D xswk("xswk", numj, nw);
+    View3D xswk("xswk", pver, numj, nw);
 
     const Real values_xsqy = synthetic_values_xsqy[0];
     Kokkos::deep_copy(xsqy, values_xsqy);
 
     View2D j_long("j_long", numj, pver);
 
-    auto psum_l = View1D("psum_l", nw);
-    auto psum_u = View1D("psum_u", nw);
+    View2D psum_l("psum_l", pver, nw);
+    View2D psum_u("psum_u", pver, nw);
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
     Kokkos::parallel_for(

--- a/src/validation/mo_photo/table_photo.cpp
+++ b/src/validation/mo_photo/table_photo.cpp
@@ -170,8 +170,8 @@ void table_photo(Ensemble *ensemble) {
               Kokkos::subview(j_long, i, Kokkos::ALL(), Kokkos::ALL());
           work_arrays.rsf =
               Kokkos::subview(rsf, i, Kokkos::ALL(), Kokkos::ALL());
-          work_arrays.xswk =
-              Kokkos::subview(xswk, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          work_arrays.xswk = Kokkos::subview(xswk, i, Kokkos::ALL(),
+                                             Kokkos::ALL(), Kokkos::ALL());
           work_arrays.psum_l =
               Kokkos::subview(psum_l, i, Kokkos::ALL(), Kokkos::ALL());
           work_arrays.psum_u =

--- a/src/validation/mo_photo/table_photo.cpp
+++ b/src/validation/mo_photo/table_photo.cpp
@@ -92,15 +92,15 @@ void table_photo(Ensemble *ensemble) {
     Kokkos::deep_copy(table_data.dprs, dprs_host);
 
     View3D rsf("rsf", ncol, table_data.nw, pver);
-    View3D xswk("xswk", ncol, table_data.numj, table_data.nw);
+    View4D xswk("xswk", ncol, pver, table_data.numj, table_data.nw);
 
     const Real values_xsqy = synthetic_values_xsqy[0];
     Kokkos::deep_copy(table_data.xsqy, values_xsqy);
 
     View3D j_long("j_long", ncol, table_data.numj, pver);
 
-    auto psum_l = View2D("psum_l", ncol, table_data.nw);
-    auto psum_u = View2D("psum_u", ncol, table_data.nw);
+    View3D psum_l("psum_l", ncol, pver, table_data.nw);
+    View3D psum_u("psum_u", ncol, pver, table_data.nw);
 
     auto pht_alias_mult_1_db = input.get_array("pht_alias_mult");
     auto pht_alias_mult_1_host =
@@ -171,9 +171,11 @@ void table_photo(Ensemble *ensemble) {
           work_arrays.rsf =
               Kokkos::subview(rsf, i, Kokkos::ALL(), Kokkos::ALL());
           work_arrays.xswk =
-              Kokkos::subview(xswk, i, Kokkos::ALL(), Kokkos::ALL());
-          work_arrays.psum_l = Kokkos::subview(psum_l, i, Kokkos::ALL());
-          work_arrays.psum_u = Kokkos::subview(psum_u, i, Kokkos::ALL());
+              Kokkos::subview(xswk, i, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+          work_arrays.psum_l =
+              Kokkos::subview(psum_l, i, Kokkos::ALL(), Kokkos::ALL());
+          work_arrays.psum_u =
+              Kokkos::subview(psum_u, i, Kokkos::ALL(), Kokkos::ALL());
 
           work_arrays.parg = Kokkos::subview(parg, i, Kokkos::ALL());
           work_arrays.eff_alb = Kokkos::subview(eff_alb, i, Kokkos::ALL());


### PR DESCRIPTION
It removes two single loops from the photo table computation.
Before PR
<img width="821" height="138" alt="image" src="https://github.com/user-attachments/assets/cd52115c-e296-4060-9b13-9a56b8af08a3" />
After PR
<img width="821" height="137" alt="image" src="https://github.com/user-attachments/assets/96a5a142-ba60-40d3-88b1-dee861bb8c32" />

It closes https://github.com/eagles-project/mam4xx/issues/513 