### PR TITLE
Fixed some aerosol species indexing problems reported in #558.

### DIFF
--- a/src/mam4xx/aero_modes.hpp
+++ b/src/mam4xx/aero_modes.hpp
@@ -6,7 +6,7 @@
 #ifndef MAM4XX_AERO_MODES_HPP
 #define MAM4XX_AERO_MODES_HPP
 
-#include "aero_species.hpp"
+#include "aero_config.hpp"
 #include "gas_species.hpp"
 #include "mam4_constants.hpp"
 
@@ -122,7 +122,7 @@ KOKKOS_INLINE_FUNCTION const mam4::Mode &modes(const int i) {
   return M[i];
 };
 
-// A list of species within each mode for MAM4.
+/// Returns the aerosol species  A list of species within each mode for MAM4.
 KOKKOS_INLINE_FUNCTION AeroId mode_aero_species(const int modeNo,
                                                 const int speciesNo) {
   // A list of species within each mode for MAM4.
@@ -158,19 +158,47 @@ KOKKOS_INLINE_FUNCTION int num_species_mode(const int i) {
 /// -1 if the species is not found within the mode.
 KOKKOS_INLINE_FUNCTION
 int aerosol_index_for_mode(ModeIndex mode, AeroId aero_id) {
-  int mode_index = static_cast<int>(mode);
-  for (int s = 0; s < 7; ++s) {
+  for (int s = 0; s < int(AeroId::NumSpecies); ++s) {
+    int mode_index = static_cast<int>(mode);
     if (aero_id == mode_aero_species(mode_index, s)) {
       return s;
     }
   }
   return -1;
 }
+
 /// Convenient function that returns bool indicating if species is
 /// within mode.
 KOKKOS_INLINE_FUNCTION
 bool mode_contains_species(ModeIndex mode, AeroId aero_id) {
   return -1 != aerosol_index_for_mode(mode, aero_id);
+}
+
+/// Calls the given lambda function f for each species in mode1 that also
+/// appears in mode2, returning the number of species found in both modes. The
+/// signature of the function f is: void f(const AeroId species_id,
+///        int idx_of_species_in_mode1,
+///        int idx_of_species_in_mode2,
+///        int num_matches_so_far)
+/// and can use any variable in the scope at which
+/// for_aerosol_species_common_to_modes is called.
+template <typename Lambda>
+KOKKOS_INLINE_FUNCTION int
+for_matching_aero_species_in_modes(const AeroConfig &aero_config,
+                                   const ModeIndex mode1, const ModeIndex mode2,
+                                   Lambda f) {
+  int matches = 0;
+  for (int s_idx1 = 0; s_idx1 < aero_config.num_aerosol_ids(); ++s_idx1) {
+    AeroId species1 = mode_aero_species(int(mode1), s_idx1);
+    for (int s_idx2 = 0; s_idx2 < aero_config.num_aerosol_ids(); ++s_idx2) {
+      AeroId species2 = mode_aero_species(int(mode2), s_idx2);
+      if (species1 == species2) {
+        f(species1, s_idx1, s_idx2, matches);
+        ++matches;
+      }
+    }
+  }
+  return matches;
 }
 
 } // namespace mam4

--- a/src/mam4xx/aero_species.cpp
+++ b/src/mam4xx/aero_species.cpp
@@ -9,37 +9,39 @@
 namespace mam4 {
 
 AeroSpeciesHostView default_aero_species() {
-  AeroSpeciesHostView species("Aerosol species", int(AeroId::NumSpecies));
-  species[int(AeroId::SOA)] =
-      AeroSpecies{Constants::molec_weight_c, defaults::mam4_density_soa,
-                  defaults::mam4_hyg_soa};
-  species[int(AeroId::SO4)] =
-      AeroSpecies{Constants::molec_weight_so4, defaults::mam4_density_so4,
-                  defaults::mam4_hyg_so4};
-  species[int(AeroId::POM)] =
-      AeroSpecies{Constants::molec_weight_c, defaults::mam4_density_pom,
-                  defaults::mam4_hyg_pom};
-  species[int(AeroId::BC)] =
-      AeroSpecies{Constants::molec_weight_c, defaults::mam4_density_bc,
-                  defaults::mam4_hyg_bc};
-  species[int(AeroId::NaCl)] =
-      AeroSpecies{Constants::molec_weight_nacl, defaults::mam4_density_nacl,
-                  defaults::mam4_hyg_nacl};
-  species[int(AeroId::DST)] =
-      AeroSpecies{defaults::mam4_molec_weight_dst, defaults::mam4_density_dst,
-                  defaults::mam4_hyg_dst};
-  species[int(AeroId::MOM)] =
-      AeroSpecies{defaults::mam4_molec_weight_mom, defaults::mam4_density_mom,
-                  defaults::mam4_hyg_mom};
+  AeroSpeciesHostView species(
+      "Aerosol species",
+      {
+          AeroSpecies{AeroId::SOA, Constants::molec_weight_c,
+                      defaults::mam4_density_soa, defaults::mam4_hyg_soa},
+          AeroSpecies{AeroId::SO4, Constants::molec_weight_so4,
+                      defaults::mam4_density_so4, defaults::mam4_hyg_so4},
+          AeroSpecies{AeroId::POM, Constants::molec_weight_c,
+                      defaults::mam4_density_pom, defaults::mam4_hyg_pom},
+          AeroSpecies{AeroId::BC, Constants::molec_weight_c,
+                      defaults::mam4_density_bc, defaults::mam4_hyg_bc},
+          AeroSpecies{AeroId::NaCl, Constants::molec_weight_nacl,
+                      defaults::mam4_density_nacl, defaults::mam4_hyg_nacl},
+          AeroSpecies{AeroId::DST, defaults::mam4_molec_weight_dst,
+                      defaults::mam4_density_dst, defaults::mam4_hyg_dst},
+          AeroSpecies{AeroId::MOM, defaults::mam4_molec_weight_mom,
+                      defaults::mam4_density_mom, defaults::mam4_hyg_mom},
+      });
   return species;
 }
 
 AeroSpeciesView
 aero_species_on_device(const AeroSpeciesHostView &species_on_host) {
-  AeroSpeciesView species_on_device("On-device aerosol species",
-                                    species_on_host.extent(0));
-  Kokkos::deep_copy(species_on_device, species_on_host);
+  AeroSpeciesView species_on_device("On-device aerosol species");
+  Kokkos::deep_copy(species_on_device.view_, species_on_host.view_);
   return species_on_device;
+}
+
+AeroSpeciesHostView
+aero_species_on_host(const AeroSpeciesView &species_on_device) {
+  AeroSpeciesHostView species_on_host("On-host aerosol species");
+  Kokkos::deep_copy(species_on_host.view_, species_on_device.view_);
+  return species_on_host;
 }
 
 std::string aero_id_str(const AeroId aid) {

--- a/src/mam4xx/aero_species.hpp
+++ b/src/mam4xx/aero_species.hpp
@@ -120,21 +120,38 @@ AeroIdRange all_aerosol_ids() { return AeroIdRange(); }
 
 // Here's a generic container you can associate with an aerosol species,
 // accessing it with an AeroId instead of an integer index.
-template <typename T> class AeroSpeciesData {
+template <typename T, typename DeviceType = ekat::DefaultDevice>
+class AeroSpeciesData {
 public:
   AeroSpeciesData() : view_() {}
   explicit AeroSpeciesData(const std::string &label)
       : view_(label, int(AeroId::NumSpecies)) {}
   AeroSpeciesData(const std::string &label, std::initializer_list<T> data)
       : view_(label, int(AeroId::NumSpecies)) {
-    for (size_t i = 0; i < data.size(); ++i)
-      view_[i] = data.begin()[i];
+    if (not std::is_same<DeviceType, ekat::HostDevice>::value) {
+      auto host_data = on_host();
+      for (size_t i = 0; i < data.size(); ++i)
+        host_data.view_[i] = data.begin()[i];
+      copy_from_host(host_data);
+    }
   }
   KOKKOS_INLINE_FUNCTION
   AeroSpeciesData(const AeroSpeciesData &) = default;
 
   KOKKOS_INLINE_FUNCTION
   AeroSpeciesData &operator=(const AeroSpeciesData &) = default;
+
+  // allocates a copy of the species data on the host
+  AeroSpeciesData<T, ekat::HostDevice>
+  on_host(const std::string label = "") const {
+    AeroSpeciesData<T, ekat::HostDevice> host_data(label);
+    Kokkos::deep_copy(host_data.view_, view_);
+    return host_data;
+  }
+  // copies host data into place on device
+  void copy_from_host(const AeroSpeciesData<T, ekat::HostDevice> &host_data) {
+    Kokkos::deep_copy(view_, host_data.view_);
+  }
 
   // access to species via AeroIds
   KOKKOS_INLINE_FUNCTION
@@ -145,7 +162,10 @@ public:
   constexpr size_t size() const { return view_.extent(0); }
 
 private:
-  typename ekat::KokkosTypes<ekat::DefaultDevice>::view_1d<T> view_;
+  typename ekat::KokkosTypes<DeviceType>::view_1d<T> view_;
+
+  friend class AeroSpeciesData<T, ekat::HostDevice>;
+  friend class AeroSpeciesData<T, ekat::DefaultDevice>;
 };
 
 // default values for aerosol species properties

--- a/src/mam4xx/aero_species.hpp
+++ b/src/mam4xx/aero_species.hpp
@@ -13,19 +13,6 @@
 
 namespace mam4 {
 
-/// @struct AeroSpecies
-/// This type represents an aerosol species.
-struct AeroSpecies {
-  // Molecular weight [kg/mol]
-  Real molecular_weight;
-
-  /// Material density [kg/m^3]
-  Real density;
-
-  /// Hygroscopicity
-  Real hygroscopicity;
-};
-
 /// Identifiers for aerosol species that inhabit MAM4 modes.
 enum class AeroId {
   SOA = 0,        // secondary organic aerosol
@@ -39,13 +26,127 @@ enum class AeroId {
   None = 8        // invalid aerosol species
 };
 
-/// A device-side Kokkos View containing aerosol species.
-using AeroSpeciesView =
-    typename ekat::KokkosTypes<ekat::DefaultDevice>::view_1d<AeroSpecies>;
+/// @struct AeroSpecies
+/// This type represents an aerosol species.
+struct AeroSpecies {
+  // Canonical species identifier
+  AeroId id;
+  // Molecular weight [kg/mol]
+  Real molecular_weight;
 
-/// A host-side Kokkos View for configuring aerosol species.
-using AeroSpeciesHostView =
-    typename ekat::KokkosTypes<ekat::HostDevice>::view_1d<AeroSpecies>;
+  /// Material density [kg/m^3]
+  Real density;
+
+  /// Hygroscopicity
+  Real hygroscopicity;
+};
+
+/// This wraps a view of AeroSpecies, allowing only certain operations, and
+/// indexing by AeroId, which creates a distinction between AeroId and integer
+/// aerosol-mode indices, which are a rich source of bugs.
+template <typename DeviceType> class AeroSpeciesList {
+public:
+  explicit AeroSpeciesList(const std::string &label)
+      : view_(label, int(AeroId::NumSpecies)) {}
+  AeroSpeciesList(const std::string &label,
+                  std::initializer_list<AeroSpecies> species)
+      : view_(label, int(AeroId::NumSpecies)) {
+    for (size_t i = 0; i < species.size(); ++i)
+      view_[i] = species.begin()[i];
+  }
+
+  // access to species via AeroIds
+  KOKKOS_INLINE_FUNCTION
+  const AeroSpecies &operator[](AeroId id) const { return view_[int(id)]; }
+  KOKKOS_INLINE_FUNCTION
+  AeroSpecies &operator[](AeroId id) { return view_[int(id)]; }
+
+  KOKKOS_INLINE_FUNCTION
+  constexpr size_t size() const { return view_.extent(0); }
+
+private:
+  typename ekat::KokkosTypes<DeviceType>::view_1d<AeroSpecies> view_;
+
+  // these functions get access to view_
+  friend AeroSpeciesList<ekat::DefaultDevice>
+  aero_species_on_device(const AeroSpeciesList<ekat::HostDevice> &);
+  friend AeroSpeciesList<ekat::HostDevice>
+  aero_species_on_host(const AeroSpeciesList<ekat::DefaultDevice> &);
+};
+
+/// TODO: Rename these types to indicate that they're not **exactly** Kokkos
+/// views, but rather thin wrappers around them to enforce aerosol identifier
+/// type safety.
+using AeroSpeciesView = AeroSpeciesList<ekat::DefaultDevice>;
+using AeroSpeciesHostView = AeroSpeciesList<ekat::HostDevice>;
+
+// This iterator allows you to loop over all aerosol species with a C++ range
+// iterator. E.g. for (AeroId aid: all_aerosol_ids()) {
+//   // your logic goes here
+// }
+class AeroIdIterator {
+  int value_;
+
+public:
+  KOKKOS_INLINE_FUNCTION
+  explicit AeroIdIterator(int v) : value_(v) {}
+  KOKKOS_INLINE_FUNCTION
+  AeroId operator*() const { return static_cast<AeroId>(value_); }
+  KOKKOS_INLINE_FUNCTION
+  AeroIdIterator &operator++() {
+    ++value_;
+    return *this;
+  }
+  KOKKOS_INLINE_FUNCTION
+  bool operator!=(const AeroIdIterator &other) const {
+    return value_ != other.value_;
+  }
+};
+
+class AeroIdRange {
+  int begin_value_, end_value_;
+
+public:
+  KOKKOS_INLINE_FUNCTION
+  AeroIdRange() : begin_value_(0), end_value_(int(AeroId::NumSpecies)) {}
+  KOKKOS_INLINE_FUNCTION
+  AeroIdIterator begin() const { return AeroIdIterator(begin_value_); }
+  KOKKOS_INLINE_FUNCTION
+  AeroIdIterator end() const { return AeroIdIterator(end_value_); }
+};
+
+KOKKOS_INLINE_FUNCTION
+AeroIdRange all_aerosol_ids() { return AeroIdRange(); }
+
+// Here's a generic container you can associate with an aerosol species,
+// accessing it with an AeroId instead of an integer index.
+template <typename T> class AeroSpeciesData {
+public:
+  AeroSpeciesData() : view_() {}
+  explicit AeroSpeciesData(const std::string &label)
+      : view_(label, int(AeroId::NumSpecies)) {}
+  AeroSpeciesData(const std::string &label, std::initializer_list<T> data)
+      : view_(label, int(AeroId::NumSpecies)) {
+    for (size_t i = 0; i < data.size(); ++i)
+      view_[i] = data.begin()[i];
+  }
+  KOKKOS_INLINE_FUNCTION
+  AeroSpeciesData(const AeroSpeciesData &) = default;
+
+  KOKKOS_INLINE_FUNCTION
+  AeroSpeciesData &operator=(const AeroSpeciesData &) = default;
+
+  // access to species via AeroIds
+  KOKKOS_INLINE_FUNCTION
+  const T &operator[](AeroId id) const { return view_[int(id)]; }
+  KOKKOS_INLINE_FUNCTION
+  T &operator[](AeroId id) { return view_[int(id)]; }
+  KOKKOS_INLINE_FUNCTION
+  constexpr size_t size() const { return view_.extent(0); }
+
+private:
+  typename ekat::KokkosTypes<ekat::DefaultDevice>::view_1d<T> view_;
+};
 
 // default values for aerosol species properties
 namespace defaults {
@@ -88,7 +189,12 @@ AeroSpeciesHostView default_aero_species();
 /// Return a newly-created device view whose data is copied from the given host
 /// view.
 AeroSpeciesView
-aero_species_on_device(const AeroSpeciesHostView &aero_species_on_host);
+aero_species_on_device(const AeroSpeciesHostView &species_on_host);
+
+/// Return a newly-created host view whose data is copied from the given device
+/// view.
+AeroSpeciesHostView
+aero_species_on_host(const AeroSpeciesView &species_on_device);
 
 /// Maps an AeroId to the name of its species.
 std::string aero_id_str(const AeroId id);

--- a/src/mam4xx/aging.hpp
+++ b/src/mam4xx/aging.hpp
@@ -92,8 +92,6 @@ KOKKOS_INLINE_FUNCTION void mam_pcarbon_aging_frac(
         frac_coag) { // fraction of aerosol change due to coagulation [unitless]
 
   const int ipair = 0;
-  const int iaer_so4 = static_cast<int>(AeroId::SO4);
-  const int iaer_soa = static_cast<int>(AeroId::SOA);
 
   const int imom_pc = static_cast<int>(ModeIndex::PrimaryCarbon);
 
@@ -103,9 +101,9 @@ KOKKOS_INLINE_FUNCTION void mam_pcarbon_aging_frac(
 
   // Compute the aerosol volume per mole
   const Real so4_vol =
-      _molecular_weight_so4 * 1000.0 / aero_species(iaer_so4).density;
+      _molecular_weight_so4 * 1000.0 / aero_species[AeroId::SO4].density;
   const Real soa_vol =
-      _molecular_weight_soa * 1000.0 / aero_species(iaer_soa).density;
+      _molecular_weight_soa * 1000.0 / aero_species[AeroId::SOA].density;
 
   // (Bad Constants) for hygroscopicitiy
   constexpr Real hygro_soa = 0.14000000000000001;
@@ -113,6 +111,11 @@ KOKKOS_INLINE_FUNCTION void mam_pcarbon_aging_frac(
   const Real fac_m2v_eqvhyg_aer = soa_vol * hygro_soa / hygro_so4;
 
   // for default MAM4 only so4 and soa contribute to aging
+  // FIXME: should iaer_so4 and iaer_soa be species mode indices instead of
+  // AeroIds??
+  const int iaer_so4 = static_cast<int>(AeroId::SO4);
+  const int iaer_soa = static_cast<int>(AeroId::SOA);
+
   const Real vol_shell = qaer_cur[iaer_so4][imom_pc] * so4_vol +
                          qaer_cur[iaer_soa][imom_pc] * fac_m2v_eqvhyg_aer;
   Real qaer_del_cond_tmp =

--- a/src/mam4xx/calcsize.hpp
+++ b/src/mam4xx/calcsize.hpp
@@ -7,6 +7,7 @@
 #define MAM4XX_CALCSIZE_HPP
 
 #include "aero_config.hpp"
+#include "aero_modes.hpp"
 #include "atmosphere.hpp"
 #include "conversions.hpp"
 #include "floating_point.hpp"
@@ -896,37 +897,30 @@ public:
     config_ = calcsize_config;
     const Real one = 1.0;
 
-    // find aerosol species in accumulation that can be transfer to aitken mode
-    const int accum_idx = int(ModeIndex::Accumulation);
-    const int aitken_idx = int(ModeIndex::Aitken);
+    // find aerosol species in accumulation that can be transferred to aitken
+    // mode
 
-    // check if accumulation species exists in aitken mode
-    // also save idx for transfer
-    int count = 0;
-    for (int isp = 0; isp < num_species_mode(accum_idx); ++isp) {
-      // assume species can not be transfer.
+    // first assume all species cannot be transferred.
+    for (int isp = 0; isp < aero_config.num_aerosol_ids(); ++isp) {
       _noxf_acc2ait[isp] = true;
-      AeroId sp_accum = mode_aero_species(accum_idx, isp);
+    }
 
-      for (int jsp = 0; jsp < num_species_mode(aitken_idx); ++jsp) {
-        AeroId sp_aitken = mode_aero_species(aitken_idx, jsp);
-        if (sp_accum == sp_aitken) {
-          // false : can be transfer.
-          _noxf_acc2ait[isp] = false;
+    // now find species common to the two modes and record their indices
+    int count = for_matching_aero_species_in_modes(
+        aero_config, ModeIndex::Accumulation, ModeIndex::Aitken,
+        [&](AeroId species_id, int species_idx_in_mode1,
+            int species_idx_in_mode2, int num_matches_so_far) {
+          // false : can be transferred
+          _noxf_acc2ait[species_idx_in_mode1] = false;
           // save index for transfer from accumulation to aitken mode
-          _acc_spec_in_ait[count] = isp;
+          _acc_spec_in_ait[num_matches_so_far] = species_idx_in_mode1;
           // save index for transfer from aitken to accumulation mode
-          _ait_spec_in_acc[count] = jsp;
-          count++;
-          break;
-        }
-      } // end aitken foor
-    }   // end accumulation for
+          _ait_spec_in_acc[num_matches_so_far] = species_idx_in_mode2;
+        });
     _n_common_species_ait_accum = count;
 
     // Set mode parameters.
-    auto aero_species_h = Kokkos::create_mirror_view(aero_config.aero_species);
-    Kokkos::deep_copy(aero_species_h, aero_config.aero_species);
+    auto aero_species_h = aero_species_on_host(aero_config.aero_species);
     for (int m = 0; m < AeroConfig::num_modes(); ++m) {
       // FIXME: There is a comment in modal_aero_newnuc.F90 that Dick Easter
       // FIXME: thinks that dgnum_aer isn't used in MAM4, but it is actually
@@ -949,8 +943,8 @@ public:
       // compute inv density; density is constant, so we can compute in init.
       const auto n_spec = num_species_mode(m);
       for (int ispec = 0; ispec < n_spec; ispec++) {
-        const int aero_id = int(mode_aero_species(m, ispec));
-        _inv_density[m][ispec] = Real(1.0) / aero_species_h(aero_id).density;
+        auto aero_id = mode_aero_species(m, ispec);
+        _inv_density[m][ispec] = Real(1.0) / aero_species_h[aero_id].density;
       } // for(ispec)
       // FIXME: do we need to update num2vol_ratio_min_nmodes and
       // num2vol_ratio_max_nmodes as well?

--- a/src/mam4xx/convproc.hpp
+++ b/src/mam4xx/convproc.hpp
@@ -457,15 +457,15 @@ public:
   static Real specdens_amode(const AeroSpeciesView &aero_species, const int i) {
     // clang-format off
     const Real specdens_amode[maxd_aspectype] = {
-      aero_species(int(AeroId::SO4)).density,
+      aero_species[AeroId::SO4].density,
       mam4::max(),
       mam4::max(),
-      aero_species(int(AeroId::POM)).density,
-      aero_species(int(AeroId::SOA)).density,
-      aero_species(int(AeroId::BC)).density,
-      aero_species(int(AeroId::NaCl)).density,
-      aero_species(int(AeroId::DST)).density,
-      aero_species(int(AeroId::MOM)).density,
+      aero_species[AeroId::POM].density,
+      aero_species[AeroId::SOA].density,
+      aero_species[AeroId::BC].density,
+      aero_species[AeroId::NaCl].density,
+      aero_species[AeroId::DST].density,
+      aero_species[AeroId::MOM].density,
       0, 0, 0, 0, 0};
     // clang-format on
     return specdens_amode[i];
@@ -477,15 +477,15 @@ public:
   static Real spechygro(const AeroSpeciesView &aero_species, const int i) {
     // clang-format off
     const Real spechygro[maxd_aspectype] = {
-       aero_species(int(AeroId::SO4)).hygroscopicity,
+       aero_species[AeroId::SO4].hygroscopicity,
        mam4::max(),
        mam4::max(),
-       aero_species(int(AeroId::POM)).hygroscopicity,
-       0.1400000000e+00, // FIXME: should be aero_species(int(AeroId::SOA)).hygroscopicity
-       aero_species(int(AeroId::BC)).hygroscopicity,
-       aero_species(int(AeroId::NaCl)).hygroscopicity,
-       0.6800000000e-01, // FIXME: should be aero_species(int(AeroId::DST)).hygroscopicity,
-       aero_species(int(AeroId::MOM)).hygroscopicity,
+       aero_species[AeroId::POM].hygroscopicity,
+       0.1400000000e+00, // FIXME: should be aero_species(AeroId::SOA).hygroscopicity
+       aero_species[AeroId::BC].hygroscopicity,
+       aero_species[AeroId::NaCl].hygroscopicity,
+       0.6800000000e-01, // FIXME: should be aero_species(AeroId::DST).hygroscopicity,
+       aero_species[AeroId::MOM].hygroscopicity,
        0, 0, 0, 0, 0};
     // clang-format on
     return spechygro[i];

--- a/src/mam4xx/hetfrz.hpp
+++ b/src/mam4xx/hetfrz.hpp
@@ -934,8 +934,8 @@ KOKKOS_INLINE_FUNCTION void calculate_mass_mean_radius(
   hetraer[1] = r_dust_a1_prescribed;
   hetraer[2] = r_dust_a3_prescribed;
 
-  const Real specdens_bc = aero_species(int(AeroId::BC)).density;
-  const Real specdens_dust = aero_species(int(AeroId::DST)).density;
+  const Real specdens_bc = aero_species[AeroId::BC].density;
+  const Real specdens_dust = aero_species[AeroId::DST].density;
   // BC
   if (((bcmac + bcmpc) * 1.0e-3 > aermc_min_threshold) &
       (bc_num > aernum_min_threshold)) {
@@ -1002,12 +1002,12 @@ KOKKOS_INLINE_FUNCTION void calculate_coated_fraction(
   const Real pom_equivso4_factor = spechygro_pom / spechygro_so4;
   const Real mom_equivso4_factor = spechygro_mom / spechygro_so4;
 
-  const Real specdens_so4 = aero_species(int(AeroId::SO4)).density;
-  const Real specdens_pom = aero_species(int(AeroId::POM)).density;
-  const Real specdens_mom = aero_species(int(AeroId::MOM)).density;
-  const Real specdens_soa = aero_species(int(AeroId::SOA)).density;
-  const Real specdens_dst = aero_species(int(AeroId::DST)).density;
-  const Real specdens_bc = aero_species(int(AeroId::BC)).density;
+  const Real specdens_so4 = aero_species[AeroId::SO4].density;
+  const Real specdens_pom = aero_species[AeroId::POM].density;
+  const Real specdens_mom = aero_species[AeroId::MOM].density;
+  const Real specdens_soa = aero_species[AeroId::SOA].density;
+  const Real specdens_dst = aero_species[AeroId::DST].density;
+  const Real specdens_bc = aero_species[AeroId::BC].density;
 
   vol_shell[1] =
       (so4mac / specdens_so4 + pommac * pom_equivso4_factor / specdens_pom +

--- a/src/mam4xx/mam4_amicphys.hpp
+++ b/src/mam4xx/mam4_amicphys.hpp
@@ -1127,7 +1127,7 @@ void mam_newnuc_1subarea(
 KOKKOS_INLINE_FUNCTION
 void mam_amicphys_1subarea(
     // in
-    const AeroSpeciesView &aero_species, const int newnuc_h2so4_conc_optaa,
+    const AeroConfig &aero_config, const int newnuc_h2so4_conc_optaa,
     const int gaexch_h2so4_uptake_optaa, const bool do_cond_sub,
     const bool do_rename_sub, const bool do_newnuc_sub, const bool do_coag_sub,
     const Real deltat, const int jsubarea, const bool iscldy_subarea,
@@ -1509,18 +1509,21 @@ void mam_amicphys_1subarea(
           qaercw_delsub_grow4rnam_tmp[im][is] = qaercw_delsub_grow4rnam[is][im];
         }
       }
+
       // BAD CONSTANT
-      constexpr Real mass_2_vol[num_aerosol_ids] = {0.15,
-                                                    6.4971751412429377e-002,
-                                                    0.15,
-                                                    7.0588235294117650e-003,
-                                                    3.0789473684210526e-002,
-                                                    5.1923076923076926e-002,
-                                                    156.20986883198000};
+      AeroSpeciesData<Real> mass_2_vol("mass-to-volume conversion factors");
+      mass_2_vol[AeroId::SOA] = 0.15;
+      mass_2_vol[AeroId::SO4] = 6.4971751412429377e-002;
+      mass_2_vol[AeroId::POM] = 0.15;
+      mass_2_vol[AeroId::BC] = 7.0588235294117650e-003;
+      mass_2_vol[AeroId::NaCl] = 3.0789473684210526e-002;
+      mass_2_vol[AeroId::DST] = 5.1923076923076926e-002;
+      mass_2_vol[AeroId::MOM] = 156.20986883198000;
 
       Rename rename;
       rename.mam_rename_1subarea_(
-          iscldy_subarea, smallest_dryvol_value, dest_mode_of_mode,   // in
+          aero_config, iscldy_subarea, smallest_dryvol_value,
+          dest_mode_of_mode,                                          // in
           mean_std_dev, fmode_dist_tail_fac, v2n_lo_rlx, v2n_hi_rlx,  // in
           ln_diameter_tail_fac, num_pairs, diameter_cutoff,           // in
           ln_dia_cutoff, diameter_threshold, mass_2_vol, dgnum_amode, // in
@@ -1667,11 +1670,11 @@ void mam_amicphys_1subarea(
 
     if (do_aging_in_subarea) {
       mam4::aging::mam_pcarbon_aging_1subarea(
-          aero_species, n_so4_monolayers_pcage, dgn_a,  // input
-          qnum_cur, qnum_delsub_cond, qnum_delsub_coag, // in-outs
-          qaer_cur, qaer_delsub_cond, qaer_delsub_coag, // in-outs
-          qaer_delsub_coag_in);                         // in-outs
-    }                                                   // do_aging_in_subarea
+          aero_config.aero_species, n_so4_monolayers_pcage, dgn_a, // input
+          qnum_cur, qnum_delsub_cond, qnum_delsub_coag,            // in-outs
+          qaer_cur, qaer_delsub_cond, qaer_delsub_coag,            // in-outs
+          qaer_delsub_coag_in);                                    // in-outs
+    } // do_aging_in_subarea
 
     // The following block has to be placed here (after both condensation and
     // aging) as both can change the values of qnum_delsub_cond and

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -19,7 +19,7 @@ namespace modal_aero_calcsize {
 constexpr int maxd_aspectype = ndrop::maxd_aspectype;
 
 inline void init_calcsize(
-    const AeroSpeciesHostView &aero_species,
+    const AeroConfig &aero_config,
     Real inv_density[AeroConfig::num_modes()][AeroConfig::num_aerosol_ids()],
     Real num2vol_ratio_min[AeroConfig::num_modes()],
     Real num2vol_ratio_max[AeroConfig::num_modes()],
@@ -40,36 +40,33 @@ inline void init_calcsize(
 
   // find aerosol species in accumulation that can be transfer to aitken mode
   const int accum_idx = int(ModeIndex::Accumulation);
-  const int aitken_idx = int(ModeIndex::Aitken);
+
+  // first assume all species cannot be transferred.
+  for (int isp = 0; isp < aero_config.num_aerosol_ids(); ++isp) {
+    noxf_acc2ait[isp] = true;
+  }
 
   // check if accumulation species exists in aitken mode
   // also save idx for transfer
-  int count = 0;
-  for (int isp = 0; isp < num_species_mode(accum_idx); ++isp) {
-    // assume species can not be transfer.
-    noxf_acc2ait[isp] = true;
-    AeroId sp_accum = mode_aero_species(accum_idx, isp);
-
-    for (int jsp = 0; jsp < num_species_mode(aitken_idx); ++jsp) {
-      AeroId sp_aitken = mode_aero_species(aitken_idx, jsp);
-      if (sp_accum == sp_aitken) {
+  int count = for_matching_aero_species_in_modes(
+      aero_config, ModeIndex::Accumulation, ModeIndex::Aitken,
+      [&](AeroId species_id, int species_idx_in_mode1, int species_idx_in_mode2,
+          int num_matches_so_far) {
         // false : can be transfer.
-        noxf_acc2ait[isp] = false;
+        noxf_acc2ait[species_idx_in_mode1] = false;
         // save index for transfer from accumulation to aitken mode
         // adding offset because we are using this index for state_q
         // Note: we assuimg accum mode is the first mode
-        acc_spec_in_ait[count] = isp + utils::aero_start_ind();
+        acc_spec_in_ait[num_matches_so_far] =
+            species_idx_in_mode1 + utils::aero_start_ind();
         // save index for transfer from aitken to accumulation mode
         // adding offset because we are using this index for state_q
         // offset: aero_start + num of spec accum + 1 (number concentration)
         // Note: we assumig Aitken mode is the second mode
-        ait_spec_in_acc[count] =
-            jsp + utils::aero_start_ind() + num_species_mode(accum_idx) + 1;
-        count++;
-        break;
-      }
-    } // end aitken foor
-  }   // end accumulation for
+        ait_spec_in_acc[num_matches_so_far] = species_idx_in_mode2 +
+                                              utils::aero_start_ind() +
+                                              num_species_mode(accum_idx) + 1;
+      });
   n_common_species_ait_accum = count;
 
   // Set mode parameters.
@@ -95,8 +92,8 @@ inline void init_calcsize(
     // compute inv density; density is constant, so we can compute in init.
     const auto n_spec = num_species_mode(m);
     for (int ispec = 0; ispec < n_spec; ispec++) {
-      const int aero_id = int(mode_aero_species(m, ispec));
-      inv_density[m][ispec] = Real(1.0) / aero_species(aero_id).density;
+      AeroId aid = mode_aero_species(m, ispec);
+      inv_density[m][ispec] = Real(1.0) / aero_config.aero_species[aid].density;
     } // for(ispec)
     // FIXME: do we need to update num2vol_ratio_min_nmodes and
     // num2vol_ratio_max_nmodes as well?
@@ -130,8 +127,12 @@ struct CalcsizeData {
   const bool do_aitacc_transfer = true;
   bool update_mmr = false;
 
-  void initialize() {
-    init_calcsize(default_aero_species(), inv_density, num2vol_ratio_min,
+  void initialize(const AeroConfig &aero_config) {
+    ndrop::get_e3sm_parameters(nspec_amode, lspectype_amode, lmassptr_amode,
+                               numptr_amode, specdens_amode, spechygro, mam_idx,
+                               mam_cnst_idx);
+
+    init_calcsize(aero_config, inv_density, num2vol_ratio_min,
                   num2vol_ratio_max, num2vol_ratio_max_nmodes,
                   num2vol_ratio_min_nmodes, num2vol_ratio_nom_nmodes,
                   dgnmin_nmodes, dgnmax_nmodes, dgnnom_nmodes,

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -70,6 +70,7 @@ inline void init_calcsize(
   n_common_species_ait_accum = count;
 
   // Set mode parameters.
+  auto aero_species_h = aero_species_on_host(aero_config.aero_species);
   for (int m = 0; m < AeroConfig::num_modes(); ++m) {
     // FIXME: There is a comment in modal_aero_newnuc.F90 that Dick Easter
     // FIXME: thinks that dgnum_aer isn't used in MAM4, but it is actually
@@ -93,7 +94,7 @@ inline void init_calcsize(
     const auto n_spec = num_species_mode(m);
     for (int ispec = 0; ispec < n_spec; ispec++) {
       AeroId aid = mode_aero_species(m, ispec);
-      inv_density[m][ispec] = Real(1.0) / aero_config.aero_species[aid].density;
+      inv_density[m][ispec] = Real(1.0) / aero_species_h[aid].density;
     } // for(ispec)
     // FIXME: do we need to update num2vol_ratio_min_nmodes and
     // num2vol_ratio_max_nmodes as well?

--- a/src/mam4xx/mode_dry_particle_size.hpp
+++ b/src/mam4xx/mode_dry_particle_size.hpp
@@ -35,11 +35,10 @@ void mode_avg_dry_particle_diam(const AeroSpeciesView &aero_species,
                                 const Prognostics &progs, int mode_idx, int k) {
   Real volume_mixing_ratio_i = 0.0; // [m3 aerosol / kg air]
   Real volume_mixing_ratio_c = 0.0; // [m3 aerosol / kg air]
-  for (int aid = 0; aid < AeroConfig::num_aerosol_ids(); ++aid) {
-    const int s = aerosol_index_for_mode(static_cast<ModeIndex>(mode_idx),
-                                         static_cast<AeroId>(aid));
+  for (AeroId aid : all_aerosol_ids()) {
+    const int s = aerosol_index_for_mode(static_cast<ModeIndex>(mode_idx), aid);
     if (s >= 0) {
-      const AeroSpecies &species = aero_species(aid);
+      const AeroSpecies &species = aero_species[aid];
       volume_mixing_ratio_i += progs.q_aero_i[mode_idx][s](k) / species.density;
 
       volume_mixing_ratio_c += progs.q_aero_c[mode_idx][s](k) / species.density;

--- a/src/mam4xx/mode_dry_particle_size.hpp
+++ b/src/mam4xx/mode_dry_particle_size.hpp
@@ -39,11 +39,10 @@ void mode_avg_dry_particle_diam(const AeroSpeciesView &aero_species,
     const int s = aerosol_index_for_mode(static_cast<ModeIndex>(mode_idx),
                                          static_cast<AeroId>(aid));
     if (s >= 0) {
-      volume_mixing_ratio_i +=
-          progs.q_aero_i[mode_idx][s](k) / aero_species(s).density;
+      const AeroSpecies &species = aero_species(aid);
+      volume_mixing_ratio_i += progs.q_aero_i[mode_idx][s](k) / species.density;
 
-      volume_mixing_ratio_c +=
-          progs.q_aero_c[mode_idx][s](k) / aero_species(s).density;
+      volume_mixing_ratio_c += progs.q_aero_c[mode_idx][s](k) / species.density;
     }
   }
   const Real mean_vol_i = volume_mixing_ratio_i / progs.n_mode_i[mode_idx](k);

--- a/src/mam4xx/mode_hygroscopicity.hpp
+++ b/src/mam4xx/mode_hygroscopicity.hpp
@@ -43,10 +43,10 @@ void mode_hygroscopicity_i(const AeroSpeciesView &aero_species,
     const int s = aerosol_index_for_mode(static_cast<ModeIndex>(mode_idx),
                                          static_cast<AeroId>(aid));
     if (s >= 0) {
+      const AeroSpecies &species = aero_species(aid);
       const Real mass_mix_ratio = progs.q_aero_i[mode_idx][s](k);
-      volume_mixing_ratio += mass_mix_ratio / aero_species(s).density;
-      hyg += mass_mix_ratio * aero_species(s).hygroscopicity /
-             aero_species(s).density;
+      volume_mixing_ratio += mass_mix_ratio / species.density;
+      hyg += mass_mix_ratio * species.hygroscopicity / species.density;
     }
   }
   diags.hygroscopicity[mode_idx](k) = hyg / volume_mixing_ratio;

--- a/src/mam4xx/mode_hygroscopicity.hpp
+++ b/src/mam4xx/mode_hygroscopicity.hpp
@@ -39,11 +39,10 @@ void mode_hygroscopicity_i(const AeroSpeciesView &aero_species,
                            int mode_idx, int k) {
   Real hyg = 0.0;
   Real volume_mixing_ratio = 0.0; // [m3 aerosol / kg air]
-  for (int aid = 0; aid < AeroConfig::num_aerosol_ids(); ++aid) {
-    const int s = aerosol_index_for_mode(static_cast<ModeIndex>(mode_idx),
-                                         static_cast<AeroId>(aid));
+  for (AeroId aid : all_aerosol_ids()) {
+    const int s = aerosol_index_for_mode(static_cast<ModeIndex>(mode_idx), aid);
     if (s >= 0) {
-      const AeroSpecies &species = aero_species(aid);
+      const AeroSpecies &species = aero_species[aid];
       const Real mass_mix_ratio = progs.q_aero_i[mode_idx][s](k);
       volume_mixing_ratio += mass_mix_ratio / species.density;
       hyg += mass_mix_ratio * species.hygroscopicity / species.density;

--- a/src/mam4xx/mode_wet_particle_size.hpp
+++ b/src/mam4xx/mode_wet_particle_size.hpp
@@ -218,13 +218,13 @@ void mode_avg_wet_particle_diam_water_uptake(const Diagnostics &diags,
 //    @param dgn_awet [out] geometric mean diameter (m) of each aerosol mode
 // ------------------------------------------------------------------------
 KOKKOS_INLINE_FUNCTION
-void diag_dgn_wet(
-    const mam4::AeroConfig &aero_config,
-    const Real qaer_cur[mam4::AeroConfig::num_aerosol_ids()]
-                       [mam4::AeroConfig::num_modes()],
-    const Real qnum_cur[mam4::AeroConfig::num_modes()],
-    const Real molecular_weight_gm[mam4::AeroConfig::num_aerosol_ids()],
-    const Real dwet_ddry_ratio, Real dgn_awet[mam4::AeroConfig::num_modes()]) {
+void diag_dgn_wet(const mam4::AeroConfig &aero_config,
+                  const Real qaer_cur[mam4::AeroConfig::num_aerosol_ids()]
+                                     [mam4::AeroConfig::num_modes()],
+                  const Real qnum_cur[mam4::AeroConfig::num_modes()],
+                  const AeroSpeciesData<Real> molecular_weight_gm,
+                  const Real dwet_ddry_ratio,
+                  Real dgn_awet[mam4::AeroConfig::num_modes()]) {
   static constexpr int num_aer = mam4::AeroConfig::num_aerosol_ids();
   static constexpr int num_modes = mam4::AeroConfig::num_modes();
   // --------------------------
@@ -236,9 +236,9 @@ void diag_dgn_wet(
     for (int iaer = 0; iaer < num_aer; ++iaer) {
       const AeroId aid = mode_aero_species(n, iaer);
       if (aid != AeroId::None) {
-        const Real weight_gm_per_mol = molecular_weight_gm[iaer];
+        const Real weight_gm_per_mol = molecular_weight_gm[aid];
         const Real tmpa = qaer_cur[iaer][n] * weight_gm_per_mol;
-        tmp_dryvol += tmpa / aero_config.aero_species(int(aid)).density;
+        tmp_dryvol += tmpa / aero_config.aero_species[aid].density;
       }
     }
     // Convert dry volume to dry diameter, then to wet diameter

--- a/src/mam4xx/mode_wet_particle_size.hpp
+++ b/src/mam4xx/mode_wet_particle_size.hpp
@@ -234,9 +234,12 @@ void diag_dgn_wet(
     Real tmp_dryvol = 0.0;
     // Sum up the volume of all species in this mode
     for (int iaer = 0; iaer < num_aer; ++iaer) {
-      const Real weight_gm_per_mol = molecular_weight_gm[iaer];
-      const Real tmpa = qaer_cur[iaer][n] * weight_gm_per_mol;
-      tmp_dryvol += tmpa / aero_config.aero_species(iaer).density;
+      const AeroId aid = mode_aero_species(n, iaer);
+      if (aid != AeroId::None) {
+        const Real weight_gm_per_mol = molecular_weight_gm[iaer];
+        const Real tmpa = qaer_cur[iaer][n] * weight_gm_per_mol;
+        tmp_dryvol += tmpa / aero_config.aero_species(int(aid)).density;
+      }
     }
     // Convert dry volume to dry diameter, then to wet diameter
     const Real sx = std::log(mam4::modes(n).mean_std_dev);

--- a/src/mam4xx/nucleate_ice.hpp
+++ b/src/mam4xx/nucleate_ice.hpp
@@ -265,7 +265,7 @@ private:
       _nucleate_ice_subgrid;
 
 public:
-  AeroSpeciesView aero_species;
+  AeroSpeciesView aero_species = aero_species_on_device(default_aero_species());
 
   // name--unique name of the process implemented by this class
   const char *name() const { return "MAM4 nucleate_ice"; }

--- a/src/mam4xx/rename.hpp
+++ b/src/mam4xx/rename.hpp
@@ -673,18 +673,20 @@ public:
           rename_idx = _mam4xx2rename_idx[imode][jspec];
 
           const AeroId aero_id = mode_aero_species(imode, jspec);
-          const Real molecular_weight =
-              aero_species(int(aero_id)).molecular_weight;
+          if (aero_id != AeroId::None) {
+            const Real molecular_weight =
+                aero_species(int(aero_id)).molecular_weight;
 
-          // convert mass mixing ratios to molar mixing ratios
-          qmol_i_cur[imode][rename_idx] = conversions::vmr_from_mmr(
-              prognostics.q_aero_i[imode][rename_idx](kk), molecular_weight);
-          qmol_i_del[imode][rename_idx] = conversions::vmr_from_mmr(
-              tendencies.q_aero_i[imode][rename_idx](kk), molecular_weight);
-          qmol_c_cur[imode][rename_idx] = conversions::vmr_from_mmr(
-              prognostics.q_aero_c[imode][rename_idx](kk), molecular_weight);
-          qmol_c_del[imode][rename_idx] = conversions::vmr_from_mmr(
-              tendencies.q_aero_c[imode][rename_idx](kk), molecular_weight);
+            // convert mass mixing ratios to molar mixing ratios
+            qmol_i_cur[imode][rename_idx] = conversions::vmr_from_mmr(
+                prognostics.q_aero_i[imode][rename_idx](kk), molecular_weight);
+            qmol_i_del[imode][rename_idx] = conversions::vmr_from_mmr(
+                tendencies.q_aero_i[imode][rename_idx](kk), molecular_weight);
+            qmol_c_cur[imode][rename_idx] = conversions::vmr_from_mmr(
+                prognostics.q_aero_c[imode][rename_idx](kk), molecular_weight);
+            qmol_c_del[imode][rename_idx] = conversions::vmr_from_mmr(
+                tendencies.q_aero_c[imode][rename_idx](kk), molecular_weight);
+          }
         }
       }
 

--- a/src/mam4xx/rename.hpp
+++ b/src/mam4xx/rename.hpp
@@ -580,21 +580,21 @@ public:
     // than the ones from aero_modes.hpp this uses the aero_modes.hpp values
     const Real unit_factor = 1000; // from kg/mol to kg/kmol
 
-    for (int iaero = 0; iaero < AeroConfig::num_aerosol_ids(); ++iaero) {
-      _mass_2_vol[iaero] = aero_species_h(iaero).molecular_weight /
-                           aero_species_h(iaero).density * unit_factor;
+    for (int aid = 0; aid < AeroConfig::num_aerosol_ids(); ++aid) {
+      _mass_2_vol[aid] = aero_species_h(aid).molecular_weight /
+                         aero_species_h(aid).density * unit_factor;
     }
     // Correction because of differences in MWs between mam4xx and mam4
-    int iaer_soa = aerosol_index_for_mode(ModeIndex::Accumulation, AeroId::SOA);
-    int iaer_so4 = aerosol_index_for_mode(ModeIndex::Accumulation, AeroId::SO4);
-    int iaer_pom = aerosol_index_for_mode(ModeIndex::Accumulation, AeroId::POM);
+    int soa_idx = int(AeroId::SOA);
+    int so4_idx = int(AeroId::SO4);
+    int pom_idx = int(AeroId::POM);
 
-    _mass_2_vol[iaer_soa] =
-        config_._molecular_weight_soa / aero_species_h(iaer_soa).density;
-    _mass_2_vol[iaer_so4] =
-        config_._molecular_weight_so4 / aero_species_h(iaer_so4).density;
-    _mass_2_vol[iaer_pom] =
-        config_._molecular_weight_pom / aero_species_h(iaer_pom).density;
+    _mass_2_vol[soa_idx] =
+        config_._molecular_weight_soa / aero_species_h(soa_idx).density;
+    _mass_2_vol[so4_idx] =
+        config_._molecular_weight_so4 / aero_species_h(so4_idx).density;
+    _mass_2_vol[pom_idx] =
+        config_._molecular_weight_pom / aero_species_h(pom_idx).density;
 
   } // end(init)
 
@@ -671,19 +671,20 @@ public:
         for (int jspec = 0; jspec < nspec; ++jspec) {
           // get the mapping from the mam4xx species ordering to rename's
           rename_idx = _mam4xx2rename_idx[imode][jspec];
+
+          const AeroId aero_id = mode_aero_species(imode, jspec);
+          const Real molecular_weight =
+              aero_species(int(aero_id)).molecular_weight;
+
           // convert mass mixing ratios to molar mixing ratios
           qmol_i_cur[imode][rename_idx] = conversions::vmr_from_mmr(
-              prognostics.q_aero_i[imode][rename_idx](kk),
-              aero_species(rename_idx).molecular_weight);
+              prognostics.q_aero_i[imode][rename_idx](kk), molecular_weight);
           qmol_i_del[imode][rename_idx] = conversions::vmr_from_mmr(
-              tendencies.q_aero_i[imode][rename_idx](kk),
-              aero_species(rename_idx).molecular_weight);
+              tendencies.q_aero_i[imode][rename_idx](kk), molecular_weight);
           qmol_c_cur[imode][rename_idx] = conversions::vmr_from_mmr(
-              prognostics.q_aero_c[imode][rename_idx](kk),
-              aero_species(rename_idx).molecular_weight);
+              prognostics.q_aero_c[imode][rename_idx](kk), molecular_weight);
           qmol_c_del[imode][rename_idx] = conversions::vmr_from_mmr(
-              tendencies.q_aero_c[imode][rename_idx](kk),
-              aero_species(rename_idx).molecular_weight);
+              tendencies.q_aero_c[imode][rename_idx](kk), molecular_weight);
         }
       }
 

--- a/src/mam4xx/rename.hpp
+++ b/src/mam4xx/rename.hpp
@@ -572,7 +572,6 @@ public:
                                 _num_pairs,                 // out
                                 _diameter_cutoff,           // out
                                 _ln_dia_cutoff, _diameter_threshold);
-    auto aero_species_h = aero_species_on_host(aero_config.aero_species);
 
     for (int imode = 0; imode < AeroConfig::num_modes(); ++imode) {
       _dgnum_amode[imode] = modes(imode).nom_diameter;
@@ -588,7 +587,8 @@ public:
     //     150, 115, 150, 12, 58.5, 135, 250092}; // [kg/kmol]
     // for (int iaero = 0; iaero < AeroConfig::num_aerosol_ids(); ++iaero) {
     //   _mass_2_vol[iaero] =
-    //      molecular_weight_rename[iaero] / aero_species_h(iaero).density;
+    //      molecular_weight_rename[iaero] /
+    //      aero_config.aero_species(iaero).density;
     // }
     // FIXME.
     // Molecular weights (MW) of aerosol species have units of kg/mol,
@@ -599,19 +599,22 @@ public:
 
     _mass_2_vol =
         AeroSpeciesData<Real>("Aerosol mass-to-volume conversion factors");
+    auto mass_2_vol_h = _mass_2_vol.on_host();
+    auto aero_species_h = aero_species_on_host(aero_config.aero_species);
     for (AeroId aid : all_aerosol_ids()) {
-      _mass_2_vol[aid] = aero_species_h[aid].molecular_weight /
-                         aero_species_h[aid].density * unit_factor;
+      mass_2_vol_h[aid] = aero_species_h[aid].molecular_weight /
+                          aero_species_h[aid].density * unit_factor;
     }
 
     // Corrections because of differences in MWs between mam4xx and mam4
-    _mass_2_vol[AeroId::SOA] =
+    mass_2_vol_h[AeroId::SOA] =
         config_._molecular_weight_soa / aero_species_h[AeroId::SO4].density;
-    _mass_2_vol[AeroId::SO4] =
+    mass_2_vol_h[AeroId::SO4] =
         config_._molecular_weight_so4 / aero_species_h[AeroId::SO4].density;
-    _mass_2_vol[AeroId::POM] =
+    mass_2_vol_h[AeroId::POM] =
         config_._molecular_weight_pom / aero_species_h[AeroId::POM].density;
 
+    _mass_2_vol.copy_from_host(mass_2_vol_h);
   } // end(init)
 
   // NOTE: this corresponds to mam_rename_1subarea() in the fortran refactor
@@ -729,8 +732,7 @@ public:
   } // end compute_tendencies()
 
   // Make mam_rename_1subarea public for testing proposes.
-  KOKKOS_INLINE_FUNCTION
-  void mam_rename_1subarea_(
+  KOKKOS_INLINE_FUNCTION void mam_rename_1subarea_(
       const AeroConfig &aero_config, const bool is_cloudy_cur,
       const Real &smallest_dryvol_value,
       const int *dest_mode_of_mode,                             // in

--- a/src/mam4xx/rename.hpp
+++ b/src/mam4xx/rename.hpp
@@ -19,21 +19,39 @@ namespace mam4 {
 
 namespace rename {
 
+/// This function converts a mass-mixing ratio (mmr, [kg aerosol/kg air]) for
+/// the given species to an aerosol specific volume [aerosol m^3/kg air]
+KOKKOS_INLINE_FUNCTION
+double specific_volume_from_mmr(const AeroSpecies &species, double mmr) {
+  const Real molecular_weight =
+      1000.0 * species.molecular_weight; // kg/mol -> kg/kmol
+  return mmr * molecular_weight / species.density;
+}
+
+/// This function converts a volume-mixing ratio (vmr) for the given species to
+/// a mass-mixing ratio (mmr)
+KOKKOS_INLINE_FUNCTION
+double mmr_from_specific_volume(const AeroSpecies &species,
+                                double specific_volume) {
+  const Real molecular_weight =
+      1000.0 * species.molecular_weight; // kg/mol -> kg/kmol
+  return specific_volume * species.density / molecular_weight;
+}
+
 KOKKOS_INLINE_FUNCTION
 void compute_dryvol_change_in_src_mode(
-    const int nmode,              // in
-    const int nspec,              // in
-    const int *dest_mode_of_mode, // in
+    const AeroConfig &aero_config, // in
+    const int *dest_mode_of_mode,  // in
     const Real q_mmr[AeroConfig::num_modes()]
                     [AeroConfig::num_aerosol_ids()], // in
     const Real q_del_growth[AeroConfig::num_modes()]
                            [AeroConfig::num_aerosol_ids()], // in
-    const Real mass_2_vol[AeroConfig::num_aerosol_ids()],   // in
+    const AeroSpeciesData<Real> mass_2_vol,                 // in
     Real dryvol[AeroConfig::num_modes()],
     Real deldryvol[AeroConfig::num_modes()] // out
 ) {
   const Real zero = 0;
-  for (int m = 0; m < nmode; ++m) {
+  for (int m = 0; m < aero_config.num_modes(); ++m) {
     int dest_mode = dest_mode_of_mode[m];
 
     if (dest_mode >= 0) {
@@ -52,13 +70,13 @@ void compute_dryvol_change_in_src_mode(
       // [(g/mol-species) / (kg-species/m3)]; where molecular_weight has units
       // [g/mol-species] and density units are [kg-species/m3] which results in
       // the units of m3/kmol-species
-
-      for (int ispec = 0; ispec < nspec; ++ispec) {
+      for (AeroId aid : all_aerosol_ids()) {
+        int ispec = aerosol_index_for_mode(ModeIndex(m), aid);
         // Multiply by mass_2_vol [m3/kmol-species] to convert
         // q_mmr [kmol-species/kmol-air] to volume units [m3/kmol-air]
-        tmp_dryvol += q_mmr[m][ispec] * mass_2_vol[ispec];
+        tmp_dryvol += q_mmr[m][ispec] * mass_2_vol[aid];
         // accumulate the "growth" in volume units as well
-        tmp_del_dryvol += q_del_growth[m][ispec] * mass_2_vol[ispec];
+        tmp_del_dryvol += q_del_growth[m][ispec] * mass_2_vol[aid];
       }
 
       // This is dry volume before the growth
@@ -534,8 +552,8 @@ private:
       // is the amount of a given species. This factor is obtained by
       // (molecular_weight/density) of a species. That is, [ (g/mol-species) /
       // (kg-species/m3)].
-      _mass_2_vol[AeroConfig::num_aerosol_ids()],
       _dgnum_amode[AeroConfig::num_modes()];
+  AeroSpeciesData<Real> _mass_2_vol;
 
 public:
   // name--unique name of the process implemented by this class
@@ -554,8 +572,7 @@ public:
                                 _num_pairs,                 // out
                                 _diameter_cutoff,           // out
                                 _ln_dia_cutoff, _diameter_threshold);
-    auto aero_species_h = Kokkos::create_mirror_view(aero_config.aero_species);
-    Kokkos::deep_copy(aero_species_h, aero_config.aero_species);
+    auto aero_species_h = aero_species_on_host(aero_config.aero_species);
 
     for (int imode = 0; imode < AeroConfig::num_modes(); ++imode) {
       _dgnum_amode[imode] = modes(imode).nom_diameter;
@@ -580,21 +597,20 @@ public:
     // than the ones from aero_modes.hpp this uses the aero_modes.hpp values
     const Real unit_factor = 1000; // from kg/mol to kg/kmol
 
-    for (int aid = 0; aid < AeroConfig::num_aerosol_ids(); ++aid) {
-      _mass_2_vol[aid] = aero_species_h(aid).molecular_weight /
-                         aero_species_h(aid).density * unit_factor;
+    _mass_2_vol =
+        AeroSpeciesData<Real>("Aerosol mass-to-volume conversion factors");
+    for (AeroId aid : all_aerosol_ids()) {
+      _mass_2_vol[aid] = aero_species_h[aid].molecular_weight /
+                         aero_species_h[aid].density * unit_factor;
     }
-    // Correction because of differences in MWs between mam4xx and mam4
-    int soa_idx = int(AeroId::SOA);
-    int so4_idx = int(AeroId::SO4);
-    int pom_idx = int(AeroId::POM);
 
-    _mass_2_vol[soa_idx] =
-        config_._molecular_weight_soa / aero_species_h(soa_idx).density;
-    _mass_2_vol[so4_idx] =
-        config_._molecular_weight_so4 / aero_species_h(so4_idx).density;
-    _mass_2_vol[pom_idx] =
-        config_._molecular_weight_pom / aero_species_h(pom_idx).density;
+    // Corrections because of differences in MWs between mam4xx and mam4
+    _mass_2_vol[AeroId::SOA] =
+        config_._molecular_weight_soa / aero_species_h[AeroId::SO4].density;
+    _mass_2_vol[AeroId::SO4] =
+        config_._molecular_weight_so4 / aero_species_h[AeroId::SO4].density;
+    _mass_2_vol[AeroId::POM] =
+        config_._molecular_weight_pom / aero_species_h[AeroId::POM].density;
 
   } // end(init)
 
@@ -675,7 +691,7 @@ public:
           const AeroId aero_id = mode_aero_species(imode, jspec);
           if (aero_id != AeroId::None) {
             const Real molecular_weight =
-                aero_species(int(aero_id)).molecular_weight;
+                aero_species[aero_id].molecular_weight;
 
             // convert mass mixing ratios to molar mixing ratios
             qmol_i_cur[imode][rename_idx] = conversions::vmr_from_mmr(
@@ -690,7 +706,7 @@ public:
         }
       }
 
-      mam_rename_1subarea_(is_cloudy_cur, smallest_dryvol_value,
+      mam_rename_1subarea_(config, is_cloudy_cur, smallest_dryvol_value,
                            dest_mode_of_mode,                  // in
                            mean_std_dev,                       // in
                            fmode_dist_tail_fac,                // in
@@ -715,7 +731,8 @@ public:
   // Make mam_rename_1subarea public for testing proposes.
   KOKKOS_INLINE_FUNCTION
   void mam_rename_1subarea_(
-      const bool is_cloudy_cur, const Real &smallest_dryvol_value,
+      const AeroConfig &aero_config, const bool is_cloudy_cur,
+      const Real &smallest_dryvol_value,
       const int *dest_mode_of_mode,                             // in
       const Real mean_std_dev[AeroConfig::num_modes()],         // in
       const Real fmode_dist_tail_fac[AeroConfig::num_modes()],  // in
@@ -726,9 +743,9 @@ public:
       const Real diameter_cutoff[AeroConfig::num_modes()],      // in
       const Real ln_dia_cutoff[AeroConfig::num_modes()],        // in
       const Real diameter_threshold[AeroConfig::num_modes()],   // in
-      const Real mass_2_vol[AeroConfig::num_aerosol_ids()],
-      const Real dgnum_amode[AeroConfig::num_modes()], // in
-      Real qnum_i_cur[AeroConfig::num_modes()],        // out
+      const AeroSpeciesData<Real> &mass_2_vol,                  // in
+      const Real dgnum_amode[AeroConfig::num_modes()],          // in
+      Real qnum_i_cur[AeroConfig::num_modes()],                 // out
       Real qmol_i_cur[AeroConfig::num_modes()]
                      [AeroConfig::num_aerosol_ids()], // out
       const Real qmol_i_del[AeroConfig::num_modes()]
@@ -748,15 +765,13 @@ public:
     // Interstitial aerosols: Compute initial (before growth) aerosol dry
     // volume and also the growth in dry volume of the "src" mode
 
-    rename::compute_dryvol_change_in_src_mode(
-        mam4::AeroConfig::num_modes(),       // in
-        mam4::AeroConfig::num_aerosol_ids(), // in
-        dest_mode_of_mode,                   // in
-        qmol_i_cur,                          // in
-        qmol_i_del,                          // in
-        mass_2_vol,                          // in
-        dryvol_i,                            // out
-        deldryvol_i                          // out
+    rename::compute_dryvol_change_in_src_mode(aero_config,       // in
+                                              dest_mode_of_mode, // in
+                                              qmol_i_cur,        // in
+                                              qmol_i_del,        // in
+                                              mass_2_vol,        // in
+                                              dryvol_i,          // out
+                                              deldryvol_i        // out
     );
 
     Real dryvol_c[mam4::AeroConfig::num_modes()] = {zero};
@@ -764,15 +779,13 @@ public:
 
     if (is_cloudy_cur) {
 
-      rename::compute_dryvol_change_in_src_mode(
-          AeroConfig::num_modes(),       // in
-          AeroConfig::num_aerosol_ids(), // in
-          dest_mode_of_mode,             // in
-          qmol_c_cur,                    // in
-          qmol_c_del,                    // in
-          mass_2_vol,                    // in
-          dryvol_c,                      // out
-          deldryvol_c                    // out
+      rename::compute_dryvol_change_in_src_mode(aero_config,       // in
+                                                dest_mode_of_mode, // in
+                                                qmol_c_cur,        // in
+                                                qmol_c_del,        // in
+                                                mass_2_vol,        // in
+                                                dryvol_c,          // out
+                                                deldryvol_c        // out
       );
 
     } // end is_cloudy_cur

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -72,15 +72,14 @@ inline void init_scavimptbl(const AeroConfig &aero_config,
     sigmag_amode[i] = modes(i).mean_std_dev;
   }
 
-  auto aero_species = Kokkos::create_mirror(aero_config.aero_species);
-  Kokkos::deep_copy(aero_species, aero_config.aero_species);
+  auto aero_species_h = aero_species_on_host(aero_config.aero_species);
 
   // Note: Original code uses the following aerosol densities.
   // sulfate, sulfate, dust, p-organic
-  aerosol_dry_density[0] = aero_species(int(AeroId::SO4)).density;
-  aerosol_dry_density[1] = aero_species(int(AeroId::SO4)).density;
-  aerosol_dry_density[2] = aero_species(int(AeroId::DST)).density;
-  aerosol_dry_density[3] = aero_species(int(AeroId::POM)).density;
+  aerosol_dry_density[0] = aero_species_h[AeroId::SO4].density;
+  aerosol_dry_density[1] = aero_species_h[AeroId::SO4].density;
+  aerosol_dry_density[2] = aero_species_h[AeroId::DST].density;
+  aerosol_dry_density[3] = aero_species_h[AeroId::POM].density;
   aero_model::modal_aero_bcscavcoef_init(dgnum_amode, sigmag_amode,
                                          aerosol_dry_density, scavimptblnum,
                                          scavimptblvol);

--- a/src/tests/mode_averages_unit_tests.cpp
+++ b/src/tests/mode_averages_unit_tests.cpp
@@ -73,11 +73,11 @@ TEST_CASE("modal_averages", "") {
     Real dry_aero_mean_particle_diam_total[4];
     for (int m = 0; m < 4; ++m) {
       Real dry_vol = 0.0;
-      for (int aid = 0; aid < 7; ++aid) {
-        const int s = aerosol_index_for_mode(static_cast<mam4::ModeIndex>(m),
-                                             static_cast<mam4::AeroId>(aid));
+      for (mam4::AeroId aid : mam4::all_aerosol_ids()) {
+        const int s =
+            aerosol_index_for_mode(static_cast<mam4::ModeIndex>(m), aid);
         if (s >= 0) {
-          dry_vol += mass_mixing_ratio / aero_species_h(aid).density;
+          dry_vol += mass_mixing_ratio / aero_species_h[aid].density;
         }
       }
       const Real mean_vol = dry_vol / number_mixing_ratio;
@@ -152,11 +152,11 @@ TEST_CASE("modal_averages", "") {
     for (int m = 0; m < 4; ++m) {
       Real dry_vol = 0.0;
       Real hyg = 0.0;
-      for (int aid = 0; aid < 7; ++aid) {
-        const int s = aerosol_index_for_mode(static_cast<mam4::ModeIndex>(m),
-                                             static_cast<mam4::AeroId>(aid));
+      for (mam4::AeroId aid : mam4::all_aerosol_ids()) {
+        const int s =
+            aerosol_index_for_mode(static_cast<mam4::ModeIndex>(m), aid);
         if (s >= 0) {
-          const mam4::AeroSpecies &species = aero_species_h(aid);
+          const mam4::AeroSpecies &species = aero_species_h[aid];
           dry_vol += mass_mixing_ratio / species.density;
           hyg += mass_mixing_ratio * species.hygroscopicity / species.density;
         }

--- a/src/tests/mode_averages_unit_tests.cpp
+++ b/src/tests/mode_averages_unit_tests.cpp
@@ -77,7 +77,7 @@ TEST_CASE("modal_averages", "") {
         const int s = aerosol_index_for_mode(static_cast<mam4::ModeIndex>(m),
                                              static_cast<mam4::AeroId>(aid));
         if (s >= 0) {
-          dry_vol += mass_mixing_ratio / aero_species_h(s).density;
+          dry_vol += mass_mixing_ratio / aero_species_h(aid).density;
         }
       }
       const Real mean_vol = dry_vol / number_mixing_ratio;
@@ -156,9 +156,9 @@ TEST_CASE("modal_averages", "") {
         const int s = aerosol_index_for_mode(static_cast<mam4::ModeIndex>(m),
                                              static_cast<mam4::AeroId>(aid));
         if (s >= 0) {
-          dry_vol += mass_mixing_ratio / aero_species_h(s).density;
-          hyg += mass_mixing_ratio * aero_species_h(s).hygroscopicity /
-                 aero_species_h(s).density;
+          const mam4::AeroSpecies &species = aero_species_h(aid);
+          dry_vol += mass_mixing_ratio / species.density;
+          hyg += mass_mixing_ratio * species.hygroscopicity / species.density;
         }
       }
       hygro[m] = hyg / dry_vol;

--- a/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
+++ b/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
@@ -10,9 +10,10 @@ using namespace skywalker;
 
 void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
+    mam4::AeroConfig aero_config;
     constexpr int pcnst = mam4::aero_model::pcnst;
     constexpr int pver = mam4::ndrop::pver;
-    constexpr int ntot_amode = mam4::AeroConfig::num_modes();
+    constexpr int ntot_amode = aero_config.num_modes();
 
     using View2D = mam4::DeviceType::view_2d<Real>;
     constexpr Real zero = 0.0;
@@ -67,7 +68,7 @@ void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
         mam4::validation::get_input_in_columnview(input, "cldn");
 
     mam4::modal_aero_calcsize::CalcsizeData cal_data;
-    cal_data.initialize();
+    cal_data.initialize(aero_config);
     const bool update_mmr = true;
     cal_data.set_update_mmr(update_mmr);
 

--- a/src/validation/aero_model/aero_model_wetdep.cpp
+++ b/src/validation/aero_model/aero_model_wetdep.cpp
@@ -167,7 +167,7 @@ void aero_model_wetdep(Ensemble *ensemble) {
     mam4::wetdep::View1D work("work", work_len);
 
     mam4::modal_aero_calcsize::CalcsizeData cal_data;
-    cal_data.initialize();
+    cal_data.initialize(aero_config);
     const bool update_mmr = true;
     cal_data.set_update_mmr(update_mmr);
 

--- a/src/validation/aero_model/modal_aero_bcscavcoef_init.cpp
+++ b/src/validation/aero_model/modal_aero_bcscavcoef_init.cpp
@@ -25,10 +25,10 @@ void modal_aero_bcscavcoef_init(Ensemble *ensemble) {
     Real aerosol_dry_density[mam4::AeroConfig::num_modes()] = {};
     // Note: Original code uses the following aerosol densities.
     // sulfate, sulfate, dust, p-organic
-    aerosol_dry_density[0] = aero_species_h(int(mam4::AeroId::SO4)).density;
-    aerosol_dry_density[1] = aero_species_h(int(mam4::AeroId::SO4)).density;
-    aerosol_dry_density[2] = aero_species_h(int(mam4::AeroId::DST)).density;
-    aerosol_dry_density[3] = aero_species_h(int(mam4::AeroId::POM)).density;
+    aerosol_dry_density[0] = aero_species_h[mam4::AeroId::SO4].density;
+    aerosol_dry_density[1] = aero_species_h[mam4::AeroId::SO4].density;
+    aerosol_dry_density[2] = aero_species_h[mam4::AeroId::DST].density;
+    aerosol_dry_density[3] = aero_species_h[mam4::AeroId::POM].density;
 
     mam4::aero_model::modal_aero_bcscavcoef_init(
         dgnum_amode.data(), sigmag_amode.data(), aerosol_dry_density,

--- a/src/validation/aerosol_optics/aero_rad_props_lw.cpp
+++ b/src/validation/aerosol_optics/aero_rad_props_lw.cpp
@@ -20,6 +20,8 @@ void aero_rad_props_lw(Ensemble *ensemble) {
     constexpr Real zero = 0;
     Real pblh = 1000;
 
+    mam4::AeroConfig aero_config;
+
     const auto dt = input.get_array("dt")[0];
     // const Real t = zero;
     const auto state_q_db = input.get_array("state_q");
@@ -269,7 +271,7 @@ void aero_rad_props_lw(Ensemble *ensemble) {
 
     mam4::Prognostics progs = mam4::validation::create_prognostics(mam4::nlev);
     mam4::modal_aero_opt::CalcsizeData cal_data;
-    cal_data.initialize();
+    cal_data.initialize(aero_config);
 
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {

--- a/src/validation/aerosol_optics/aero_rad_props_sw.cpp
+++ b/src/validation/aerosol_optics/aero_rad_props_sw.cpp
@@ -18,6 +18,8 @@ void aero_rad_props_sw(Ensemble *ensemble) {
     constexpr Real zero = 0;
     Real pblh = 1000;
 
+    mam4::AeroConfig aero_config;
+
     constexpr int maxd_aspectype = mam4::ndrop::maxd_aspectype;
     constexpr int pver = mam4::nlev;
 
@@ -322,7 +324,7 @@ void aero_rad_props_sw(Ensemble *ensemble) {
     mam4::Prognostics progs = mam4::validation::create_prognostics(mam4::nlev);
 
     mam4::modal_aero_opt::CalcsizeData cal_data;
-    cal_data.initialize();
+    cal_data.initialize(aero_config);
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(

--- a/src/validation/aerosol_optics/modal_aero_lw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_lw.cpp
@@ -20,6 +20,8 @@ void modal_aero_lw(Ensemble *ensemble) {
     constexpr Real zero = 0;
     Real pblh = 1000;
 
+    mam4::AeroConfig aero_config;
+
     const auto dt = input.get_array("dt")[0];
     // const Real t = zero;
     const auto state_q_db = input.get_array("state_q");
@@ -242,7 +244,7 @@ void modal_aero_lw(Ensemble *ensemble) {
 
     mam4::Prognostics progs = mam4::validation::create_prognostics(mam4::nlev);
     mam4::modal_aero_opt::CalcsizeData cal_data;
-    cal_data.initialize();
+    cal_data.initialize(aero_config);
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(

--- a/src/validation/aerosol_optics/modal_aero_sw.cpp
+++ b/src/validation/aerosol_optics/modal_aero_sw.cpp
@@ -18,6 +18,7 @@ void modal_aero_sw(Ensemble *ensemble) {
     constexpr Real zero = 0;
     Real pblh = 1000;
 
+    mam4::AeroConfig aero_config;
     constexpr int maxd_aspectype = mam4::ndrop::maxd_aspectype;
     constexpr int pver = mam4::nlev;
 
@@ -281,7 +282,7 @@ void modal_aero_sw(Ensemble *ensemble) {
     mam4::Prognostics progs = mam4::validation::create_prognostics(mam4::nlev);
 
     mam4::modal_aero_opt::CalcsizeData cal_data;
-    cal_data.initialize();
+    cal_data.initialize(aero_config);
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(

--- a/src/validation/calcsize/aitken_accum_exchange.cpp
+++ b/src/validation/calcsize/aitken_accum_exchange.cpp
@@ -69,8 +69,7 @@ void aitken_accum_exchange(Ensemble *ensemble) {
     const Real dryvol_i_accsv = input.get("dryvol_i_accsv");
     const Real dryvol_c_accsv = input.get("dryvol_c_accsv");
 
-    auto aero_species_h = Kokkos::create_mirror_view(mam4_config.aero_species);
-    Kokkos::deep_copy(aero_species_h, mam4_config.aero_species);
+    auto aero_species_h = aero_species_on_host(mam4_config.aero_species);
     Real inv_density[nmodes][nspec];
 
     int count = 0;
@@ -96,8 +95,8 @@ void aitken_accum_exchange(Ensemble *ensemble) {
         h_prog_aero_c(0) = q_c[count];
         Kokkos::deep_copy(progs.q_aero_c[imode][isp], h_prog_aero_c);
 
-        const int aero_id = int(mam4::mode_aero_species(imode, isp));
-        inv_density[imode][isp] = Real(1.0) / aero_species_h(aero_id).density;
+        mam4::AeroId aero_id = mam4::mode_aero_species(imode, isp);
+        inv_density[imode][isp] = Real(1.0) / aero_species_h[aero_id].density;
 
         count++;
       } // end species

--- a/src/validation/calcsize/compute_dry_volume.cpp
+++ b/src/validation/calcsize/compute_dry_volume.cpp
@@ -48,9 +48,9 @@ void compute_dry_volume_k(Ensemble *ensemble) {
           Real inv_density[4][7];
           const auto n_spec = mam4::num_species_mode(imode);
           for (int ispec = 0; ispec < n_spec; ispec++) {
-            const int aero_id = int(mam4::mode_aero_species(imode, ispec));
+            mam4::AeroId aero_id = mam4::mode_aero_species(imode, ispec);
             inv_density[imode][ispec] =
-                Real(1.0) / aero_species(aero_id).density;
+                Real(1.0) / aero_species[aero_id].density;
           } // for(ispec)
 
           Real dryvol_i_k = 0;

--- a/src/validation/calcsize/modal_aero_calcsize_sub.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub.cpp
@@ -14,6 +14,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
     constexpr int pver = mam4::ndrop::pver;
     constexpr int ntot_amode = mam4::AeroConfig::num_modes();
 
+    mam4::AeroConfig aero_config;
     using View2D = mam4::DeviceType::view_2d<Real>;
 
     auto state_q_db = input.get_array("state_q");
@@ -38,7 +39,7 @@ void modal_aero_calcsize_sub(Ensemble *ensemble) {
     View2D dgnumdry_m("dgnumdry_m", pver, ntot_amode);
     View2D dgncur_c("dgncur_c", pver, ntot_amode);
     mam4::modal_aero_opt::CalcsizeData cal_data;
-    cal_data.initialize();
+    cal_data.initialize(aero_config);
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(

--- a/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
+++ b/src/validation/calcsize/modal_aero_calcsize_sub_ptend.cpp
@@ -15,6 +15,8 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
     constexpr int ntot_amode = mam4::AeroConfig::num_modes();
     using View2D = mam4::DeviceType::view_2d<Real>;
 
+    mam4::AeroConfig aero_config;
+
     auto state_q_db = input.get_array("state_q");
     auto qqcw_db = input.get_array("qqcw");
     const auto dt = input.get_array("dt")[0];
@@ -45,7 +47,7 @@ void modal_aero_calcsize_sub_ptend(Ensemble *ensemble) {
     View2D dqqcwdt("dqqcwdt", pver, pcnst);
 
     mam4::modal_aero_calcsize::CalcsizeData cal_data;
-    cal_data.initialize();
+    cal_data.initialize(aero_config);
     const bool update_mmr = true;
     cal_data.set_update_mmr(update_mmr);
 

--- a/src/validation/rename/compute_dryvol_change_in_src_mode.cpp
+++ b/src/validation/rename/compute_dryvol_change_in_src_mode.cpp
@@ -10,11 +10,12 @@ using namespace skywalker;
 
 void compute_dryvol_change_in_src_mode(Ensemble *ensemble) {
 
-  auto aero_species_h = mam4::default_aero_species();
+  mam4::AeroConfig aero_config;
+  auto aero_species_h = mam4::aero_species_on_host(aero_config.aero_species);
 
   ensemble->process([=](const Input &input, Output &output) {
-    const int nmodes = mam4::AeroConfig::num_modes();
-    const int naerosol_species = mam4::AeroConfig::num_aerosol_ids();
+    const int nmodes = aero_config.num_modes();
+    const int naerosol_species = aero_config.num_aerosol_ids();
 
     const Real zero = 0;
 
@@ -39,7 +40,7 @@ void compute_dryvol_change_in_src_mode(Ensemble *ensemble) {
     Real diameter_cutoff[nmodes];
     Real ln_dia_cutoff[nmodes];
     Real diameter_threshold[nmodes];
-    Real mass_2_vol[naerosol_species];
+    mam4::AeroSpeciesData<Real> mass_2_vol("mass-to-volume conversion factors");
 
     mam4::rename::find_renaming_pairs(dest_mode_of_mode,    // in
                                       mean_std_dev,         // out
@@ -52,18 +53,18 @@ void compute_dryvol_change_in_src_mode(Ensemble *ensemble) {
                                       ln_dia_cutoff, diameter_threshold);
 
     // We use MWs from rename-mam4 for validation proposes
-    Real molecular_weight_rename[naerosol_species] = {
-        150, 115, 150, 12, 58.5, 135, 250092}; // [kg/kmol]
-    for (int iaero = 0; iaero < naerosol_species; ++iaero) {
-      mass_2_vol[iaero] =
-          molecular_weight_rename[iaero] / aero_species_h(iaero).density;
+    mam4::AeroSpeciesData<Real> molecular_weight_rename(
+        "species molecular weights",
+        {150, 115, 150, 12, 58.5, 135, 250092}); // [kg/kmol]
+    for (mam4::AeroId aid : mam4::all_aerosol_ids()) {
+      mass_2_vol[aid] =
+          molecular_weight_rename[aid] / aero_species_h[aid].density;
     }
 
     Real dryvol[4] = {zero};
     Real deldryvol[4] = {zero};
 
-    mam4::rename::compute_dryvol_change_in_src_mode(nmodes,            // in
-                                                    naerosol_species,  // in
+    mam4::rename::compute_dryvol_change_in_src_mode(aero_config,
                                                     dest_mode_of_mode, // in
                                                     q_mmr,             // in
                                                     q_del_growth,      // in

--- a/src/validation/rename/mam_rename_1subarea.cpp
+++ b/src/validation/rename/mam_rename_1subarea.cpp
@@ -16,10 +16,6 @@ void mam_rename_1subarea(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
     int nlev = 1;
 
-    mam4::Prognostics progs(nlev);
-    mam4::Diagnostics diags(nlev);
-    mam4::Tendencies tends(nlev);
-
     mam4::AeroConfig mam4_config(aero_species);
     mam4::RenameProcess process(mam4_config);
 
@@ -78,7 +74,6 @@ void mam_rename_1subarea(Ensemble *ensemble) {
     Real diameter_cutoff[nmodes];
     Real ln_dia_cutoff[nmodes];
     Real diameter_threshold[nmodes];
-    mam4::AeroSpeciesData<Real> mass_2_vol("mass-to-volume conversion factors");
 
     mam4::rename::find_renaming_pairs(dest_mode_of_mode,    // in
                                       mean_std_dev,         // out
@@ -95,13 +90,16 @@ void mam_rename_1subarea(Ensemble *ensemble) {
       dgnum_amode[m] = mam4::modes(m).nom_diameter;
     }
     //// We use MWs from rename-mam4 for validation proposes
-    mam4::AeroSpeciesData<Real> molecular_weight_rename(
+    mam4::AeroSpeciesData<Real> mass_2_vol("mass-to-volume conversion factors");
+    mam4::AeroSpeciesData<Real, ekat::HostDevice> molecular_weight_rename_h(
         "species molecular weights",
         {150, 115, 150, 12, 58.5, 135, 250092}); // [kg/kmol]
+    auto mass_2_vol_h = mass_2_vol.on_host();
     for (mam4::AeroId aid : mam4::all_aerosol_ids()) {
-      mass_2_vol[aid] =
-          molecular_weight_rename[aid] / aero_species_h[aid].density;
+      mass_2_vol_h[aid] =
+          molecular_weight_rename_h[aid] / aero_species_h[aid].density;
     }
+    mass_2_vol.copy_from_host(mass_2_vol_h);
 
     this_rename.mam_rename_1subarea_(
         mam4_config, iscloudy, smallest_dryvol_value,
@@ -115,8 +113,8 @@ void mam_rename_1subarea(Ensemble *ensemble) {
         diameter_cutoff,      // in
         ln_dia_cutoff,        // in
         diameter_threshold,   // in
-        mass_2_vol,
-        dgnum_amode, // in
+        mass_2_vol,           // in
+        dgnum_amode,          // in
         qnum_cur, qaer_cur, qaer_del_grow4rnam, qnumcw_cur, qaercw_cur,
         qaercw_del_grow4rnam);
 

--- a/src/validation/rename/mam_rename_1subarea.cpp
+++ b/src/validation/rename/mam_rename_1subarea.cpp
@@ -78,7 +78,7 @@ void mam_rename_1subarea(Ensemble *ensemble) {
     Real diameter_cutoff[nmodes];
     Real ln_dia_cutoff[nmodes];
     Real diameter_threshold[nmodes];
-    Real mass_2_vol[naerosol_species];
+    mam4::AeroSpeciesData<Real> mass_2_vol("mass-to-volume conversion factors");
 
     mam4::rename::find_renaming_pairs(dest_mode_of_mode,    // in
                                       mean_std_dev,         // out
@@ -95,29 +95,30 @@ void mam_rename_1subarea(Ensemble *ensemble) {
       dgnum_amode[m] = mam4::modes(m).nom_diameter;
     }
     //// We use MWs from rename-mam4 for validation proposes
-    Real molecular_weight_rename[naerosol_species] = {
-        150, 115, 150, 12, 58.5, 135, 250092}; // [kg/kmol]
-    for (int iaero = 0; iaero < naerosol_species; ++iaero) {
-      mass_2_vol[iaero] =
-          molecular_weight_rename[iaero] / aero_species_h(iaero).density;
+    mam4::AeroSpeciesData<Real> molecular_weight_rename(
+        "species molecular weights",
+        {150, 115, 150, 12, 58.5, 135, 250092}); // [kg/kmol]
+    for (mam4::AeroId aid : mam4::all_aerosol_ids()) {
+      mass_2_vol[aid] =
+          molecular_weight_rename[aid] / aero_species_h[aid].density;
     }
 
-    this_rename.mam_rename_1subarea_(iscloudy, smallest_dryvol_value,
-                                     dest_mode_of_mode,    // in
-                                     mean_std_dev,         // in
-                                     fmode_dist_tail_fac,  // in
-                                     v2n_lo_rlx,           // in
-                                     v2n_hi_rlx,           // in
-                                     ln_diameter_tail_fac, // in
-                                     num_pairs,            // in
-                                     diameter_cutoff,      // in
-                                     ln_dia_cutoff,        // in
-                                     diameter_threshold,   // in
-                                     mass_2_vol,
-                                     dgnum_amode, // in
-                                     qnum_cur, qaer_cur, qaer_del_grow4rnam,
-                                     qnumcw_cur, qaercw_cur,
-                                     qaercw_del_grow4rnam);
+    this_rename.mam_rename_1subarea_(
+        mam4_config, iscloudy, smallest_dryvol_value,
+        dest_mode_of_mode,    // in
+        mean_std_dev,         // in
+        fmode_dist_tail_fac,  // in
+        v2n_lo_rlx,           // in
+        v2n_hi_rlx,           // in
+        ln_diameter_tail_fac, // in
+        num_pairs,            // in
+        diameter_cutoff,      // in
+        ln_dia_cutoff,        // in
+        diameter_threshold,   // in
+        mass_2_vol,
+        dgnum_amode, // in
+        qnum_cur, qaer_cur, qaer_del_grow4rnam, qnumcw_cur, qaercw_cur,
+        qaercw_del_grow4rnam);
 
     std::vector<Real> qnum_cur_out(nmodes + 1, 0);
     mam4::validation::convert_modal_array_to_vector(qnum_cur, qnum_cur_out);


### PR DESCRIPTION
This PR fixes some aerosol indices that are improperly used to fetch aerosol species properties. I noticed a pattern in which we mistakenly use the offset of an aerosol species within its mode to refer to a specific aerosol species. One might call this "using an aerosol index (position 0, 1, 2, within a mode) in place of an aerosol identifier (SO4, SOA, POM). See #558 for details.

Closes #558