### PR TITLE
Rewrite gas_washout function to eliminate Kokkos::single. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ if (MAM4XX_ENABLE_SKYWALKER)
   FetchContent_Declare(
     mam_x_validation
     GIT_REPOSITORY https://github.com/eagles-project/mam_x_validation.git
-    GIT_TAG        9c57194af6d69a53102e0b2e4e2384fe8f91791b # 2026/04/23
+    GIT_TAG        8abea036f30f1d4c3005b205169bd2d4c0a701c3 # 2026/04/23
   )
   list(APPEND mam4xx_tpls mam_x_validation)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,7 @@ if (MAM4XX_ENABLE_SKYWALKER)
   FetchContent_Declare(
     mam_x_validation
     GIT_REPOSITORY https://github.com/eagles-project/mam_x_validation.git
-    GIT_TAG        5f471bbaf5245c77d4c892d3d0c444ec9dd93c34  # 2026/03/04
+    GIT_TAG        9c57194af6d69a53102e0b2e4e2384fe8f91791b # 2026/04/23
   )
   list(APPEND mam4xx_tpls mam_x_validation)
 endif()

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -131,30 +131,31 @@ void gas_washout(
     allca[kk] = 0; // pretend allca is a kokkos view.
   });
   for (int k = ktop; k < pver; k++) {
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, ktop, k+1), [&](int kk) {
-      if (rain(kk) != 0.0) { // finding rain cloud
-        const Real xeqca =
-            xgas(k) /
-            (xliq(kk) * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
-            xliq(kk) * avo2;
-        //-----------------------------------------------------------------
-        //       ... calculate ca; inside cloud concentration in  #/cm3(air)
-        //-----------------------------------------------------------------
-        const Real xca = geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) *
-                         xliq(kk) * cm3_2_m3;
+    Kokkos::parallel_for(
+        Kokkos::TeamVectorRange(team, ktop, k + 1), [&](int kk) {
+          if (rain(kk) != 0.0) { // finding rain cloud
+            const Real xeqca =
+                xgas(k) /
+                (xliq(kk) * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
+                xliq(kk) * avo2;
+            //-----------------------------------------------------------------
+            //       ... calculate ca; inside cloud concentration in  #/cm3(air)
+            //-----------------------------------------------------------------
+            const Real xca = geo_fac * xkgm * xgas(k) / (xrm * xum) *
+                             delz_i(k) * xliq(kk) * cm3_2_m3;
 
-        // -----------------------------------------------------------------
-        //       ... if is not saturated (take hno3 as an example)
-        //               hno3(gas)_new = hno3(gas)_old - hno3(h2o)
-        //           otherwise
-        //               hno3(gas)_new = hno3(gas)_old
-        // -----------------------------------------------------------------
-        allca[kk] += xca;
-        if (allca[kk] < xeqca) {
-          xgas(k) = mam4::max(xgas(k) - xca, 0.0);
-        }
-      }
-    });
+            // -----------------------------------------------------------------
+            //       ... if is not saturated (take hno3 as an example)
+            //               hno3(gas)_new = hno3(gas)_old - hno3(h2o)
+            //           otherwise
+            //               hno3(gas)_new = hno3(gas)_old
+            // -----------------------------------------------------------------
+            allca[kk] += xca;
+            if (allca[kk] < xeqca) {
+              xgas(k) = mam4::max(xgas(k) - xca, 0.0);
+            }
+          }
+        });
     team.team_barrier();
   }
 } // end subroutine gas_washout

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -131,7 +131,7 @@ void gas_washout(
     allca[kk] = 0; // pretend allca is a kokkos view.
   });
   for (int k = ktop; k < pver; k++) {
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, k, pver), [&](int kk) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, ktop, k+1), [&](int kk) {
       if (rain(kk) != 0.0) { // finding rain cloud
         const Real xeqca =
             xgas(k) /

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -104,12 +104,10 @@ void calc_precip_rescale(
 //=================================================================================
 KOKKOS_INLINE_FUNCTION
 void gas_washout(
-    const ThreadTeam &team,
-    const int ktop,               
-    const int pver,              
-    const Real xkgm,              // mass flux on rain drop //in
-    const ColumnView xliq,           // liquid rain water content [gm/m^3] // in
-    const ColumnView rain,           
+    const ThreadTeam &team, const int ktop, const int pver,
+    const Real xkgm,       // mass flux on rain drop //in
+    const ColumnView xliq, // liquid rain water content [gm/m^3] // in
+    const ColumnView rain,
     const ColumnView xhen_i,      // henry's law constant
     const ConstColumnView tfld_i, // temperature [K]
     const ColumnView delz_i,      // layer depth about interfaces [cm]  // in
@@ -136,13 +134,14 @@ void gas_washout(
     Kokkos::parallel_for(Kokkos::TeamVectorRange(team, k, pver), [&](int kk) {
       if (rain(kk) != 0.0) { // finding rain cloud
         const Real xeqca =
-            xgas(k) / (xliq(kk) * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
+            xgas(k) /
+            (xliq(kk) * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
             xliq(kk) * avo2;
         //-----------------------------------------------------------------
         //       ... calculate ca; inside cloud concentration in  #/cm3(air)
         //-----------------------------------------------------------------
-        const Real xca =
-            geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq(kk) * cm3_2_m3;
+        const Real xca = geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) *
+                         xliq(kk) * cm3_2_m3;
 
         // -----------------------------------------------------------------
         //       ... if is not saturated (take hno3 as an example)
@@ -386,11 +385,11 @@ void sethet_detail(
   // race condition for xgas2.  Hence the Kokkos::single.
   // calculate gas washout by cloud
   gas_washout(team, ktop, pver, xkgm, xliq, rain, // in
-              xhen_h2o2, tfld, delz,    // in
-              xgas2);                   // inout
-  gas_washout(team, ktop, pver, xkgm, xliq , rain,// in
-              xhen_so2, tfld, delz,     // in
-              xgas3);                   // inout
+              xhen_h2o2, tfld, delz,              // in
+              xgas2);                             // inout
+  gas_washout(team, ktop, pver, xkgm, xliq, rain, // in
+              xhen_so2, tfld, delz,               // in
+              xgas3);                             // inout
   Kokkos::parallel_for(Kokkos::TeamVectorRange(team, ktop, pver), [&](int kk) {
     // gas_washout is odd in that it modifies all of xgas2 and xgas3
     // from level kk to level pver so calling it in parallel is a

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -5,6 +5,7 @@
 #include "gas_chem_mechanism.hpp"
 #include "mam4_constants.hpp"
 #include "mam4_math.hpp"
+#include <ekat_subview_utils.hpp>
 
 namespace mam4 {
 
@@ -111,7 +112,8 @@ void gas_washout(
     const ColumnView xhen_i,      // henry's law constant
     const ConstColumnView tfld_i, // temperature [K]
     const ColumnView delz_i,      // layer depth about interfaces [cm]  // in
-    const ColumnView xgas) {      // gas concentration // inout
+    const ColumnView xgas,        // gas concentration // inout
+    const ColumnView scratch) {
   //------------------------------------------------------------------------
   // calculate gas washout by cloud if not saturated
   //------------------------------------------------------------------------
@@ -126,10 +128,8 @@ void gas_washout(
   //       ... calculate the saturation concentration eqca
   // -----------------------------------------------------------------
   // total of ca between level plev and kk [#/cm3]
-  Real allca[mam4::nlev] = {};
-  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver), [&](int kk) {
-    allca[kk] = 0; // pretend allca is a kokkos view.
-  });
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver),
+                       [&](int kk) { scratch[kk] = 0; });
   for (int k = ktop; k < pver; k++) {
     Kokkos::parallel_for(
         Kokkos::TeamVectorRange(team, ktop, k + 1), [&](int kk) {
@@ -150,8 +150,8 @@ void gas_washout(
             //           otherwise
             //               hno3(gas)_new = hno3(gas)_old
             // -----------------------------------------------------------------
-            allca[kk] += xca;
-            if (allca[kk] < xeqca) {
+            scratch[kk] += xca;
+            if (scratch[kk] < xeqca) {
               xgas(k) = mam4::max(xgas(k) - xca, 0.0);
             }
           }
@@ -238,10 +238,9 @@ void sethet_detail(
     const ColumnView &xhen_h2o2, // henry law constants
     const ColumnView &xhen_hno3, // henry law constants
     const ColumnView &xhen_so2,  // henry law constants
-    const ColumnView tmp_hetrates[gas_pcnst], const int spc_h2o2_ndx,
-    const int spc_so2_ndx, const int h2o2_ndx, const int so2_ndx,
-    const int h2so4_ndx, const int gas_wetdep_cnt, const int wetdep_map[3],
-    const int indexm) {
+    const View2D tmp_hetrates, const int spc_h2o2_ndx, const int spc_so2_ndx,
+    const int h2o2_ndx, const int so2_ndx, const int h2so4_ndx,
+    const int gas_wetdep_cnt, const int wetdep_map[3], const int indexm) {
 
   const int pver = mam4::nlev;
   //-----------------------------------------------------------------------
@@ -301,7 +300,7 @@ void sethet_detail(
   Kokkos::parallel_for(Kokkos::TeamVectorRange(team, local_pver), [&](int kk) {
     for (int mm = 0; mm < gas_pcnst; ++mm) {
       het_rates(kk, mm) = 0.0;
-      tmp_hetrates[mm](kk) = 0.0; // initiate temporary array
+      tmp_hetrates(mm, kk) = 0.0; // initiate temporary array
     }
   });
   team.team_barrier();
@@ -385,12 +384,15 @@ void sethet_detail(
   // from level kk to level pver so calling it in parallel is a
   // race condition for xgas2.  Hence the Kokkos::single.
   // calculate gas washout by cloud
+  View1D scratch_space = ekat::subview(tmp_hetrates, 0);
   gas_washout(team, ktop, pver, xkgm, xliq, rain, // in
               xhen_h2o2, tfld, delz,              // in
-              xgas2);                             // inout
+              xgas2, scratch_space);              // inout
   gas_washout(team, ktop, pver, xkgm, xliq, rain, // in
               xhen_so2, tfld, delz,               // in
-              xgas3);                             // inout
+              xgas3, scratch_space);              // inout
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, local_pver),
+                       [&](int kk) { scratch_space(kk) = 0.0; });
   Kokkos::parallel_for(Kokkos::TeamVectorRange(team, ktop, pver), [&](int kk) {
     // gas_washout is odd in that it modifies all of xgas2 and xgas3
     // from level kk to level pver so calling it in parallel is a
@@ -421,7 +423,7 @@ void sethet_detail(
     } else {
       yh2o2 = large_value_lifetime;
     }
-    tmp_hetrates[1](kk) =
+    tmp_hetrates(1, kk) =
         mam4::max(1.0 / yh2o2, 0.0) * stay; // FIXME: bad constant index
 
     Real yso2 = 0;
@@ -432,7 +434,7 @@ void sethet_detail(
     } else {
       yso2 = large_value_lifetime;
     }
-    tmp_hetrates[2](kk) =
+    tmp_hetrates(2, kk) =
         mam4::max(1.0 / yso2, 0.0) * stay; // FIXME: bad constant index
   });
   team.team_barrier();
@@ -456,7 +458,7 @@ void sethet_detail(
 
       if (h2o2_ndx >= 0) {
         calc_het_rates(satf_h2o2, rain(kk), xhen_h2o2(kk), // in
-                       tmp_hetrates[1](kk), work1, work2,  // in
+                       tmp_hetrates(1, kk), work1, work2,  // in
                        het_rates(kk, h2o2_ndx));           // out
       }
       // if ( prog_modal_aero .and.
@@ -464,13 +466,13 @@ void sethet_detail(
         het_rates(kk, so2_ndx) = het_rates(kk, h2o2_ndx);
       } else if (so2_ndx >= 0) {
         calc_het_rates(satf_so2, rain(kk), xhen_so2(kk),  // in
-                       tmp_hetrates[2](kk), work1, work2, // in
+                       tmp_hetrates(2, kk), work1, work2, // in
                        het_rates(kk, so2_ndx));           // out
       }
 
       if (h2so4_ndx >= 0) {
         calc_het_rates(satf_hno3, rain(kk), xhen_hno3(kk), // in
-                       tmp_hetrates[0](kk), work1, work2,  // in
+                       tmp_hetrates(0, kk), work1, work2,  // in
                        het_rates(kk, h2so4_ndx));          // out
       }
     }
@@ -540,12 +542,8 @@ void sethet(
   work_ptr += nlev;
   const auto xhen_so2 = View1D(work_ptr, nlev);
   work_ptr += nlev;
-
-  ColumnView tmp_hetrates[gas_pcnst];
-  for (int i = 0; i < gas_pcnst; ++i) {
-    tmp_hetrates[i] = ColumnView(work_ptr, nlev);
-    work_ptr += nlev;
-  }
+  View2D tmp_hetrates = View2D(work_ptr, gas_pcnst, nlev);
+  work_ptr += gas_pcnst * nlev;
 
   // BAD CONSTANT
   // FIXME: should we move these indices and map to a config file?

--- a/src/mam4xx/mo_sethet.hpp
+++ b/src/mam4xx/mo_sethet.hpp
@@ -105,9 +105,11 @@ void calc_precip_rescale(
 KOKKOS_INLINE_FUNCTION
 void gas_washout(
     const ThreadTeam &team,
-    const int plev,               // calculate from this level below //in
+    const int ktop,               
+    const int pver,              
     const Real xkgm,              // mass flux on rain drop //in
-    const Real xliq_ik,           // liquid rain water content [gm/m^3] // in
+    const ColumnView xliq,           // liquid rain water content [gm/m^3] // in
+    const ColumnView rain,           
     const ColumnView xhen_i,      // henry's law constant
     const ConstColumnView tfld_i, // temperature [K]
     const ColumnView delz_i,      // layer depth about interfaces [cm]  // in
@@ -126,32 +128,35 @@ void gas_washout(
   //       ... calculate the saturation concentration eqca
   // -----------------------------------------------------------------
   // total of ca between level plev and kk [#/cm3]
-  Real allca = 0.0;
+  Real allca[mam4::nlev] = {};
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, pver), [&](int kk) {
+    allca[kk] = 0; // pretend allca is a kokkos view.
+  });
+  for (int k = ktop; k < pver; k++) {
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, k, pver), [&](int kk) {
+      if (rain(kk) != 0.0) { // finding rain cloud
+        const Real xeqca =
+            xgas(k) / (xliq(kk) * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
+            xliq(kk) * avo2;
+        //-----------------------------------------------------------------
+        //       ... calculate ca; inside cloud concentration in  #/cm3(air)
+        //-----------------------------------------------------------------
+        const Real xca =
+            geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq(kk) * cm3_2_m3;
 
-  // This loop causes problems because plev is the only level this
-  // function should be changing but it changes values in other levels
-  // which prevents gas_washout from running in parallel over all the
-  // levels in a column.
-  for (int k = plev; k < pver; k++) {
-    const Real xeqca =
-        xgas(k) / (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
-        xliq_ik * avo2;
-    //-----------------------------------------------------------------
-    //       ... calculate ca; inside cloud concentration in  #/cm3(air)
-    //-----------------------------------------------------------------
-    const Real xca =
-        geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq_ik * cm3_2_m3;
-
-    // -----------------------------------------------------------------
-    //       ... if is not saturated (take hno3 as an example)
-    //               hno3(gas)_new = hno3(gas)_old - hno3(h2o)
-    //           otherwise
-    //               hno3(gas)_new = hno3(gas)_old
-    // -----------------------------------------------------------------
-    allca += xca;
-    if (allca < xeqca) {
-      xgas(k) = mam4::max(xgas(k) - xca, 0.0);
-    }
+        // -----------------------------------------------------------------
+        //       ... if is not saturated (take hno3 as an example)
+        //               hno3(gas)_new = hno3(gas)_old - hno3(h2o)
+        //           otherwise
+        //               hno3(gas)_new = hno3(gas)_old
+        // -----------------------------------------------------------------
+        allca[kk] += xca;
+        if (allca[kk] < xeqca) {
+          xgas(k) = mam4::max(xgas(k) - xca, 0.0);
+        }
+      }
+    });
+    team.team_barrier();
   }
 } // end subroutine gas_washout
 
@@ -376,58 +381,59 @@ void sethet_detail(
     xgas3(kk) = xso2(kk);
   });
   team.team_barrier();
-  Kokkos::single(Kokkos::PerTeam(team), [=]() {
+  // gas_washout is odd in that it modifies all of xgas2 and xgas3
+  // from level kk to level pver so calling it in parallel is a
+  // race condition for xgas2.  Hence the Kokkos::single.
+  // calculate gas washout by cloud
+  gas_washout(team, ktop, pver, xkgm, xliq, rain, // in
+              xhen_h2o2, tfld, delz,    // in
+              xgas2);                   // inout
+  gas_washout(team, ktop, pver, xkgm, xliq , rain,// in
+              xhen_so2, tfld, delz,     // in
+              xgas3);                   // inout
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, ktop, pver), [&](int kk) {
     // gas_washout is odd in that it modifies all of xgas2 and xgas3
     // from level kk to level pver so calling it in parallel is a
     // race condition for xgas2.  Hence the Kokkos::single.
-    for (int kk = ktop; kk < pver; ++kk) {
-      Real stay =
-          1.0; // fraction of layer traversed by falling drop in timestep delt
-      if (rain(kk) != 0.0) { // finding rain cloud
-        stay = ((zmid(kk) - zsurf) * km2cm) / (xum * delt);
-        stay = mam4::min(stay, 1.0);
-        // calculate gas washout by cloud
-        gas_washout(team, kk, xkgm, xliq(kk), // in
-                    xhen_h2o2, tfld, delz,    // in
-                    xgas2);                   // inout
-        gas_washout(team, kk, xkgm, xliq(kk), // in
-                    xhen_so2, tfld, delz,     // in
-                    xgas3);                   // inout
-      }
-      //-----------------------------------------------------------------
-      //       ... calculate the lifetime of washout (second)
-      //             after all layers washout
-      //             the concentration of hno3 is reduced
-      //             then the lifetime xtt is calculated by
-      //
-      //                  xtt = (xhno3(ini) - xgas1(new))/(dt*xhno3(ini))
-      //                  where dt = passing time (s) in vertical
-      //                             path below the cloud
-      //                        dt = dz(cm)/um(cm/s)
-      //-----------------------------------------------------------------
-      const Real xdtm = delz(kk) / xum; // the traveling time in each dz
-
-      const Real xxx2 = (xh2o2(kk) - xgas2(kk));
-      Real yh2o2 = 0;    // washout lifetime [s]
-      if (xxx2 != 0.0) { // if no washout lifetime = 1.e29
-        yh2o2 = xh2o2(kk) / xxx2 * xdtm;
-      } else {
-        yh2o2 = large_value_lifetime;
-      }
-      tmp_hetrates[1](kk) =
-          mam4::max(1.0 / yh2o2, 0.0) * stay; // FIXME: bad constant index
-
-      Real yso2 = 0;
-      const Real xxx3 =
-          (xso2(kk) - xgas3(kk)); // working variables for h2o2 (2) and so2 (3)
-      if (xxx3 != 0.0) {          // if no washout lifetime = 1.e29
-        yso2 = xso2(kk) / xxx3 * xdtm;
-      } else {
-        yso2 = large_value_lifetime;
-      }
-      tmp_hetrates[2](kk) =
-          mam4::max(1.0 / yso2, 0.0) * stay; // FIXME: bad constant index
+    Real stay =
+        1.0; // fraction of layer traversed by falling drop in timestep delt
+    if (rain(kk) != 0.0) { // finding rain cloud
+      stay = ((zmid(kk) - zsurf) * km2cm) / (xum * delt);
+      stay = mam4::min(stay, 1.0);
     }
+    //-----------------------------------------------------------------
+    //       ... calculate the lifetime of washout (second)
+    //             after all layers washout
+    //             the concentration of hno3 is reduced
+    //             then the lifetime xtt is calculated by
+    //
+    //                  xtt = (xhno3(ini) - xgas1(new))/(dt*xhno3(ini))
+    //                  where dt = passing time (s) in vertical
+    //                             path below the cloud
+    //                        dt = dz(cm)/um(cm/s)
+    //-----------------------------------------------------------------
+    const Real xdtm = delz(kk) / xum; // the traveling time in each dz
+
+    const Real xxx2 = (xh2o2(kk) - xgas2(kk));
+    Real yh2o2 = 0;    // washout lifetime [s]
+    if (xxx2 != 0.0) { // if no washout lifetime = 1.e29
+      yh2o2 = xh2o2(kk) / xxx2 * xdtm;
+    } else {
+      yh2o2 = large_value_lifetime;
+    }
+    tmp_hetrates[1](kk) =
+        mam4::max(1.0 / yh2o2, 0.0) * stay; // FIXME: bad constant index
+
+    Real yso2 = 0;
+    const Real xxx3 =
+        (xso2(kk) - xgas3(kk)); // working variables for h2o2 (2) and so2 (3)
+    if (xxx3 != 0.0) {          // if no washout lifetime = 1.e29
+      yso2 = xso2(kk) / xxx3 * xdtm;
+    } else {
+      yso2 = large_value_lifetime;
+    }
+    tmp_hetrates[2](kk) =
+        mam4::max(1.0 / yso2, 0.0) * stay; // FIXME: bad constant index
   });
   team.team_barrier();
   //-----------------------------------------------------------------

--- a/src/validation/mo_sethet/gas_washout.cpp
+++ b/src/validation/mo_sethet/gas_washout.cpp
@@ -81,7 +81,8 @@ void gas_washout(Ensemble *ensemble) {
     const auto delz_i_in = input.get_array("delz_i");
     const auto xgas_in = input.get_array("xgas");
 
-    mam4::ColumnView xliq_i, xhen_i, tfld_i, delz_i, xgas_old, xgas_new;
+    mam4::ColumnView xliq_i, xhen_i, tfld_i, delz_i, xgas_old, xgas_new,
+        scratch;
     auto xliq_i_host = View1DHost((Real *)xliq_i_in.data(), pver);
     auto xhen_i_host = View1DHost((Real *)xhen_i_in.data(), pver);
     auto tfld_i_host = View1DHost((Real *)tfld_i_in.data(), pver);
@@ -93,6 +94,7 @@ void gas_washout(Ensemble *ensemble) {
     delz_i = mam4::testing::create_column_view(pver);
     xgas_old = mam4::testing::create_column_view(pver);
     xgas_new = mam4::testing::create_column_view(pver);
+    scratch = mam4::testing::create_column_view(pver);
     Kokkos::deep_copy(xliq_i, xliq_i_host);
     Kokkos::deep_copy(xhen_i, xhen_i_host);
     Kokkos::deep_copy(tfld_i, tfld_i_host);
@@ -117,7 +119,7 @@ void gas_washout(Ensemble *ensemble) {
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           gas_washout(team, plev, pver, xkgm, xliq_i, rain_i, xhen_i, tfld_i,
-                      delz_i, xgas_new);
+                      delz_i, xgas_new, scratch);
         });
 
     Kokkos::deep_copy(xgas_host, xgas_old);

--- a/src/validation/mo_sethet/gas_washout.cpp
+++ b/src/validation/mo_sethet/gas_washout.cpp
@@ -105,21 +105,20 @@ void gas_washout(Ensemble *ensemble) {
     Kokkos::deep_copy(rain_i, 0.1);
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
-    const int ktop = 0;
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
-      Kokkos::single(Kokkos::PerTeam(team), [=]() {
-        for (int kk = ktop; kk < pver; ++kk) 
-          old_gas_washout(team, kk, xkgm, xliq_i[kk], xhen_i, tfld_i, delz_i,
-                          xgas_old);
-      });
-    });
+          Kokkos::single(Kokkos::PerTeam(team), [=]() {
+            for (int kk = plev; kk < pver; ++kk)
+              old_gas_washout(team, kk, xkgm, xliq_i[kk], xhen_i, tfld_i,
+                              delz_i, xgas_old);
+          });
+        });
     // now the new one
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
-      gas_washout(team, ktop, pver, xkgm, xliq_i, rain_i, xhen_i, tfld_i, delz_i, 
-        xgas_new);
-    });
+          gas_washout(team, plev, pver, xkgm, xliq_i, rain_i, xhen_i, tfld_i,
+                      delz_i, xgas_new);
+        });
 
     Kokkos::deep_copy(xgas_host, xgas_old);
     std::vector<Real> xgas_old_out(pver);
@@ -135,7 +134,7 @@ void gas_washout(Ensemble *ensemble) {
     // compute an error norm
     Real l2 = 0.0;
     for (int k = 0; k < pver; k++) {
-      const  Real diff = xgas_new_out[k] - xgas_old_out[k];
+      const Real diff = xgas_new_out[k] - xgas_old_out[k];
       l2 += diff * diff;
     }
     l2 = sqrt(l2);

--- a/src/validation/mo_sethet/gas_washout.cpp
+++ b/src/validation/mo_sethet/gas_washout.cpp
@@ -6,6 +6,64 @@
 #include <mam4xx/mam4.hpp>
 #include <validation.hpp>
 
+namespace mam4::mo_sethet {
+
+//=================================================================================
+KOKKOS_INLINE_FUNCTION
+void old_gas_washout(
+    const ThreadTeam &team,
+    const int plev,               // calculate from this level below //in
+    const Real xkgm,              // mass flux on rain drop //in
+    const Real xliq_ik,           // liquid rain water content [gm/m^3] // in
+    const ColumnView xhen_i,      // henry's law constant
+    const ConstColumnView tfld_i, // temperature [K]
+    const ColumnView delz_i,      // layer depth about interfaces [cm]  // in
+    const ColumnView xgas) {      // gas concentration // inout
+  //------------------------------------------------------------------------
+  // calculate gas washout by cloud if not saturated
+  //------------------------------------------------------------------------
+  // FIXME: BAD CONSTANTS
+  const Real const0 = boltz_cgs * 1.0e-6; // [atmospheres/deg k/cm^3]
+  constexpr Real geo_fac =
+      6.0; // geometry factor (surf area/volume = geo_fac/diameter)
+  constexpr Real xrm = .189;  // mean diameter of rain drop [cm]
+  constexpr Real xum = 748.0; // mean rain drop terminal velocity [cm/s]
+
+  // -----------------------------------------------------------------
+  //       ... calculate the saturation concentration eqca
+  // -----------------------------------------------------------------
+  // total of ca between level plev and kk [#/cm3]
+  Real allca = 0.0;
+
+  // This loop causes problems because plev is the only level this
+  // function should be changing but it changes values in other levels
+  // which prevents gas_washout from running in parallel over all the
+  // levels in a column.
+  for (int k = plev; k < pver; k++) {
+    const Real xeqca =
+        xgas(k) / (xliq_ik * avo2 + 1.0 / (xhen_i(k) * const0 * tfld_i(k))) *
+        xliq_ik * avo2;
+    //-----------------------------------------------------------------
+    //       ... calculate ca; inside cloud concentration in  #/cm3(air)
+    //-----------------------------------------------------------------
+    const Real xca =
+        geo_fac * xkgm * xgas(k) / (xrm * xum) * delz_i(k) * xliq_ik * cm3_2_m3;
+
+    // -----------------------------------------------------------------
+    //       ... if is not saturated (take hno3 as an example)
+    //               hno3(gas)_new = hno3(gas)_old - hno3(h2o)
+    //           otherwise
+    //               hno3(gas)_new = hno3(gas)_old
+    // -----------------------------------------------------------------
+    allca += xca;
+    if (allca < xeqca) {
+      xgas(k) = mam4::max(xgas(k) - xca, 0.0);
+    }
+  }
+} // end subroutine old_gas_washout
+
+} // namespace mam4::mo_sethet
+
 using namespace skywalker;
 using namespace mam4::mo_sethet;
 
@@ -14,43 +72,73 @@ void gas_washout(Ensemble *ensemble) {
     using View1DHost = typename mam4::HostType::view_1d<Real>;
     constexpr int pver = mam4::nlev;
 
-    const int plev = input.get_array("plev")[0];
+    const int plev =
+        input.get_array("plev")[0] - 1; // 1-based to 0-based index conversion
     const Real xkgm = input.get_array("xkgm")[0];
-    const Real xliq_ik = input.get_array("xliq_ik")[0];
+    const auto xliq_i_in = input.get_array("xliq_ik");
     const auto xhen_i_in = input.get_array("xhen_i");
     const auto tfld_i_in = input.get_array("tfld_i");
     const auto delz_i_in = input.get_array("delz_i");
     const auto xgas_in = input.get_array("xgas");
 
-    mam4::ColumnView xhen_i, tfld_i, delz_i, xgas;
+    mam4::ColumnView xliq_i, xhen_i, tfld_i, delz_i, xgas_old, xgas_new;
+    auto xliq_i_host = View1DHost((Real *)xliq_i_in.data(), pver);
     auto xhen_i_host = View1DHost((Real *)xhen_i_in.data(), pver);
     auto tfld_i_host = View1DHost((Real *)tfld_i_in.data(), pver);
     auto delz_i_host = View1DHost((Real *)delz_i_in.data(), pver);
     auto xgas_host = View1DHost((Real *)xgas_in.data(), pver);
+    xliq_i = mam4::testing::create_column_view(pver);
     xhen_i = mam4::testing::create_column_view(pver);
     tfld_i = mam4::testing::create_column_view(pver);
     delz_i = mam4::testing::create_column_view(pver);
-    xgas = mam4::testing::create_column_view(pver);
+    xgas_old = mam4::testing::create_column_view(pver);
+    xgas_new = mam4::testing::create_column_view(pver);
+    Kokkos::deep_copy(xliq_i, xliq_i_host);
     Kokkos::deep_copy(xhen_i, xhen_i_host);
     Kokkos::deep_copy(tfld_i, tfld_i_host);
     Kokkos::deep_copy(delz_i, delz_i_host);
-    Kokkos::deep_copy(xgas, xgas_host);
+    Kokkos::deep_copy(xgas_old, xgas_host);
+    Kokkos::deep_copy(xgas_new, xgas_host);
+
+    // rain just needs to be non-zero to trigger this test
+    auto rain_i = mam4::testing::create_column_view(pver);
+    Kokkos::deep_copy(rain_i, 0.1);
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
+          // try the old implementation
+          // int ktop = 0, pver = 1;
           Kokkos::single(Kokkos::PerTeam(team), [=]() {
-            //          gas_washout(team, 0, 1, xkgm, xliq_ik, xhen_i, tfld_i,
-            //          delz_i,
-            //                      xgas);
+            old_gas_washout(team, plev, xkgm, xliq_i[0], xhen_i, tfld_i, delz_i,
+                            xgas_old);
           });
+
+          // now the new one
+          gas_washout(team, plev, 1, xkgm, xliq_i, rain_i, xhen_i, tfld_i,
+                      delz_i, xgas_new);
         });
 
-    Kokkos::deep_copy(xgas_host, xgas);
-    std::vector<Real> xgas_out(pver);
-    for (int k = 0; k < pver; k++)
-      xgas_out[k] = xgas_host(k);
+    Kokkos::deep_copy(xgas_host, xgas_old);
+    std::vector<Real> xgas_old_out(pver);
+    for (int k = 0; k < pver; k++) {
+      xgas_old_out[k] = xgas_host(k);
+    }
+    Kokkos::deep_copy(xgas_host, xgas_new);
+    std::vector<Real> xgas_new_out(pver);
+    for (int k = 0; k < pver; k++) {
+      xgas_new_out[k] = xgas_host(k);
+    }
 
-    output.set("xgas", xgas_out);
+    // compute an error norm
+    Real l2 = 0.0;
+    for (int k = 0; k < pver; k++) {
+      l2 += xgas_new_out[k] - xgas_old_out[k];
+    }
+    l2 = sqrt(l2);
+    printf("xgas error (L2): %g\n", l2);
+
+    output.set("xgas", xgas_new_out);
   });
 }

--- a/src/validation/mo_sethet/gas_washout.cpp
+++ b/src/validation/mo_sethet/gas_washout.cpp
@@ -40,8 +40,9 @@ void gas_washout(Ensemble *ensemble) {
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Kokkos::single(Kokkos::PerTeam(team), [=]() {
-            gas_washout(team, plev - 1, xkgm, xliq_ik, xhen_i, tfld_i, delz_i,
-                        xgas);
+	      
+//          gas_washout(team, 0, 1, xkgm, xliq_ik, xhen_i, tfld_i, delz_i,
+//                      xgas);
           });
         });
 

--- a/src/validation/mo_sethet/gas_washout.cpp
+++ b/src/validation/mo_sethet/gas_washout.cpp
@@ -105,20 +105,21 @@ void gas_washout(Ensemble *ensemble) {
     Kokkos::deep_copy(rain_i, 0.1);
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
-
+    const int ktop = 0;
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
-          // try the old implementation
-          // int ktop = 0, pver = 1;
-          Kokkos::single(Kokkos::PerTeam(team), [=]() {
-            old_gas_washout(team, plev, xkgm, xliq_i[0], xhen_i, tfld_i, delz_i,
-                            xgas_old);
-          });
-
-          // now the new one
-          gas_washout(team, plev, 1, xkgm, xliq_i, rain_i, xhen_i, tfld_i,
-                      delz_i, xgas_new);
-        });
+      Kokkos::single(Kokkos::PerTeam(team), [=]() {
+        for (int kk = ktop; kk < pver; ++kk) 
+          old_gas_washout(team, kk, xkgm, xliq_i[kk], xhen_i, tfld_i, delz_i,
+                          xgas_old);
+      });
+    });
+    // now the new one
+    Kokkos::parallel_for(
+        team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
+      gas_washout(team, ktop, pver, xkgm, xliq_i, rain_i, xhen_i, tfld_i, delz_i, 
+        xgas_new);
+    });
 
     Kokkos::deep_copy(xgas_host, xgas_old);
     std::vector<Real> xgas_old_out(pver);
@@ -134,7 +135,8 @@ void gas_washout(Ensemble *ensemble) {
     // compute an error norm
     Real l2 = 0.0;
     for (int k = 0; k < pver; k++) {
-      l2 += xgas_new_out[k] - xgas_old_out[k];
+      const  Real diff = xgas_new_out[k] - xgas_old_out[k];
+      l2 += diff * diff;
     }
     l2 = sqrt(l2);
     printf("xgas error (L2): %g\n", l2);

--- a/src/validation/mo_sethet/gas_washout.cpp
+++ b/src/validation/mo_sethet/gas_washout.cpp
@@ -40,9 +40,9 @@ void gas_washout(Ensemble *ensemble) {
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Kokkos::single(Kokkos::PerTeam(team), [=]() {
-	      
-//          gas_washout(team, 0, 1, xkgm, xliq_ik, xhen_i, tfld_i, delz_i,
-//                      xgas);
+            //          gas_washout(team, 0, 1, xkgm, xliq_ik, xhen_i, tfld_i,
+            //          delz_i,
+            //                      xgas);
           });
         });
 

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -96,16 +96,13 @@ void sethet(Ensemble *ensemble) {
     xk0_so2 = mam4::testing::create_column_view(pver);
     so2_diss = mam4::testing::create_column_view(pver);
 
-    ColumnView tmp_hetrates[gas_pcnst];
     View2DHost qin_host("qin_host", pver, gas_pcnst);
 
     View2D het_rates("het_rates", pver, gas_pcnst);
     View2D qin("qin", pver, gas_pcnst);
     auto het_rates_host = Kokkos::create_mirror_view(het_rates);
 
-    for (int mm = 0; mm < gas_pcnst; ++mm) {
-      tmp_hetrates[mm] = mam4::testing::create_column_view(pver);
-    }
+    View2D tmp_hetrates(" tmp_hetrates", gas_pcnst, pver);
 
     int count = 0;
     for (int mm = 0; mm < gas_pcnst; ++mm) {
@@ -116,9 +113,7 @@ void sethet(Ensemble *ensemble) {
     }
 
     // transfer data to GPU.
-    for (int mm = 0; mm < gas_pcnst; ++mm) {
-      Kokkos::deep_copy(tmp_hetrates[mm], 0.0);
-    }
+    Kokkos::deep_copy(tmp_hetrates, 0.0);
     Kokkos::deep_copy(qin, qin_host);
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);


### PR DESCRIPTION
There was a loop over the column that used a Kokkos::single to iterate.  With a little refactoring of the code this was replaced with a Kokkos::parallel.

Performance testing of this kernel demonstrated a 3-4x speedup with these changes, as shown here:

<img width="1826" height="762" alt="image" src="https://github.com/user-attachments/assets/db1df33b-6acf-4f98-9b84-37d6477c185c" />

But since this kernel was not expensive to begin with, the overall speedup of the aerosol processes was not significant:

<img width="1402" height="1712" alt="image (1)" src="https://github.com/user-attachments/assets/5bf73c68-8fec-4733-a691-afa3d1590b3f" />

Note that this kernel is part of the aero_microphysics timing. 
