### PR TITLE
Try adding the git tag reference we use to the github ekat clone action.

### DIFF
--- a/.github/workflows/at2_gcc-cuda.yml
+++ b/.github/workflows/at2_gcc-cuda.yml
@@ -82,6 +82,7 @@ jobs:
         with:
           repository: E3SM-Project/EKAT
           submodules: recursive
+          ref: 007bdcff6cb26948517d2d26f3d7ca005363d119 # 2026/04/13
           path: ${{ github.workspace }}/ekat_src
       - name: Show action trigger
         uses: ./.github/actions/show-workflow-trigger

--- a/.github/workflows/at2_gcc-cuda.yml
+++ b/.github/workflows/at2_gcc-cuda.yml
@@ -82,6 +82,8 @@ jobs:
         with:
           repository: E3SM-Project/EKAT
           submodules: recursive
+          # NOTE: The ref: used here must match the one in CMakeLists.txt that will be used by
+          # cmake when running outside of github actions.
           ref: 007bdcff6cb26948517d2d26f3d7ca005363d119 # 2026/04/13
           path: ${{ github.workspace }}/ekat_src
       - name: Show action trigger

--- a/.github/workflows/gh_gcc-cpu.yml
+++ b/.github/workflows/gh_gcc-cpu.yml
@@ -111,6 +111,7 @@ jobs:
         with:
           repository: E3SM-Project/EKAT
           submodules: recursive
+          ref: 007bdcff6cb26948517d2d26f3d7ca005363d119 # 2026/04/13
           path: ${{ github.workspace }}/ekat_src
 
       - name: Configuring MAM4xx (${{ matrix.build-type }}, ${{ matrix.fp-precision }} precision)

--- a/.github/workflows/gh_gcc-cpu.yml
+++ b/.github/workflows/gh_gcc-cpu.yml
@@ -111,7 +111,9 @@ jobs:
         with:
           repository: E3SM-Project/EKAT
           submodules: recursive
-          ref: 007bdcff6cb26948517d2d26f3d7ca005363d119 # 2026/04/13
+          # NOTE: The ref: used here must match the one in CMakeLists.txt that will be used by
+          # cmake when running outside of github actions.
+          ref: 007bdcff6cb26948517d2d26f3d7ca005363d119 
           path: ${{ github.workspace }}/ekat_src
 
       - name: Configuring MAM4xx (${{ matrix.build-type }}, ${{ matrix.fp-precision }} precision)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,15 @@ if (MAM4XX_STANDALONE)
     set(ekat_SOURCE_DIR $ENV{EKAT_SOURCE_DIR})
     message(STATUS "Building EKAT from source at $ENV{EKAT_SOURCE_DIR}")
   endif()
+
+  # Fetch a specific SHA for ekat so we can update manually when needed and not
+  # every time ekat updates the master branch.  
+  # NOTE: This same tag is used in the github workflow actions and should match
+  # the tags in 
+  #      .github/workflows/at2_gcc-cuda.yml 
+  # and 
+  #      .github/workflows/at2_gcc-cuda.yml
+  # files for the actions/checkout@v4 ref: option. 
   FetchContent_Declare(
     EKAT
     GIT_REPOSITORY https://github.com/E3SM-Project/EKAT.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ if (MAM4XX_STANDALONE)
   # the tags in 
   #      .github/workflows/at2_gcc-cuda.yml 
   # and 
-  #      .github/workflows/at2_gcc-cuda.yml
+  #      .github/workflows/gh_gcc-cpu.yml
   # files for the actions/checkout@v4 ref: option. 
   FetchContent_Declare(
     EKAT


### PR DESCRIPTION
The CMakeLists.txt file clones a specific SHA of ekat but the github action was set up to clone master.  This made the github build different from a cmake build.  Now both checkout the same SHA. 