### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR not CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ else()
   set(MAM4XX_NUM_VERTICAL_LEVELS ${SCREAM_NUM_VERTICAL_LEV} CACHE STRING "the number of vertical levels per column equals scream num levels")
 endif()
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
 #--------------------------
 # End configurable options


### PR DESCRIPTION
For native mam4xx builds these are the same but when building mam4xx inside of E3SM, the CMAKE_CURRENT_SOURCE_DIR points to the mam4xx directory while CMAKE_SOURCE_DIR points to E3SM.