### PR TITLE
Code cleanup, formatting improvements, and better default team sizes for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,6 @@ endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
-# Blessed version of clang-format.
-set(CLANG_FORMAT_VERSION 14)
-
 #--------------------------
 # End configurable options
 #--------------------------
@@ -237,31 +234,8 @@ endif()
 # source directories
 add_subdirectory(src)
 
-# formatting and format checking using clang-format
-if (NOT TARGET format-cxx)
-  find_program(CLANG_FORMAT clang-format)
-  if (NOT CLANG_FORMAT STREQUAL "CLANG_FORMAT-NOTFOUND")
-    # Is this the blessed version? If not, we create targets that warn the user
-    # to obtain the right version.
-    execute_process(COMMAND clang-format --version
-      OUTPUT_VARIABLE CF_VERSION)
-    string(STRIP ${CF_VERSION} CF_VERSION)
-    if (NOT ${CF_VERSION} MATCHES ${CLANG_FORMAT_VERSION})
-      add_custom_target(format-cxx
-        echo "You have clang-format version ${CF_VERSION}, but ${CLANG_FORMAT_VERSION} is required."
-        "Please make sure this version appears in your path and rerun config.sh.")
-      add_custom_target(format-cxx-check
-        echo "You have clang-format version ${CF_VERSION}, but ${CLANG_FORMAT_VERSION} is required."
-        "Please make sure this version appears in your path and rerun config.sh.")
-    else()
-      add_custom_target(format-cxx
-        find ${PROJECT_SOURCE_DIR}/src -name "*.[hc]pp" -exec ${CLANG_FORMAT} -i {} \+;
-        VERBATIM
-        COMMENT "Auto-formatting C++ code...")
-      add_custom_target(format-cxx-check
-        find ${PROJECT_SOURCE_DIR}/src -name "*.[hc]pp" -exec ${CLANG_FORMAT} -n --Werror -ferror-limit=1 {} \+;
-        VERBATIM
-        COMMENT "Checking C++ formatting...")
-    endif()
-  endif()
-endif()
+# formatting targets (using clang-format):
+# * `format-cxx` formats the code in place
+# * `format-cxx-check` reports whether the code is properly formatted
+include(add_formatting_targets)
+add_formatting_targets()

--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,11 @@
 
 # This script builds mam4xx in standalone mode. Run it like this:
 #
-# `./build.sh <build-dir> <device> <precision> <build_type> [gpu_type] [gpu_arch]
+# `./build.sh <build_dir> <device> <precision> <build_type> [gpu_type] [gpu_arch]`
 #
 # where
-# * <build-dir> is the build directory prefix (e.g. `build`) in which you
-#   would like mam4xx configured and built
+# * <build_dir> is the build directory (e.g. `build`) in which you would like
+#   mam4xx configured and built
 # * <device> (either `cpu` or `gpu`), identifies the device type for which mam4xx
 #   is built.
 # * <precision> (either `single` or `double`) determines the precision of
@@ -35,7 +35,7 @@ fi
 
 if [[ "$BUILD_DIR" == "" ]]; then
   echo "mam4xx build directory was not specified!"
-  echo "Usage: $0 <prefix> <device> <precision> <build_type> [gpu_type] [gpu_arch]"
+  echo "Usage: $0 <build_dir> <device> <precision> <build_type> [gpu_type] [gpu_arch]"
   exit
 fi
 

--- a/cmake/add_formatting_targets.cmake
+++ b/cmake/add_formatting_targets.cmake
@@ -1,0 +1,35 @@
+# Blessed version of clang-format.
+set(CLANG_FORMAT_VERSION 14)
+
+# This macro creates the following targets for checking code formatting:
+# make format-c       <-- reformats C code to conform to desired style
+# make format-c-check <-- checks C code formatting, reporting any errors
+macro(add_formatting_targets)
+  if (NOT TARGET format-cxx)
+    find_program(CLANG_FORMAT NAMES clang-format-${CLANG_FORMAT_VERSION} clang-format)
+    if (NOT CLANG_FORMAT STREQUAL "CLANG_FORMAT-NOTFOUND")
+      # Is this our blessed version? If not, we create targets that warn the user
+      # to obtain the right version.
+      execute_process(COMMAND ${CLANG_FORMAT} --version
+        OUTPUT_VARIABLE CF_VERSION)
+      string(STRIP ${CF_VERSION} CF_VERSION)
+      if (NOT ${CF_VERSION} MATCHES ${CLANG_FORMAT_VERSION})
+        add_custom_target(format-cxx
+          echo "You have clang-format version ${CF_VERSION}, but ${CLANG_FORMAT_VERSION} is required."
+          "Please make sure this version appears in your path and rerun cmake.")
+        add_custom_target(format-cxx-check
+          echo "You have clang-format version ${CF_VERSION}, but ${CLANG_FORMAT_VERSION} is required."
+          "Please make sure this version appears in your path and rerun cmake.")
+      else()
+        add_custom_target(format-cxx
+          find ${PROJECT_SOURCE_DIR}/src -name "*.[hc]pp" -exec ${CLANG_FORMAT} -i {} \+;
+          VERBATIM
+          COMMENT "Auto-formatting C++ code...")
+        add_custom_target(format-cxx-check
+          find ${PROJECT_SOURCE_DIR}/src -name "*.[hc]pp" -exec ${CLANG_FORMAT} -n --Werror -ferror-limit=1 {} \+;
+          VERBATIM
+          COMMENT "Checking C++ formatting...")
+      endif()
+    endif()
+  endif()
+endmacro()

--- a/src/mam4xx/conversions.hpp
+++ b/src/mam4xx/conversions.hpp
@@ -245,27 +245,6 @@ KOKKOS_INLINE_FUNCTION Real saturation_mixing_ratio_hardy(Real T, Real P) {
 /// @param [in] w water vapor mixing ratio [kg vapor / kg dry air]
 /// @param [in] p total pressure [Pa]
 /// @param [in] T temperature [K]
-/// @param [in] wsat A function that computes the saturation mixing ratio from
-///                 the temperature. If not supplied,
-///                 @ref saturation_mixing_ratio_hardy is used.
-/// @return relative humidity [1]
-// KOKKOS_INLINE_FUNCTION Real relative_humidity_from_vapor_mixing_ratio(
-//     Real w, Real T, Real p,
-//     Real (*wsat)(Real, Real) = saturation_mixing_ratio_hardy) {
-//   const auto ws = wsat(T, p);
-//   return w / ws;
-// }
-
-/// Computes the relative humidity from the water vapor mixing ratio and the
-/// pressure and temperature, given the relationship between temperature and
-/// the water vapor saturation pressure.
-///
-/// Use this formula with parameterizations that are defined with respect to
-/// air air (and note that mixing ratio is defined with respect to dry air).
-///
-/// @param [in] w water vapor mixing ratio [kg vapor / kg dry air]
-/// @param [in] p total pressure [Pa]
-/// @param [in] T temperature [K]
 /// @return relative humidity [1]
 KOKKOS_INLINE_FUNCTION Real relative_humidity_from_vapor_mixing_ratio(Real w,
                                                                       Real T,

--- a/src/tests/mam4_photo_setcol.cpp
+++ b/src/tests/mam4_photo_setcol.cpp
@@ -23,6 +23,12 @@ template <> struct PrecisionTolerance<double> {
 
 using mam4::Real;
 
+#ifdef MAM4XX_ENABLE_GPU
+constexpr int team_size = mam4::nlev;
+#else
+constexpr int team_size = 1;
+#endif
+
 // Test compute_o3_column_density: serial reference vs parallel implementation
 TEST_CASE("compute_o3_column_density", "mo_photo") {
 
@@ -89,7 +95,7 @@ TEST_CASE("compute_o3_column_density", "mo_photo") {
   View1D o3_col_dens("o3_col_dens", pver);
   Kokkos::deep_copy(mmr_o3, mmr_o3_host);
 
-  auto team_policy = mam4::ThreadTeamPolicy(1, Kokkos::AUTO);
+  auto team_policy = mam4::ThreadTeamPolicy(1, team_size);
   Kokkos::parallel_for(
       "compute_o3_column", team_policy,
       KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
@@ -446,7 +452,7 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
     View2D psum_u_d("psum_u", pver, test_nw);
 
     Kokkos::parallel_for(
-        "interpolate_rsf_par", mam4::ThreadTeamPolicy(1, Kokkos::AUTO),
+        "interpolate_rsf_par", mam4::ThreadTeamPolicy(1, pver),
         KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           mam4::mo_photo::interpolate_rsf(
               team, alb_in_d, test_sza_in, p_in_d, colo3_in_d, pver, sza_d,
@@ -704,7 +710,7 @@ TEST_CASE("jlong", "mo_photo") {
     const auto temper = atm.temperature;
 
     Kokkos::parallel_for(
-        "jlong_par", mam4::ThreadTeamPolicy(1, Kokkos::AUTO),
+        "jlong_par", mam4::ThreadTeamPolicy(1, pver),
         KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           mam4::mo_photo::jlong(
               team, test_sza_in, alb_in_d, p_in_d, temper, colo3_in_d, xsqy_d,

--- a/src/tests/mam4_photo_setcol.cpp
+++ b/src/tests/mam4_photo_setcol.cpp
@@ -452,7 +452,7 @@ TEST_CASE("interpolate_rsf", "mo_photo") {
     View2D psum_u_d("psum_u", pver, test_nw);
 
     Kokkos::parallel_for(
-        "interpolate_rsf_par", mam4::ThreadTeamPolicy(1, pver),
+        "interpolate_rsf_par", mam4::ThreadTeamPolicy(1, team_size),
         KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           mam4::mo_photo::interpolate_rsf(
               team, alb_in_d, test_sza_in, p_in_d, colo3_in_d, pver, sza_d,
@@ -710,7 +710,7 @@ TEST_CASE("jlong", "mo_photo") {
     const auto temper = atm.temperature;
 
     Kokkos::parallel_for(
-        "jlong_par", mam4::ThreadTeamPolicy(1, pver),
+        "jlong_par", mam4::ThreadTeamPolicy(1, team_size),
         KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           mam4::mo_photo::jlong(
               team, test_sza_in, alb_in_d, p_in_d, temper, colo3_in_d, xsqy_d,

--- a/src/tests/mam4_spitfire_transport_unit_tests.cpp
+++ b/src/tests/mam4_spitfire_transport_unit_tests.cpp
@@ -10,6 +10,12 @@
 
 using mam4::Real;
 
+#ifdef MAM4XX_ENABLE_GPU
+constexpr int team_size = mam4::nlev;
+#else
+constexpr int team_size = 1;
+#endif
+
 TEST_CASE("minmod", "mam4_spitfire_transport") {
   Real aa = 1.0;
   Real bb = 2.0;
@@ -32,7 +38,7 @@ TEST_CASE("median", "mam4_spitfire_transport") {
 
 TEST_CASE("get_flux", "mam4_spitfire_transport") {
 
-  auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+  auto team_policy = mam4::ThreadTeamPolicy(1u, team_size);
 
   const Real deltat = 10.0;
   mam4::ColumnView xw = mam4::testing::create_column_view(mam4::nlev);

--- a/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
+++ b/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
@@ -71,7 +71,7 @@ void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
     const bool update_mmr = true;
     cal_data.set_update_mmr(update_mmr);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           // FIXME: top_lev is set to 1 in calcsize ?

--- a/src/validation/aero_model/aero_model_wetdep.cpp
+++ b/src/validation/aero_model/aero_model_wetdep.cpp
@@ -168,7 +168,7 @@ void aero_model_wetdep(Ensemble *ensemble) {
     const bool update_mmr = true;
     cal_data.set_update_mmr(update_mmr);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           auto progs_in = progs;

--- a/src/validation/aero_model/modal_aero_bcscavcoef_get.cpp
+++ b/src/validation/aero_model/modal_aero_bcscavcoef_get.cpp
@@ -81,7 +81,7 @@ void modal_aero_bcscavcoef_get(Ensemble *ensemble) {
 
     const Real dgnum_amode_imode = dgnum_amode[imode];
 
-    mam4::ThreadTeamPolicy team_policy(ncol, Kokkos::AUTO);
+    mam4::ThreadTeamPolicy team_policy(ncol, mam4::testing::team_size);
 
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {

--- a/src/validation/aerosol_optics/aero_rad_props_lw.cpp
+++ b/src/validation/aerosol_optics/aero_rad_props_lw.cpp
@@ -228,7 +228,7 @@ void aero_rad_props_lw(Ensemble *ensemble) {
       } // d3
 
     View2D odap_aer("odap_aer", nlwbands, pver);
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
 
     auto vapor_mixing_ratio = create_column_view(mam4::nlev);
     auto liquid_mixing_ratio = create_column_view(mam4::nlev); //

--- a/src/validation/aerosol_optics/aero_rad_props_sw.cpp
+++ b/src/validation/aerosol_optics/aero_rad_props_sw.cpp
@@ -324,7 +324,7 @@ void aero_rad_props_sw(Ensemble *ensemble) {
     mam4::modal_aero_opt::CalcsizeData cal_data;
     cal_data.initialize();
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           static constexpr int nlev_loc = mam4::nlev;

--- a/src/validation/aerosol_optics/binterp.cpp
+++ b/src/validation/aerosol_optics/binterp.cpp
@@ -56,7 +56,7 @@ void binterp(Ensemble *ensemble) {
     View1D coef("coef", ncoef);
     View1D tab("tab", 4);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           int itab = 0;

--- a/src/validation/aerosol_optics/calc_refin_complex.cpp
+++ b/src/validation/aerosol_optics/calc_refin_complex.cpp
@@ -79,7 +79,7 @@ void calc_refin_complex(Ensemble *ensemble) {
     Kokkos::deep_copy(crefwsw, crefwsw_host);
 
     View1D outputs("outputs", 5);
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Real refr = zero;

--- a/src/validation/aerosol_optics/calc_volc_ext.cpp
+++ b/src/validation/aerosol_optics/calc_volc_ext.cpp
@@ -33,7 +33,7 @@ void calc_volc_ext(Ensemble *ensemble) {
 
     View1D tropopause_m("tropopause_m", 1);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           calc_volc_ext(trop_level, state_zm, ext_cmip6_sw, extinct,

--- a/src/validation/aerosol_optics/data_transfer_state_q_qqwc_to_prog.cpp
+++ b/src/validation/aerosol_optics/data_transfer_state_q_qqwc_to_prog.cpp
@@ -101,7 +101,7 @@ void data_transfer_state_q_qqwc_to_prog(Ensemble *ensemble) {
     Kokkos::deep_copy(state_q_output_non, state_non);
 
     mam4::Prognostics progs = mam4::validation::create_prognostics(mam4::nlev);
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           // 1. We inject values of state_q in prog.

--- a/src/validation/aerosol_optics/modal_aero_lw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_lw.cpp
@@ -244,7 +244,7 @@ void modal_aero_lw(Ensemble *ensemble) {
     mam4::modal_aero_opt::CalcsizeData cal_data;
     cal_data.initialize();
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           static constexpr int nlev_loc = mam4::nlev;

--- a/src/validation/aerosol_optics/modal_aero_sw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_sw.cpp
@@ -283,7 +283,7 @@ void modal_aero_sw(Ensemble *ensemble) {
     mam4::modal_aero_opt::CalcsizeData cal_data;
     cal_data.initialize();
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           static constexpr int nlev_loc = mam4::nlev;

--- a/src/validation/aerosol_optics/volcanic_cmip_sw.cpp
+++ b/src/validation/aerosol_optics/volcanic_cmip_sw.cpp
@@ -72,7 +72,7 @@ void volcanic_cmip_sw(Ensemble *ensemble) {
     mam4::validation::convert_1d_vector_to_transpose_2d_view_device(tau_w_f_db,
                                                                     tau_w_f);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           mam4::aero_rad_props::volcanic_cmip_sw(

--- a/src/validation/calcsize/compute_tendencies.cpp
+++ b/src/validation/calcsize/compute_tendencies.cpp
@@ -65,7 +65,7 @@ void compute_tendencies(Ensemble *ensemble) {
       } // end species
     }   // end modes
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           process.compute_tendencies(team, t, dt, atm, sfc, progs, diags,

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -40,7 +40,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
     mam4::modal_aero_opt::CalcsizeData cal_data;
     cal_data.initialize();
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           // FIXME: top_lev is set to 1 in calcsize ?

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -49,7 +49,7 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
     const bool update_mmr = true;
     cal_data.set_update_mmr(update_mmr);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           // FIXME: top_lev is set to 1 in calcsize ?

--- a/src/validation/hetfrz/hetfrz_rates_1box.cpp
+++ b/src/validation/hetfrz/hetfrz_rates_1box.cpp
@@ -676,7 +676,7 @@ void hetfrz_rates_1box(Ensemble *ensemble) {
 
     mam4::AeroConfig mam4_config;
     mam4::HetfrzProcess process(mam4_config);
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Real t = 0.0;
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {

--- a/src/validation/mo_chm_diags/chm_diags.cpp
+++ b/src/validation/mo_chm_diags/chm_diags.cpp
@@ -269,7 +269,7 @@ void chm_diags(Ensemble *ensemble) {
     auto df_sox = mam4::testing::create_column_view(1);
     auto df_nhx = mam4::testing::create_column_view(1);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           mam4::mo_chm_diags::chm_diags(

--- a/src/validation/mo_chm_diags/het_diags.cpp
+++ b/src/validation/mo_chm_diags/het_diags.cpp
@@ -78,7 +78,7 @@ void het_diags(Ensemble *ensemble) {
         250092.672000, 1.007400,   12.011000,     12.011000, 250092.672000,
         1.007400};
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           mam4::mo_chm_diags::het_diags(team, het_rates, mmr, pdel, wght,

--- a/src/validation/mo_drydep/drydep_xactive.cpp
+++ b/src/validation/mo_drydep/drydep_xactive.cpp
@@ -51,7 +51,7 @@ void drydep_xactive(const mam4::seq_drydep::Data &data, Ensemble *ensemble) {
     View1D dvel_d("dvel", gas_pcnst);
     View1D dflx_d("dflx", gas_pcnst);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO());
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           int index_season[n_land_type] = {};

--- a/src/validation/mo_photo/calc_sum_wght.cpp
+++ b/src/validation/mo_photo/calc_sum_wght.cpp
@@ -41,7 +41,7 @@ void calc_sum_wght(Ensemble *ensemble) {
 
     const auto psum = View1D("psum", nw);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           calc_sum_wght(dels.data(), wrk0, // in

--- a/src/validation/mo_photo/cloud_mod.cpp
+++ b/src/validation/mo_photo/cloud_mod.cpp
@@ -39,7 +39,7 @@ void cloud_mod(Ensemble *ensemble) {
     View1D cld_mult("cld_mult", pver);
     View1D work("work", 5 * pver);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           cloud_mod(team, zen_angle, clouds, lwc, delp,

--- a/src/validation/mo_photo/find_index.cpp
+++ b/src/validation/mo_photo/find_index.cpp
@@ -25,7 +25,7 @@ void find_index(Ensemble *ensemble) {
     Kokkos::deep_copy(var_in, var_in_host);
 
     ViewInt1D idx_out("idx_out", 1);
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           find_index(var_in, var_len,

--- a/src/validation/mo_photo/interpolate_rsf.cpp
+++ b/src/validation/mo_photo/interpolate_rsf.cpp
@@ -104,7 +104,7 @@ void interpolate_rsf(Ensemble *ensemble) {
     View2D psum_u("psum_u", pver, nw);
 
     View2D rsf("rsf", nw, pver);
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           interpolate_rsf(team, alb_in, sza_in, p_in, colo3_in,

--- a/src/validation/mo_photo/jlong.cpp
+++ b/src/validation/mo_photo/jlong.cpp
@@ -133,7 +133,7 @@ void jlong(Ensemble *ensemble) {
     View2D psum_l("psum_l", pver, nw);
     View2D psum_u("psum_u", pver, nw);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           jlong(team, sza_in, alb_in, p_in, t_in, colo3_in, xsqy, sza, del_sza,

--- a/src/validation/mo_photo/table_photo.cpp
+++ b/src/validation/mo_photo/table_photo.cpp
@@ -151,7 +151,7 @@ void table_photo(Ensemble *ensemble) {
 
     View2D work_cloud_mod("work_cloud_mod", ncol, 5 * pver);
 
-    auto team_policy = mam4::ThreadTeamPolicy(ncol, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(ncol, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           const int i = team.league_rank();

--- a/src/validation/mo_sethet/calc_precip_rescale.cpp
+++ b/src/validation/mo_sethet/calc_precip_rescale.cpp
@@ -36,7 +36,7 @@ void calc_precip_rescale(Ensemble *ensemble) {
     Kokkos::deep_copy(precip, precip_host);
     // std::vector<Real> precip(pver, zero);
     mam4::DeviceType::view_1d<Real> trp_out_val("Return from Device", 1);
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           calc_precip_rescale(team, cmfdqr, nrain, nevapr, precip);

--- a/src/validation/mo_sethet/gas_washout.cpp
+++ b/src/validation/mo_sethet/gas_washout.cpp
@@ -106,7 +106,7 @@ void gas_washout(Ensemble *ensemble) {
     auto rain_i = mam4::testing::create_column_view(pver);
     Kokkos::deep_copy(rain_i, 0.1);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Kokkos::single(Kokkos::PerTeam(team), [=]() {

--- a/src/validation/mo_sethet/sethet.cpp
+++ b/src/validation/mo_sethet/sethet.cpp
@@ -116,7 +116,7 @@ void sethet(Ensemble *ensemble) {
     Kokkos::deep_copy(tmp_hetrates, 0.0);
     Kokkos::deep_copy(qin, qin_host);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Kokkos::parallel_for(

--- a/src/validation/mo_setinv/setinv_test_nlev.cpp
+++ b/src/validation/mo_setinv/setinv_test_nlev.cpp
@@ -71,7 +71,7 @@ void setinv_test_nlev(Ensemble *ensemble) {
     }
 
     // Single-column dispatch.
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           mam4::mo_setinv::setinv(team, invariants, tfld, qv, c_off, pmid);

--- a/src/validation/mo_setsox/setsox_test_nlev.cpp
+++ b/src/validation/mo_setsox/setsox_test_nlev.cpp
@@ -117,7 +117,7 @@ void setsox_test_nlev(Ensemble *ensemble) {
     }
 
     // Single-column dispatch.
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Real dqdt_aqso4[nspec] = {};

--- a/src/validation/modal_aero_amicphys_subareas/compute_qsub_from_gcm_and_qsub_of_other_subarea.cpp
+++ b/src/validation/modal_aero_amicphys_subareas/compute_qsub_from_gcm_and_qsub_of_other_subarea.cpp
@@ -66,7 +66,7 @@ void compute_qsub_from_gcm_and_qsub_of_other_subarea(Ensemble *ensemble) {
     Kokkos::deep_copy(qsub_a_d, qsub_a_h);
     Kokkos::deep_copy(qsub_b_d, qsub_b_h);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Real qsub_a_in[gas_pcnst][subarea_max];

--- a/src/validation/modal_aero_amicphys_subareas/form_gcm_of_gases_and_aerosols_from_subareas.cpp
+++ b/src/validation/modal_aero_amicphys_subareas/form_gcm_of_gases_and_aerosols_from_subareas.cpp
@@ -76,7 +76,7 @@ void form_gcm_of_gases_and_aerosols_from_subareas(Ensemble *ensemble) {
       }
     }
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Real qgcm[gas_pcnst] = {0.0};

--- a/src/validation/modal_aero_amicphys_subareas/get_partition_factors.cpp
+++ b/src/validation/modal_aero_amicphys_subareas/get_partition_factors.cpp
@@ -40,7 +40,7 @@ void get_partition_factors(Ensemble *ensemble) {
     Kokkos::deep_copy(factor_cldy_h, 0.0);
     Kokkos::deep_copy(factor_cldy_d, 0.0);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Real factor_clea_in = 0.0;

--- a/src/validation/modal_aero_amicphys_subareas/set_subarea_gases_and_aerosols.cpp
+++ b/src/validation/modal_aero_amicphys_subareas/set_subarea_gases_and_aerosols.cpp
@@ -84,7 +84,7 @@ void set_subarea_gases_and_aerosols(Ensemble *ensemble) {
     Kokkos::deep_copy(qqcwsub3_h, 0.0);
     Kokkos::deep_copy(qqcwsub3_d, 0.0);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Real qsub1[gas_pcnst][subarea_max] = {{0.0}};

--- a/src/validation/modal_aero_amicphys_subareas/set_subarea_qmass_for_cldbrn_aerosols.cpp
+++ b/src/validation/modal_aero_amicphys_subareas/set_subarea_qmass_for_cldbrn_aerosols.cpp
@@ -51,7 +51,7 @@ void set_subarea_qmass_for_cldbrn_aerosols(Ensemble *ensemble) {
     Kokkos::deep_copy(qqcwsub_h, 0.0);
     Kokkos::deep_copy(qqcwsub_d, 0.0);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Real qqcwsub[gas_pcnst][subarea_max] = {{0.0}};

--- a/src/validation/modal_aero_amicphys_subareas/set_subarea_qmass_for_intrst_aerosols.cpp
+++ b/src/validation/modal_aero_amicphys_subareas/set_subarea_qmass_for_intrst_aerosols.cpp
@@ -69,7 +69,7 @@ void set_subarea_qmass_for_intrst_aerosols(Ensemble *ensemble) {
     }
     Kokkos::deep_copy(qsubx_d, qsubx_h);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Real qsubx[gas_pcnst][subarea_max] = {{0.0}};

--- a/src/validation/modal_aero_amicphys_subareas/set_subarea_qnumb_for_cldbrn_aerosols.cpp
+++ b/src/validation/modal_aero_amicphys_subareas/set_subarea_qnumb_for_cldbrn_aerosols.cpp
@@ -60,7 +60,7 @@ void set_subarea_qnumb_for_cldbrn_aerosols(Ensemble *ensemble) {
     }
     Kokkos::deep_copy(qqcwsub_d, qqcwsub_h);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Real qqcwsub[gas_pcnst][subarea_max] = {{0.0}};

--- a/src/validation/modal_aero_amicphys_subareas/set_subarea_qnumb_for_intrst_aerosols.cpp
+++ b/src/validation/modal_aero_amicphys_subareas/set_subarea_qnumb_for_intrst_aerosols.cpp
@@ -69,7 +69,7 @@ void set_subarea_qnumb_for_intrst_aerosols(Ensemble *ensemble) {
     }
     Kokkos::deep_copy(qsubx_d, qsubx_h);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Real qsubx[gas_pcnst][subarea_max] = {{0.0}};

--- a/src/validation/modal_aero_amicphys_subareas/set_subarea_rh.cpp
+++ b/src/validation/modal_aero_amicphys_subareas/set_subarea_rh.cpp
@@ -49,7 +49,7 @@ void set_subarea_rh(Ensemble *ensemble) {
     Kokkos::deep_copy(relhumsub_h, 0.0);
     Kokkos::deep_copy(relhumsub_d, 0.0);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           Real relhumsub[subarea_max] = {};

--- a/src/validation/modal_aero_amicphys_subareas/setup_subareas.cpp
+++ b/src/validation/modal_aero_amicphys_subareas/setup_subareas.cpp
@@ -62,7 +62,7 @@ void setup_subareas(Ensemble *ensemble) {
     Kokkos::deep_copy(fcldy_h, 0.0);
     Kokkos::deep_copy(fcldy_d, 0.0);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           int nsubarea = 0;

--- a/src/validation/ndrop/dropmixnuc.cpp
+++ b/src/validation/ndrop/dropmixnuc.cpp
@@ -169,7 +169,7 @@ void dropmixnuc(Ensemble *ensemble) {
     raertend = mam4::testing::create_column_view(pver);
     qqcwtend = mam4::testing::create_column_view(pver);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           int nspec_amode[ntot_amode];

--- a/src/validation/ndrop/update_from_explmix.cpp
+++ b/src/validation/ndrop/update_from_explmix.cpp
@@ -140,7 +140,7 @@ void update_from_explmix(Ensemble *ensemble) {
       }
     }
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           int nnew = 1;

--- a/src/validation/nucleate_ice/compute_tendencies.cpp
+++ b/src/validation/nucleate_ice/compute_tendencies.cpp
@@ -128,7 +128,7 @@ void compute_tendencies(Ensemble *ensemble) {
     Kokkos::deep_copy(diags.dry_geometric_mean_diameter_i[aitken_idx],
                       dgnum[modeptr_aitken]);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1u, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           process.compute_tendencies(team, t, dt, atm, sfc, progs, diags,

--- a/src/validation/tracer_data/rebin.cpp
+++ b/src/validation/tracer_data/rebin.cpp
@@ -34,7 +34,7 @@ void rebin(Ensemble *ensemble) {
 
     View1D trg("trg", ntrg);
 
-    auto team_policy = mam4::ThreadTeamPolicy(1, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(1, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           // Call rebin function

--- a/src/validation/tracer_data/vert_interp.cpp
+++ b/src/validation/tracer_data/vert_interp.cpp
@@ -31,7 +31,7 @@ void vert_interp(Ensemble *ensemble) {
     mam4::validation::convert_1d_vector_to_2d_view_device(pmid_db, pmid);
     mam4::validation::convert_1d_vector_to_2d_view_device(datain_db, datain);
 
-    auto team_policy = mam4::ThreadTeamPolicy(ncol, Kokkos::AUTO);
+    auto team_policy = mam4::ThreadTeamPolicy(ncol, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           // Perform the vertical interpolation

--- a/src/validation/validation.hpp
+++ b/src/validation/validation.hpp
@@ -22,6 +22,13 @@ Prognostics create_prognostics(int num_levels);
 Diagnostics create_diagnostics(int num_levels);
 Tendencies create_tendencies(int num_levels);
 
+// use this team size for parallel dispatches in validation tests
+#ifdef MAM4XX_ENABLE_GPU
+constexpr int team_size = mam4::nlev;
+#else
+constexpr int team_size = 1;
+#endif
+
 } // namespace testing
 
 namespace validation {


### PR DESCRIPTION
This PR has various improvements resulting from an investigation of issues #320 and #449. Highlights:

* Some commented code has been removed.
* The formatting targets now try to detect the desired version of `clang-format` before the generic version. This lets you (for example) install `clang-format-14` alongside whatever version is present on your system.
* The team sizes in our unit and validation tests have been changed from `Kokkos::AUTO`, which can report a high number that doesn't work on some systems (like aurora).

With these changes, all tests run on aurora, with two failures related to invalid memory accesses (see #449). Those can be fixed in a subsequent PR.

Closes #320 