### PR TITLE
add scale factors for dust and seasalt emission

### DIFF
--- a/src/mam4xx/aero_model_emissions.hpp
+++ b/src/mam4xx/aero_model_emissions.hpp
@@ -29,16 +29,14 @@ constexpr int dust_nbin = 2;
 constexpr int dust_nnum = 2;
 // number of entries in the dust flux input array
 constexpr int dust_nflux_in = 4;
-// tuning parameter for dust emissions
-constexpr Real dust_emis_fact = -1.0e36;
 // Aerosol density [kg m-3]
 constexpr Real dust_density = 2.5e3;
 
 struct DustEmissionsData {
   // Kok11: fractions of bin (0.1-1) and bin (1-10) in size 0.1-10
-  KOKKOS_INLINE_FUNCTION Real dust_emis_scalefactor(const int index) const {
-    static constexpr Real dust_emis_scalefactor_[dust_nbin] = {0.011, 0.989};
-    return dust_emis_scalefactor_[index];
+  KOKKOS_INLINE_FUNCTION Real dust_emis_mass_frac_mode(const int index) const {
+    static constexpr Real dust_emis_mass_frac_mode_[dust_nbin] = {0.011, 0.989};
+    return dust_emis_mass_frac_mode_[index];
   }
   // got this value from fortran mam4::dust_model.F90:26
   KOKKOS_INLINE_FUNCTION Real dust_dmt_grd(const int index) const {
@@ -47,9 +45,7 @@ struct DustEmissionsData {
     return dust_dmt_grd_[index];
   }
   // tuning parameter for dust emissions
-  // perhaps unnecessary? it's not entirely clear to me what happens in
-  // the fortran call soil_erod_mod::soil_erod_init() where this is set
-  static constexpr Real soil_erosion_factor = 1.5;
+  Real dust_emis_scale_factor = 1.0;
   // this is set by init_dust_dmt_vwr() which takes in a constant value for
   // dust_dmt_grd (above)
   Real dust_dmt_vwr[dust_nbin];
@@ -90,8 +86,6 @@ constexpr int om_num_modes = 3;
 constexpr int seasalt_nbin = nsalt + nsalt_om;
 constexpr int seasalt_nnum = nnum + nnum_om;
 
-// FIXME: should this be read from the namelist instead?
-constexpr Real seasalt_emis_scalefactor = 0.6;
 // =============================================================================
 //      Marine Organic Matter Parameters/Constants
 // =============================================================================
@@ -192,6 +186,9 @@ struct SeasaltEmissionsData {
   }
 
   Real mpoly, mprot, mlip;
+
+  // tuning parameter for seasalt emissions
+  Real seasalt_emis_scale_factor = 1.0;
 };
 
 } // namespace BAD_CONSTANTS
@@ -359,8 +356,8 @@ void dust_emis(
       const int idx_dust = dust_indices[ibin];
       // FIXME: BAD CONSTANT
       cflux[idx_dust] = dust_flux_neg_sum * frac_ratio *
-                        data.dust_emis_scalefactor(ibin) * soil_erodibility /
-                        data.soil_erosion_factor * 1.15;
+                        data.dust_emis_mass_frac_mode(ibin) * soil_erodibility /
+                        data.dust_emis_scale_factor * 1.15;
       const int inum = dust_indices[ibin + dust_nbin];
       cflux[inum] = cflux[idx_dust] * dust_mass_to_num[ibin];
     }
@@ -514,7 +511,7 @@ KOKKOS_INLINE_FUNCTION
 void seasalt_emis_flux_calc(
     // in
     const Real (&fi)[salt_nsection], const Real &ocean_frac,
-    const Real &emis_scalefactor, const FluxType &flux_type,
+    const FluxType &flux_type,
     const SeasaltEmissionsData &data,
     // inout
     Real (&cflux)[pcnst]) {
@@ -522,7 +519,6 @@ void seasalt_emis_flux_calc(
   // input
   // fi: sea salt number fluxes in each size bin [#/m2/s]
   // ocean_frac: ocean fraction [unitless]
-  // emis_scalefactor: sea salt emission tuning factor [unitless]
   // flux_type: flux to be calculated--number flux == 0 or mass flux == 1
   //            NOTE: changed to an enum class for clarity
 
@@ -547,7 +543,7 @@ void seasalt_emis_flux_calc(
         Real cflux_tmp = 0.0;
         if (data.Dg(ibin) >= data.seasalt_size_range_lo(ispec) &&
             data.Dg(ibin) < data.seasalt_size_range_hi(ispec)) {
-          cflux_tmp = fi[ibin] * ocean_frac * emis_scalefactor;
+          cflux_tmp = fi[ibin] * ocean_frac * data.seasalt_emis_scale_factor;
 
           // For mass fluxes, multiply by the diameter
           // Note for C++ port, 4.0/3.0*pi*rdry[ibin]**3*seasalt_density
@@ -569,19 +565,19 @@ KOKKOS_INLINE_FUNCTION
 void seasalt_emis(
     // in
     const Real (&fi)[salt_nsection], const Real &ocean_frac,
-    const Real &emis_scalefactor, const SeasaltEmissionsData &data,
+    const SeasaltEmissionsData &data,
     // inout
     Real (&cflux)[pcnst]) {
   // calculate seasalt number emission fluxes
   seasalt_emis_flux_calc(
       // in
-      fi, ocean_frac, emis_scalefactor, FluxType::NumberFlux, data,
+      fi, ocean_frac, FluxType::NumberFlux, data,
       // inout
       cflux);
   // calculate seasalt mass emission fluxes
   seasalt_emis_flux_calc(
       // in
-      fi, ocean_frac, emis_scalefactor, FluxType::MassFlux, data,
+      fi, ocean_frac, FluxType::MassFlux, data,
       // inout
       cflux);
 } // end seasalt_emis()
@@ -751,13 +747,12 @@ KOKKOS_INLINE_FUNCTION
 void calc_marine_organic_numflux(
     // in
     const Real (&fi)[salt_nsection], const Real &ocean_frac,
-    const Real &emis_scalefactor, const Real (&om_seasalt)[salt_nsection],
+    const Real (&om_seasalt)[salt_nsection],
     const bool (&emit_this_mode)[organic_num_modes],
     const SeasaltEmissionsData &data,
     //  inout
     Real (&cflux)[pcnst]) {
   // ocean_frac: ocean fraction [unitless]
-  // emis_scalefactor: sea salt emission tuning factor
   // om_seasalt: marine organic aerosol fraction per size bin [unitless]
   // emit_this_mode: logical flags turn on/off marine organic emission in
   //                 aerosol modes
@@ -782,7 +777,7 @@ void calc_marine_organic_numflux(
         Real cflux_tmp = 0.0;
         if ((data.Dg(ibin) >= data.seasalt_size_range_lo(nsalt + ispec)) &&
             (data.Dg(ibin) < data.seasalt_size_range_hi(nsalt + ispec))) {
-          cflux_tmp = fi[ibin] * ocean_frac * emis_scalefactor;
+          cflux_tmp = fi[ibin] * ocean_frac * data.seasalt_emis_scale_factor;
           // Mixing state 3: internal mixture, add OM to mass and number
           cflux[num_mode_idx] +=
               cflux_tmp * (1.0 / (1.0 - om_seasalt[ibin]) - 1.0);
@@ -796,7 +791,7 @@ KOKKOS_INLINE_FUNCTION
 void calc_marine_organic_massflux(
     // in
     const Real (&fi)[salt_nsection], const Real &ocean_frac,
-    const Real &emis_scalefactor, const Real (&om_seasalt)[salt_nsection],
+    const Real (&om_seasalt)[salt_nsection],
     const Real (&mass_frac_bub_section)[n_organic_species_max][salt_nsection],
     const bool (&emit_this_mode)[organic_num_modes],
     const SeasaltEmissionsData &data,
@@ -804,7 +799,6 @@ void calc_marine_organic_massflux(
     Real (&cflux)[pcnst]) {
 
   // ocean_frac: ocean fraction [unitless]
-  // emis_scalefactor: sea salt emission tuning factor
   // om_seasalt: marine organic aerosol fraction per size bin [unitless]
   // mass_frac_bub_section: marine organic aerosol fraction per organic species
   //                        per size bin [unitless]
@@ -826,7 +820,7 @@ void calc_marine_organic_massflux(
           if ((data.Dg(ibin) >= data.seasalt_size_range_lo(idx_salt_offset)) &&
               (data.Dg(ibin) < data.seasalt_size_range_hi(idx_salt_offset))) {
             // should use dry size, convert from number to mass flux (kg/m2/s)
-            cflux_tmp = fi[ibin] * ocean_frac * emis_scalefactor * (4.0 / 3.0) *
+            cflux_tmp = fi[ibin] * ocean_frac * data.seasalt_emis_scale_factor * (4.0 / 3.0) *
                         Constants::pi * mam4::pow(data.rdry[ibin], 3) *
                         seasalt_density;
             // Mixing state 3: internal mixture, add OM to mass and number
@@ -847,14 +841,13 @@ KOKKOS_INLINE_FUNCTION
 void marine_organic_emissions(
     // in
     const Real (&fi)[salt_nsection], const Real &ocean_frac,
-    const Real &emis_scalefactor, const SeasaltEmissionsData &data,
+    const SeasaltEmissionsData &data,
     const bool (&emit_this_mode)[organic_num_modes],
     // inout
     Real (&cflux)[pcnst]) {
   // input
   // fi: sea salt number fluxes in each size bin [#/m2/s]
   // ocean_frac: ocean fraction [unitless]
-  // emis_scalefactor: sea salt emission tuning factor [unitless]
   // output
   // cflux: mass and number emission fluxes for aerosols [kg/m2/s or #/m2/s]
 
@@ -908,12 +901,12 @@ void marine_organic_emissions(
   // Total external mixture: emit only in modes 4, 5
   calc_marine_organic_numflux(
       // in
-      fi, ocean_frac, emis_scalefactor, om_seasalt, emit_this_mode, data,
+      fi, ocean_frac, om_seasalt, emit_this_mode, data,
       // inout
       cflux);
   calc_marine_organic_massflux(
       // in
-      fi, ocean_frac, emis_scalefactor, om_seasalt, mass_frac_bub_section,
+      fi, ocean_frac, om_seasalt, mass_frac_bub_section,
       emit_this_mode, data,
       // inout
       cflux);
@@ -950,7 +943,6 @@ void aero_model_emissions(
   const Real soil_erodibility = online_emiss_data.soil_erodibility;
 
   const Real dust_density_ = dust_density;
-  const Real seasalt_emis_scalefactor_ = seasalt_emis_scalefactor;
 
   dust_emis(
       // in
@@ -969,7 +961,7 @@ void aero_model_emissions(
 
   seasalt_emis(
       // in
-      fi, ocean_frac, seasalt_emis_scalefactor_, seasalt_data,
+      fi, ocean_frac, seasalt_data,
       //  inout
       cflux);
 
@@ -978,7 +970,7 @@ void aero_model_emissions(
 
   marine_organic_emissions(
       // in
-      fi, ocean_frac, seasalt_emis_scalefactor_, seasalt_data, emit_this_mode,
+      fi, ocean_frac, seasalt_data, emit_this_mode,
       // inout
       cflux);
 
@@ -990,6 +982,8 @@ void aero_model_emissions(const Real &sst, const Real &ocnfrac,
                           const Real &z_bottom, const const_view_1d &dstflx,
                           const Real &soil_erodibility, const Real &mpoly,
                           const Real &mprot, const Real &mlip,
+                          const Real &dust_emis_scale_factor,
+                          const Real &seasalt_emis_scale_factor,
                           // inout
                           view_1d &cflux_) {
 
@@ -1010,11 +1004,14 @@ void aero_model_emissions(const Real &sst, const Real &ocnfrac,
   seasalt_data.mpoly = mpoly;
   seasalt_data.mprot = mprot;
   seasalt_data.mlip = mlip;
+  seasalt_data.seasalt_emis_scale_factor = seasalt_emis_scale_factor;
 
   DustEmissionsData dust_data;
 
   // initialize dust_dmt_vwr data
   init_dust_dmt_vwr(dust_data);
+
+  dust_data.dust_emis_scale_factor = dust_emis_scale_factor;
 
   // Copy 1d view to an array
   Real cflux[pcnst];

--- a/src/mam4xx/aero_model_emissions.hpp
+++ b/src/mam4xx/aero_model_emissions.hpp
@@ -511,8 +511,7 @@ KOKKOS_INLINE_FUNCTION
 void seasalt_emis_flux_calc(
     // in
     const Real (&fi)[salt_nsection], const Real &ocean_frac,
-    const FluxType &flux_type,
-    const SeasaltEmissionsData &data,
+    const FluxType &flux_type, const SeasaltEmissionsData &data,
     // inout
     Real (&cflux)[pcnst]) {
 
@@ -820,9 +819,9 @@ void calc_marine_organic_massflux(
           if ((data.Dg(ibin) >= data.seasalt_size_range_lo(idx_salt_offset)) &&
               (data.Dg(ibin) < data.seasalt_size_range_hi(idx_salt_offset))) {
             // should use dry size, convert from number to mass flux (kg/m2/s)
-            cflux_tmp = fi[ibin] * ocean_frac * data.seasalt_emis_scale_factor * (4.0 / 3.0) *
-                        Constants::pi * mam4::pow(data.rdry[ibin], 3) *
-                        seasalt_density;
+            cflux_tmp = fi[ibin] * ocean_frac * data.seasalt_emis_scale_factor *
+                        (4.0 / 3.0) * Constants::pi *
+                        mam4::pow(data.rdry[ibin], 3) * seasalt_density;
             // Mixing state 3: internal mixture, add OM to mass and number
             // and avoid division by zero
             if (om_seasalt[ibin] > 0.0) {
@@ -906,8 +905,7 @@ void marine_organic_emissions(
       cflux);
   calc_marine_organic_massflux(
       // in
-      fi, ocean_frac, om_seasalt, mass_frac_bub_section,
-      emit_this_mode, data,
+      fi, ocean_frac, om_seasalt, mass_frac_bub_section, emit_this_mode, data,
       // inout
       cflux);
 } // end marine_organic_emissions()

--- a/src/validation/aero_emissions/dust_emis.cpp
+++ b/src/validation/aero_emissions/dust_emis.cpp
@@ -51,6 +51,7 @@ void dust_emis(Ensemble *ensemble) {
     for (int i = 0; i < dust_nbin; ++i) {
       data.dust_dmt_vwr[i] = dust_dmt_vwr_[i];
     }
+    data.dust_emis_scale_factor = 1.5;
 
     mam4::aero_model_emissions::dust_emis(dust_density, dust_flux_in, data,
                                           soil_erodibility, cflux);

--- a/src/validation/aero_emissions/marine_organic_emis.cpp
+++ b/src/validation/aero_emissions/marine_organic_emis.cpp
@@ -29,7 +29,6 @@ void marine_organic_emis(Ensemble *ensemble) {
 
     const auto fi_ = input.get_array("fi");
     const auto ocean_frac = input.get_array("ocnfrc")[0];
-    const auto emis_scalefactor = input.get_array("emis_scale")[0];
     const auto emit_this_mode_ = input.get_array("emit_this_mode");
     const auto cflux_ = input.get_array("cflx");
 
@@ -53,9 +52,10 @@ void marine_organic_emis(Ensemble *ensemble) {
     data.mpoly = input.get_array("mpoly")[0];
     data.mprot = input.get_array("mprot")[0];
     data.mlip = input.get_array("mlip")[0];
+    data.seasalt_emis_scale_factor = input.get_array("emis_scale")[0];
 
-    mam4::aero_model_emissions::marine_organic_emissions(
-        fi, ocean_frac, emis_scalefactor, data, emit_this_mode, cflux);
+    mam4::aero_model_emissions::marine_organic_emissions(fi, ocean_frac, data,
+                                                         emit_this_mode, cflux);
 
     std::vector<Real> cflux_out;
     for (int i = 0; i < pcnst; ++i) {

--- a/src/validation/aero_emissions/marine_organic_massflx_calc.cpp
+++ b/src/validation/aero_emissions/marine_organic_massflx_calc.cpp
@@ -42,7 +42,6 @@ void marine_organic_massflx_calc(Ensemble *ensemble) {
 
     const auto fi_ = input.get_array("fi");
     const Real ocean_frac = input.get_array("ocnfrc")[0];
-    const Real emis_scalefactor = input.get_array("emis_scale")[0];
     const auto om_seasalt_ = input.get_array("om_ssa");
     const auto mass_frac_bub_section_ =
         input.get_array("mass_frac_bub_section");
@@ -74,9 +73,10 @@ void marine_organic_massflx_calc(Ensemble *ensemble) {
 
     mam4::aero_model_emissions::SeasaltEmissionsData data;
     mam4::aero_model_emissions::init_seasalt(data);
+    data.seasalt_emis_scale_factor = input.get_array("emis_scale")[0];
     mam4::aero_model_emissions::calc_marine_organic_massflux(
-        fi, ocean_frac, emis_scalefactor, om_seasalt, mass_frac_bub_section,
-        emit_this_mode, data, cflux);
+        fi, ocean_frac, om_seasalt, mass_frac_bub_section, emit_this_mode, data,
+        cflux);
 
     std::vector<Real> cflux_out;
 

--- a/src/validation/aero_emissions/marine_organic_numflx_calc.cpp
+++ b/src/validation/aero_emissions/marine_organic_numflx_calc.cpp
@@ -40,7 +40,6 @@ void marine_organic_numflx_calc(Ensemble *ensemble) {
 
     const auto fi_ = input.get_array("fi");
     const Real ocean_frac = input.get_array("ocnfrc")[0];
-    const Real emis_scalefactor = input.get_array("emis_scale")[0];
     const auto om_seasalt_ = input.get_array("om_ssa");
     const auto emit_this_mode_ = input.get_array("emit_this_mode");
     const auto cflux_ = input.get_array("cflx");
@@ -66,9 +65,9 @@ void marine_organic_numflx_calc(Ensemble *ensemble) {
 
     mam4::aero_model_emissions::SeasaltEmissionsData data;
     mam4::aero_model_emissions::init_seasalt(data);
+    data.seasalt_emis_scale_factor = input.get_array("emis_scale")[0];
     mam4::aero_model_emissions::calc_marine_organic_numflux(
-        fi, ocean_frac, emis_scalefactor, om_seasalt, emit_this_mode, data,
-        cflux);
+        fi, ocean_frac, om_seasalt, emit_this_mode, data, cflux);
 
     std::vector<Real> cflux_out;
     for (int i = 0; i < pcnst; ++i) {

--- a/src/validation/aero_emissions/seasalt_emis.cpp
+++ b/src/validation/aero_emissions/seasalt_emis.cpp
@@ -28,7 +28,6 @@ void seasalt_emis(Ensemble *ensemble) {
 
     const auto fi_ = input.get_array("fi");
     const Real ocean_frac = input.get_array("ocnfrc")[0];
-    const Real emis_scalefactor = input.get_array("emis_scale")[0];
 
     constexpr int pcnst = mam4::pcnst;
     Real cflux[pcnst] = {0.0};
@@ -40,8 +39,8 @@ void seasalt_emis(Ensemble *ensemble) {
 
     mam4::aero_model_emissions::SeasaltEmissionsData data;
     mam4::aero_model_emissions::init_seasalt(data);
-    mam4::aero_model_emissions::seasalt_emis(fi, ocean_frac, emis_scalefactor,
-                                             data, cflux);
+    data.seasalt_emis_scale_factor = input.get_array("emis_scale")[0];
+    mam4::aero_model_emissions::seasalt_emis(fi, ocean_frac, data, cflux);
 
     std::vector<Real> cflux_out;
     // NOTE: the only entries that are changed are (c++ indexing):

--- a/src/validation/aero_emissions/seasalt_emisflx_calc_massflx.cpp
+++ b/src/validation/aero_emissions/seasalt_emisflx_calc_massflx.cpp
@@ -40,7 +40,6 @@ void seasalt_emisflx_calc_massflx(Ensemble *ensemble) {
 
     const auto fi_ = input.get_array("fi");
     const Real ocean_frac = input.get_array("ocnfrc")[0];
-    const Real emis_scalefactor = input.get_array("emis_scale")[0];
 
     constexpr int pcnst = mam4::pcnst;
     Real cflux[pcnst] = {0.0};
@@ -55,8 +54,9 @@ void seasalt_emisflx_calc_massflx(Ensemble *ensemble) {
 
     mam4::aero_model_emissions::SeasaltEmissionsData data;
     mam4::aero_model_emissions::init_seasalt(data);
-    mam4::aero_model_emissions::seasalt_emis_flux_calc(
-        fi, ocean_frac, emis_scalefactor, flux_type, data, cflux);
+    data.seasalt_emis_scale_factor = input.get_array("emis_scale")[0];
+    mam4::aero_model_emissions::seasalt_emis_flux_calc(fi, ocean_frac,
+                                                       flux_type, data, cflux);
 
     std::vector<Real> cflux_out;
     // NOTE: the only entries that are changed are (c++ indexing): 20, 25, 29

--- a/src/validation/aero_emissions/seasalt_emisflx_calc_numflx.cpp
+++ b/src/validation/aero_emissions/seasalt_emisflx_calc_numflx.cpp
@@ -40,7 +40,6 @@ void seasalt_emisflx_calc_numflx(Ensemble *ensemble) {
 
     const auto fi_ = input.get_array("fi");
     const Real ocean_frac = input.get_array("ocnfrc")[0];
-    const Real emis_scalefactor = input.get_array("emis_scale")[0];
 
     constexpr int pcnst = mam4::pcnst;
     Real cflux[pcnst] = {0.0};
@@ -55,8 +54,9 @@ void seasalt_emisflx_calc_numflx(Ensemble *ensemble) {
 
     mam4::aero_model_emissions::SeasaltEmissionsData data;
     mam4::aero_model_emissions::init_seasalt(data);
-    mam4::aero_model_emissions::seasalt_emis_flux_calc(
-        fi, ocean_frac, emis_scalefactor, flux_type, data, cflux);
+    data.seasalt_emis_scale_factor = input.get_array("emis_scale")[0];
+    mam4::aero_model_emissions::seasalt_emis_flux_calc(fi, ocean_frac,
+                                                       flux_type, data, cflux);
 
     std::vector<Real> cflux_out;
     // NOTE: the only entries that are changed are (c++ indexing): 22, 27, 35


### PR DESCRIPTION
Current MAMxx uses hard-wired emission factors, this PR add two scale factors

srf_emis_scale_factor_for_seasalt (default value is 0.6)
srf_emis_scale_factor_for_dust (default value is 1.5)

as namelist variables for dust and seasalt emission in MAMxx. This PR should be BFB.