### PR TITLE
Remove functions: water_uptake::get_e3sm_parameters and ndrop::get_e3sm_parameters.

### DIFF
--- a/src/mam4xx/aero_config.hpp
+++ b/src/mam4xx/aero_config.hpp
@@ -73,6 +73,49 @@ public:
 
   /// Aerosol species
   AeroSpeciesView aero_species;
+
+  static constexpr int maxd_aspectype = 14;
+  static constexpr int ntot_amode = 4;
+  // max number of species in a mode
+  static constexpr int nspec_max = 8;
+  static constexpr int nspec_amode[ntot_amode] = {7, 4, 7, 3};
+  static constexpr int numptr_amode[ntot_amode] = {23, 28, 36, 40};
+
+  static constexpr Real specdens_amode[maxd_aspectype] = {
+      0.1770000000E+04, -999.0,           -999.0,           0.1000000000E+04,
+      0.1000000000E+04, 0.1700000000E+04, 0.1900000000E+04, 0.2600000000E+04,
+      0.1601000000E+04, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
+      0.0000000000E+00, 0.0000000000E+00};
+  static constexpr Real spechygro[maxd_aspectype] = {
+      0.5070000000E+00, -999.0,           -999.0,           0.1000000083E-09,
+      0.1400000000E+00, 0.1000000013E-09, 0.1160000000E+01, 0.6800000000E-01,
+      0.1000000015E+00, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
+      0.0000000000E+00, 0.0000000000E+00};
+
+  static constexpr int lspectype_amode[maxd_aspectype][ntot_amode] = {
+      {1, 1, 8, 4}, {4, 5, 7, 6}, {5, 7, 1, 9}, {6, 9, 6, 0}, {8, 0, 4, 0},
+      {7, 0, 5, 0}, {9, 0, 9, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0},
+      {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}};
+
+  static constexpr int lmassptr_amode[maxd_aspectype][ntot_amode] = {
+      {16, 24, 29, 37}, {17, 25, 30, 38}, {18, 26, 31, 39}, {19, 27, 32, 0},
+      {20, 0, 33, 0},   {21, 0, 34, 0},   {22, 0, 35, 0},   {0, 0, 0, 0},
+      {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},
+      {0, 0, 0, 0},     {0, 0, 0, 0}};
+
+  static constexpr int mam_idx[ntot_amode][nspec_max] = {
+      {1, 2, 3, 4, 5, 6, 7, 8},
+      {9, 10, 11, 12, 13, 0, 0, 0},
+      {14, 15, 16, 17, 18, 19, 20, 21},
+      {22, 23, 24, 25, 0, 0, 0, 0},
+  };
+
+  static constexpr int mam_cnst_idx[ntot_amode][nspec_max] = {
+      {23, 16, 17, 18, 19, 20, 21, 22},
+      {28, 24, 25, 26, 27, 0, 0, 0},
+      {36, 29, 30, 31, 32, 33, 34, 35},
+      {40, 37, 38, 39, 0, 0, 0, 0},
+  };
 };
 
 /// MAM4 column-wise prognostic aerosol fields (also used for tendencies).

--- a/src/mam4xx/aero_config.hpp
+++ b/src/mam4xx/aero_config.hpp
@@ -78,44 +78,69 @@ public:
   static constexpr int ntot_amode = 4;
   // max number of species in a mode
   static constexpr int nspec_max = 8;
-  static constexpr int nspec_amode[ntot_amode] = {7, 4, 7, 3};
-  static constexpr int numptr_amode[ntot_amode] = {23, 28, 36, 40};
-
-  static constexpr Real specdens_amode[maxd_aspectype] = {
-      0.1770000000E+04, -999.0,           -999.0,           0.1000000000E+04,
-      0.1000000000E+04, 0.1700000000E+04, 0.1900000000E+04, 0.2600000000E+04,
-      0.1601000000E+04, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
-      0.0000000000E+00, 0.0000000000E+00};
-  static constexpr Real spechygro[maxd_aspectype] = {
-      0.5070000000E+00, -999.0,           -999.0,           0.1000000083E-09,
-      0.1400000000E+00, 0.1000000013E-09, 0.1160000000E+01, 0.6800000000E-01,
-      0.1000000015E+00, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
-      0.0000000000E+00, 0.0000000000E+00};
-
-  static constexpr int lspectype_amode[maxd_aspectype][ntot_amode] = {
-      {1, 1, 8, 4}, {4, 5, 7, 6}, {5, 7, 1, 9}, {6, 9, 6, 0}, {8, 0, 4, 0},
-      {7, 0, 5, 0}, {9, 0, 9, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0},
-      {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}};
-
-  static constexpr int lmassptr_amode[maxd_aspectype][ntot_amode] = {
-      {16, 24, 29, 37}, {17, 25, 30, 38}, {18, 26, 31, 39}, {19, 27, 32, 0},
-      {20, 0, 33, 0},   {21, 0, 34, 0},   {22, 0, 35, 0},   {0, 0, 0, 0},
-      {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},
-      {0, 0, 0, 0},     {0, 0, 0, 0}};
-
-  static constexpr int mam_idx[ntot_amode][nspec_max] = {
-      {1, 2, 3, 4, 5, 6, 7, 8},
-      {9, 10, 11, 12, 13, 0, 0, 0},
-      {14, 15, 16, 17, 18, 19, 20, 21},
-      {22, 23, 24, 25, 0, 0, 0, 0},
-  };
-
-  static constexpr int mam_cnst_idx[ntot_amode][nspec_max] = {
-      {23, 16, 17, 18, 19, 20, 21, 22},
-      {28, 24, 25, 26, 27, 0, 0, 0},
-      {36, 29, 30, 31, 32, 33, 34, 35},
-      {40, 37, 38, 39, 0, 0, 0, 0},
-  };
+  KOKKOS_INLINE_FUNCTION
+  static constexpr int nspec_amode(const int amode) {
+    const int nspec_amode[ntot_amode] = {7, 4, 7, 3};
+    return nspec_amode[amode];
+  }
+  KOKKOS_INLINE_FUNCTION
+  static constexpr int numptr_amode(const int amode) {
+    const int numptr_amode[ntot_amode] = {23, 28, 36, 40};
+    return numptr_amode[amode];
+  }
+  KOKKOS_INLINE_FUNCTION
+  static constexpr Real specdens_amode(const int aspectype) {
+    const Real specdens_amode[maxd_aspectype] = {
+        0.1770000000E+04, -999.0,           -999.0,           0.1000000000E+04,
+        0.1000000000E+04, 0.1700000000E+04, 0.1900000000E+04, 0.2600000000E+04,
+        0.1601000000E+04, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
+        0.0000000000E+00, 0.0000000000E+00};
+    return specdens_amode[aspectype];
+  }
+  KOKKOS_INLINE_FUNCTION
+  static constexpr Real spechygro(const int aspectype) {
+    const Real spechygro[maxd_aspectype] = {
+        0.5070000000E+00, -999.0,           -999.0,           0.1000000083E-09,
+        0.1400000000E+00, 0.1000000013E-09, 0.1160000000E+01, 0.6800000000E-01,
+        0.1000000015E+00, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
+        0.0000000000E+00, 0.0000000000E+00};
+    return spechygro[aspectype];
+  }
+  KOKKOS_INLINE_FUNCTION
+  static constexpr int lspectype_amode(const int aspectype, const int amode) {
+    const int lspectype_amode[maxd_aspectype][ntot_amode] = {
+        {1, 1, 8, 4}, {4, 5, 7, 6}, {5, 7, 1, 9}, {6, 9, 6, 0}, {8, 0, 4, 0},
+        {7, 0, 5, 0}, {9, 0, 9, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0},
+        {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}};
+    return lspectype_amode[aspectype][amode];
+  }
+  KOKKOS_INLINE_FUNCTION
+  static constexpr int lmassptr_amode(const int aspectype, const int amode) {
+    const int lmassptr_amode[maxd_aspectype][ntot_amode] = {
+        {16, 24, 29, 37}, {17, 25, 30, 38}, {18, 26, 31, 39}, {19, 27, 32, 0},
+        {20, 0, 33, 0},   {21, 0, 34, 0},   {22, 0, 35, 0},   {0, 0, 0, 0},
+        {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},
+        {0, 0, 0, 0},     {0, 0, 0, 0}};
+    return lmassptr_amode[aspectype][amode];
+  }
+  KOKKOS_INLINE_FUNCTION
+  static constexpr int mam_idx(const int amode, const int nspec) {
+    const int mam_idx[ntot_amode][nspec_max] = {
+        {1, 2, 3, 4, 5, 6, 7, 8},
+        {9, 10, 11, 12, 13, 0, 0, 0},
+        {14, 15, 16, 17, 18, 19, 20, 21},
+        {22, 23, 24, 25, 0, 0, 0, 0}};
+    return mam_idx[amode][nspec];
+  }
+  KOKKOS_INLINE_FUNCTION
+  static constexpr int mam_cnst_idx(const int amode, const int nspec) {
+    const int mam_cnst_idx[ntot_amode][nspec_max] = {
+        {23, 16, 17, 18, 19, 20, 21, 22},
+        {28, 24, 25, 26, 27, 0, 0, 0},
+        {36, 29, 30, 31, 32, 33, 34, 35},
+        {40, 37, 38, 39, 0, 0, 0, 0}};
+    return mam_cnst_idx[amode][nspec];
+  }
 };
 
 /// MAM4 column-wise prognostic aerosol fields (also used for tendencies).

--- a/src/mam4xx/aero_config.hpp
+++ b/src/mam4xx/aero_config.hpp
@@ -90,7 +90,7 @@ public:
   }
   KOKKOS_INLINE_FUNCTION
   static constexpr int numptr_amode(const int amode) {
-    const int numptr_amode[ntot_amode()] = {23, 28, 36, 40};
+    const int numptr_amode[ntot_amode()] = {22, 27, 35, 39};
     EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode());
     return numptr_amode[amode];
   }
@@ -117,9 +117,10 @@ public:
   KOKKOS_INLINE_FUNCTION
   static constexpr int lspectype_amode(const int aspectype, const int amode) {
     const int lspectype_amode[maxd_aspectype()][ntot_amode()] = {
-        {1, 1, 8, 4}, {4, 5, 7, 6}, {5, 7, 1, 9}, {6, 9, 6, 0}, {8, 0, 4, 0},
-        {7, 0, 5, 0}, {9, 0, 9, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0},
-        {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}};
+        {0, 0, 7, 3},     {3, 4, 6, 5},     {4, 6, 0, 8},     {5, 8, 5, -1},
+        {7, -1, 3, -1},   {6, -1, 4, -1},   {8, -1, 8, -1},   {-1, -1, -1, -1},
+        {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1},
+        {-1, 0, -1, -1},  {-1, -1, -1, -1}};
     EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype());
     EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode());
     return lspectype_amode[aspectype][amode];
@@ -127,10 +128,10 @@ public:
   KOKKOS_INLINE_FUNCTION
   static constexpr int lmassptr_amode(const int aspectype, const int amode) {
     const int lmassptr_amode[maxd_aspectype()][ntot_amode()] = {
-        {16, 24, 29, 37}, {17, 25, 30, 38}, {18, 26, 31, 39}, {19, 27, 32, 0},
-        {20, 0, 33, 0},   {21, 0, 34, 0},   {22, 0, 35, 0},   {0, 0, 0, 0},
-        {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},
-        {0, 0, 0, 0},     {0, 0, 0, 0}};
+        {15, 23, 28, 36}, {16, 24, 29, 37}, {17, 25, 30, 38}, {18, 26, 31, -1},
+        {19, -1, 32, -1}, {20, -1, 33, -1}, {21, -1, 34, -1}, {-1, -1, -1, -1},
+        {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1}, {-1, -1, -1, -1},
+        {-1, -1, -1, -1}, {-1, -1, -1, -1}};
     EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype());
     EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode());
     return lmassptr_amode[aspectype][amode];
@@ -138,10 +139,10 @@ public:
   KOKKOS_INLINE_FUNCTION
   static constexpr int mam_idx(const int amode, const int nspec) {
     const int mam_idx[ntot_amode()][nspec_max()] = {
-        {1, 2, 3, 4, 5, 6, 7, 8},
-        {9, 10, 11, 12, 13, 0, 0, 0},
-        {14, 15, 16, 17, 18, 19, 20, 21},
-        {22, 23, 24, 25, 0, 0, 0, 0}};
+        {0, 1, 3, 4, 4, 5, 6, 7},
+        {8, 9, 10, 11, 12, -1, -1, -1},
+        {13, 14, 15, 16, 17, 18, 19, 20},
+        {21, 22, 23, 24, -1, -1, -1, -1}};
     EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode());
     EKAT_KERNEL_ASSERT(0 <= nspec && nspec < nspec_max());
     return mam_idx[amode][nspec];
@@ -149,10 +150,10 @@ public:
   KOKKOS_INLINE_FUNCTION
   static constexpr int mam_cnst_idx(const int amode, const int nspec) {
     const int mam_cnst_idx[ntot_amode()][nspec_max()] = {
-        {23, 16, 17, 18, 19, 20, 21, 22},
-        {28, 24, 25, 26, 27, 0, 0, 0},
-        {36, 29, 30, 31, 32, 33, 34, 35},
-        {40, 37, 38, 39, 0, 0, 0, 0}};
+        {22, 15, 16, 17, 18, 19, 20, 21},
+        {27, 23, 24, 25, 26, -1, -1, -1},
+        {35, 28, 29, 30, 31, 32, 33, 34},
+        {39, 36, 37, 38, -1, -1, -1, -1}};
     EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode());
     EKAT_KERNEL_ASSERT(0 <= nspec && nspec < nspec_max());
     return mam_cnst_idx[amode][nspec];

--- a/src/mam4xx/aero_config.hpp
+++ b/src/mam4xx/aero_config.hpp
@@ -75,82 +75,86 @@ public:
   /// Aerosol species
   AeroSpeciesView aero_species;
 
-  static constexpr int maxd_aspectype = 14;
-  static constexpr int ntot_amode = 4;
+  KOKKOS_INLINE_FUNCTION
+  static constexpr int maxd_aspectype() { return 14; }
+  KOKKOS_INLINE_FUNCTION
+  static constexpr int ntot_amode() { return 4; }
   // max number of species in a mode
-  static constexpr int nspec_max = 8;
+  KOKKOS_INLINE_FUNCTION
+  static constexpr int nspec_max() { return 8; }
+
   KOKKOS_INLINE_FUNCTION
   static constexpr int nspec_amode(const int amode) {
-    const int nspec_amode[ntot_amode] = {7, 4, 7, 3};
+    const int nspec_amode[ntot_amode()] = {7, 4, 7, 3};
     return nspec_amode[amode];
   }
   KOKKOS_INLINE_FUNCTION
   static constexpr int numptr_amode(const int amode) {
-    const int numptr_amode[ntot_amode] = {23, 28, 36, 40};
-    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode);
+    const int numptr_amode[ntot_amode()] = {23, 28, 36, 40};
+    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode());
     return numptr_amode[amode];
   }
   KOKKOS_INLINE_FUNCTION
   static constexpr Real specdens_amode(const int aspectype) {
-    const Real specdens_amode[maxd_aspectype] = {
+    const Real specdens_amode[maxd_aspectype()] = {
         0.1770000000E+04, -999.0,           -999.0,           0.1000000000E+04,
         0.1000000000E+04, 0.1700000000E+04, 0.1900000000E+04, 0.2600000000E+04,
         0.1601000000E+04, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
         0.0000000000E+00, 0.0000000000E+00};
-    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype);
+    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype());
     return specdens_amode[aspectype];
   }
   KOKKOS_INLINE_FUNCTION
   static constexpr Real spechygro(const int aspectype) {
-    const Real spechygro[maxd_aspectype] = {
+    const Real spechygro[maxd_aspectype()] = {
         0.5070000000E+00, -999.0,           -999.0,           0.1000000083E-09,
         0.1400000000E+00, 0.1000000013E-09, 0.1160000000E+01, 0.6800000000E-01,
         0.1000000015E+00, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
         0.0000000000E+00, 0.0000000000E+00};
-    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype);
+    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype());
     return spechygro[aspectype];
   }
   KOKKOS_INLINE_FUNCTION
   static constexpr int lspectype_amode(const int aspectype, const int amode) {
-    const int lspectype_amode[maxd_aspectype][ntot_amode] = {
+    const int lspectype_amode[maxd_aspectype()][ntot_amode()] = {
         {1, 1, 8, 4}, {4, 5, 7, 6}, {5, 7, 1, 9}, {6, 9, 6, 0}, {8, 0, 4, 0},
         {7, 0, 5, 0}, {9, 0, 9, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0},
         {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}};
-    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype);
-    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode);
+    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype());
+    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode());
     return lspectype_amode[aspectype][amode];
   }
   KOKKOS_INLINE_FUNCTION
   static constexpr int lmassptr_amode(const int aspectype, const int amode) {
-    const int lmassptr_amode[maxd_aspectype][ntot_amode] = {
+    const int lmassptr_amode[maxd_aspectype()][ntot_amode()] = {
         {16, 24, 29, 37}, {17, 25, 30, 38}, {18, 26, 31, 39}, {19, 27, 32, 0},
         {20, 0, 33, 0},   {21, 0, 34, 0},   {22, 0, 35, 0},   {0, 0, 0, 0},
         {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},
         {0, 0, 0, 0},     {0, 0, 0, 0}};
-    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype);
-    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode);
+    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype());
+    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode());
     return lmassptr_amode[aspectype][amode];
   }
   KOKKOS_INLINE_FUNCTION
   static constexpr int mam_idx(const int amode, const int nspec) {
-    const int mam_idx[ntot_amode][nspec_max] = {
+    const int mam_idx[ntot_amode()][nspec_max()] = {
         {1, 2, 3, 4, 5, 6, 7, 8},
         {9, 10, 11, 12, 13, 0, 0, 0},
         {14, 15, 16, 17, 18, 19, 20, 21},
         {22, 23, 24, 25, 0, 0, 0, 0}};
-    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode);
-    EKAT_KERNEL_ASSERT(0 <= nspec && nspec < nspec_max);
+    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode());
+    EKAT_KERNEL_ASSERT(0 <= nspec && nspec < nspec_max());
     return mam_idx[amode][nspec];
   }
   KOKKOS_INLINE_FUNCTION
   static constexpr int mam_cnst_idx(const int amode, const int nspec) {
-    const int mam_cnst_idx[ntot_amode][nspec_max] = {
+    const int mam_cnst_idx[ntot_amode()][nspec_max()] = {
         {23, 16, 17, 18, 19, 20, 21, 22},
         {28, 24, 25, 26, 27, 0, 0, 0},
         {36, 29, 30, 31, 32, 33, 34, 35},
         {40, 37, 38, 39, 0, 0, 0, 0}};
-    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode);
-    EKAT_KERNEL_ASSERT(0 <= nspec && nspec < nspec_max);
+    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode());
+    EKAT_KERNEL_ASSERT(0 <= nspec && nspec < nspec_max());
     return mam_cnst_idx[amode][nspec];
   }
 };

--- a/src/mam4xx/aero_config.hpp
+++ b/src/mam4xx/aero_config.hpp
@@ -8,6 +8,7 @@
 
 #include "aero_species.hpp"
 #include "mam4_types.hpp"
+#include <ekat_kernel_assert.hpp>
 
 namespace mam4 {
 
@@ -86,6 +87,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   static constexpr int numptr_amode(const int amode) {
     const int numptr_amode[ntot_amode] = {23, 28, 36, 40};
+    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode);
     return numptr_amode[amode];
   }
   KOKKOS_INLINE_FUNCTION
@@ -95,6 +97,7 @@ public:
         0.1000000000E+04, 0.1700000000E+04, 0.1900000000E+04, 0.2600000000E+04,
         0.1601000000E+04, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
         0.0000000000E+00, 0.0000000000E+00};
+    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype);
     return specdens_amode[aspectype];
   }
   KOKKOS_INLINE_FUNCTION
@@ -104,6 +107,7 @@ public:
         0.1400000000E+00, 0.1000000013E-09, 0.1160000000E+01, 0.6800000000E-01,
         0.1000000015E+00, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
         0.0000000000E+00, 0.0000000000E+00};
+    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype);
     return spechygro[aspectype];
   }
   KOKKOS_INLINE_FUNCTION
@@ -112,6 +116,8 @@ public:
         {1, 1, 8, 4}, {4, 5, 7, 6}, {5, 7, 1, 9}, {6, 9, 6, 0}, {8, 0, 4, 0},
         {7, 0, 5, 0}, {9, 0, 9, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0},
         {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}};
+    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype);
+    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode);
     return lspectype_amode[aspectype][amode];
   }
   KOKKOS_INLINE_FUNCTION
@@ -121,6 +127,8 @@ public:
         {20, 0, 33, 0},   {21, 0, 34, 0},   {22, 0, 35, 0},   {0, 0, 0, 0},
         {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},     {0, 0, 0, 0},
         {0, 0, 0, 0},     {0, 0, 0, 0}};
+    EKAT_KERNEL_ASSERT(0 <= aspectype && aspectype < maxd_aspectype);
+    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode);
     return lmassptr_amode[aspectype][amode];
   }
   KOKKOS_INLINE_FUNCTION
@@ -130,6 +138,8 @@ public:
         {9, 10, 11, 12, 13, 0, 0, 0},
         {14, 15, 16, 17, 18, 19, 20, 21},
         {22, 23, 24, 25, 0, 0, 0, 0}};
+    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode);
+    EKAT_KERNEL_ASSERT(0 <= nspec && nspec < nspec_max);
     return mam_idx[amode][nspec];
   }
   KOKKOS_INLINE_FUNCTION
@@ -139,6 +149,8 @@ public:
         {28, 24, 25, 26, 27, 0, 0, 0},
         {36, 29, 30, 31, 32, 33, 34, 35},
         {40, 37, 38, 39, 0, 0, 0, 0}};
+    EKAT_KERNEL_ASSERT(0 <= amode && amode < ntot_amode);
+    EKAT_KERNEL_ASSERT(0 <= nspec && nspec < nspec_max);
     return mam_cnst_idx[amode][nspec];
   }
 };

--- a/src/mam4xx/kohler.hpp
+++ b/src/mam4xx/kohler.hpp
@@ -38,8 +38,10 @@ surface_tension_water_air(double T = Constants::triple_pt_h2o) {
   constexpr double b = -0.625;
   constexpr double mu = 1.256;
   const auto tau = 1 - T / Tc;
-  EKAT_KERNEL_ASSERT(FloatingPoint<double>::in_bounds(
-      T, Constants::triple_pt_h2o - 25, Tc, mam4::epsilon<float>()));
+  EKAT_KERNEL_ASSERT(
+      FloatingPoint<double>::in_bounds(T, Constants::triple_pt_h2o - 25, Tc,
+                                       std::numeric_limits<float>::epsilon()));
+
   return B * mam4::pow(tau, mu) * (1 + b * tau);
 }
 

--- a/src/mam4xx/kohler.hpp
+++ b/src/mam4xx/kohler.hpp
@@ -38,9 +38,8 @@ surface_tension_water_air(double T = Constants::triple_pt_h2o) {
   constexpr double b = -0.625;
   constexpr double mu = 1.256;
   const auto tau = 1 - T / Tc;
-  EKAT_KERNEL_ASSERT(
-      FloatingPoint<double>::in_bounds(T, Constants::triple_pt_h2o - 25, Tc,
-                                       std::numeric_limits<float>::epsilon()));
+  EKAT_KERNEL_ASSERT(FloatingPoint<double>::in_bounds(
+      T, Constants::triple_pt_h2o - 25, Tc, mam4::epsilon<float>()));
   return B * mam4::pow(tau, mu) * (1 + b * tau);
 }
 

--- a/src/mam4xx/kohler.hpp
+++ b/src/mam4xx/kohler.hpp
@@ -41,7 +41,6 @@ surface_tension_water_air(double T = Constants::triple_pt_h2o) {
   EKAT_KERNEL_ASSERT(
       FloatingPoint<double>::in_bounds(T, Constants::triple_pt_h2o - 25, Tc,
                                        std::numeric_limits<float>::epsilon()));
-
   return B * mam4::pow(tau, mu) * (1 + b * tau);
 }
 

--- a/src/mam4xx/mam4_math.hpp
+++ b/src/mam4xx/mam4_math.hpp
@@ -39,6 +39,9 @@ KOKKOS_INLINE_FUNCTION Real cube(const Real x) { return x * x * x; }
 KOKKOS_INLINE_FUNCTION constexpr Real epsilon() {
   return Kokkos::Experimental::epsilon_v<Real>;
 }
+KOKKOS_FUNCTION template <typename T> constexpr T epsilon() {
+  return Kokkos::Experimental::epsilon_v<T>;
+}
 
 } // namespace mam4
 

--- a/src/mam4xx/mam4_math.hpp
+++ b/src/mam4xx/mam4_math.hpp
@@ -39,6 +39,7 @@ KOKKOS_INLINE_FUNCTION Real cube(const Real x) { return x * x * x; }
 KOKKOS_INLINE_FUNCTION constexpr Real epsilon() {
   return Kokkos::Experimental::epsilon_v<Real>;
 }
+
 } // namespace mam4
 
 #endif

--- a/src/mam4xx/mam4_math.hpp
+++ b/src/mam4xx/mam4_math.hpp
@@ -39,10 +39,6 @@ KOKKOS_INLINE_FUNCTION Real cube(const Real x) { return x * x * x; }
 KOKKOS_INLINE_FUNCTION constexpr Real epsilon() {
   return Kokkos::Experimental::epsilon_v<Real>;
 }
-KOKKOS_FUNCTION template <typename T> constexpr T epsilon() {
-  return Kokkos::Experimental::epsilon_v<T>;
-}
-
 } // namespace mam4
 
 #endif

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -109,16 +109,7 @@ inline void init_calcsize(
 
 struct CalcsizeData {
 
-  int nspec_amode[AeroConfig::num_modes()];
-  int lspectype_amode[ndrop::maxd_aspectype][AeroConfig::num_modes()];
-  Real specdens_amode[ndrop::maxd_aspectype];
-  int lmassptr_amode[ndrop::maxd_aspectype][AeroConfig::num_modes()];
-  Real spechygro[ndrop::maxd_aspectype];
   Real mean_std_dev_nmodes[AeroConfig::num_modes()];
-
-  int numptr_amode[AeroConfig::num_modes()];
-  int mam_idx[AeroConfig::num_modes()][ndrop::nspec_max];
-  int mam_cnst_idx[AeroConfig::num_modes()][ndrop::nspec_max];
 
   // FIXME: inv_density: we have different order of species in mam4xx.
   Real inv_density[AeroConfig::num_modes()][AeroConfig::num_aerosol_ids()] = {};
@@ -140,10 +131,6 @@ struct CalcsizeData {
   bool update_mmr = false;
 
   void initialize() {
-    ndrop::get_e3sm_parameters(nspec_amode, lspectype_amode, lmassptr_amode,
-                               numptr_amode, specdens_amode, spechygro, mam_idx,
-                               mam_cnst_idx);
-
     init_calcsize(default_aero_species(), inv_density, num2vol_ratio_min,
                   num2vol_ratio_max, num2vol_ratio_max_nmodes,
                   num2vol_ratio_min_nmodes, num2vol_ratio_nom_nmodes,
@@ -423,10 +410,10 @@ KOKKOS_INLINE_FUNCTION void compute_dry_volume(
     const VectorType &state_q, // in
     const VectorType &qqcw,    // in
     const Real inv_density[AeroConfig::num_modes()]
-                          [AeroConfig::num_aerosol_ids()], // in
-    const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
-    Real &dryvol_i, // out
-    Real &dryvol_c) // out
+                          [AeroConfig::num_aerosol_ids()],             // in
+    const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()], // in
+    Real &dryvol_i,                                                    // out
+    Real &dryvol_c)                                                    // out
 {
   constexpr Real zero = 0.0;
   dryvol_i = zero;
@@ -582,7 +569,7 @@ KOKKOS_INLINE_FUNCTION void aitken_accum_exchange(
       accum_idx, num2vol_ratio_geomean, adj_tscale_inv, state_q, qqcw,
       drv_i_accsv, drv_c_accsv, num_i_accsv, num_c_accsv,
       calcsizedata.noxf_acc2ait, voltonum_ait, calcsizedata.inv_density,
-      calcsizedata.num2vol_ratio_max_nmodes, calcsizedata.lmassptr_amode,
+      calcsizedata.num2vol_ratio_max_nmodes, AeroConfig::lmassptr_amode,
       drv_i_noxf, drv_c_noxf, acc2_ait_index, xfercoef_num_acc2ait,
       xfercoef_vol_acc2ait, xfertend_num);
 
@@ -870,7 +857,7 @@ modal_aero_calcsize_sub(const VectorType &state_q, // in
                        state_q,                  // in
                        qqcw,                     // in
                        calcsizedata.inv_density, // in
-                       calcsizedata.lmassptr_amode,
+                       AeroConfig::lmassptr_amode,
                        dryvol_i, // out
                        dryvol_c);
 
@@ -881,10 +868,10 @@ modal_aero_calcsize_sub(const VectorType &state_q, // in
     // Both num_mode_idx and num_cldbrn_mode_idx should be exactly same and
     // should be same for both prognostic and diagnostic radiation lists
     // Fortran to C++ indexing
-    const int num_mode_idx = calcsizedata.numptr_amode[imode] - 1;
+    const int num_mode_idx = AeroConfig::numptr_amode[imode] - 1;
     // Fortran to C++ indexing
     const int num_cldbrn_mode_idx =
-        calcsizedata.numptr_amode[imode] - 1;         // numptrcw_amode[imode];
+        AeroConfig::numptr_amode[imode] - 1;          // numptrcw_amode[imode];
     const Real n_i_imode = state_q[num_mode_idx];     // from state_q
     const Real n_c_imode = qqcw[num_cldbrn_mode_idx]; // from qqcw
     // const bool update_mmr

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -156,7 +156,6 @@ KOKKOS_INLINE_FUNCTION void compute_coef_acc_ait_transfer(
                           [AeroConfig::num_aerosol_ids()],
     const Real num2vol_ratio_max_nmodes[AeroConfig::num_modes()],
     // additional parameters
-    const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
     Real &drv_i_noxf, Real &drv_c_noxf, int &acc2_ait_index,
     Real &xfercoef_num_acc2ait, Real &xfercoef_vol_acc2ait,
     Real xfertend_num[2][2]) {
@@ -194,7 +193,7 @@ KOKKOS_INLINE_FUNCTION void compute_coef_acc_ait_transfer(
           // need qmass*invdens = (kg/kg-air) * [1/(kg/m3)] = m3/kg-air
           ; // !get mmr
           // Fortran to C++ indexing
-          const int idx = lmassptr_amode[ispec][iacc] - 1;
+          const int idx = AeroConfig::lmassptr_amode(ispec, iacc) - 1;
           drv_i_noxf +=
               mam4::max(zero, state_q[idx]) * inv_density[iacc][ispec];
           drv_c_noxf += mam4::max(zero, qqcw[idx]) * inv_density[iacc][ispec];
@@ -405,15 +404,14 @@ KOKKOS_INLINE_FUNCTION void size_adjustment(
 
 } /// size_adjustment
 template <typename VectorType>
-KOKKOS_INLINE_FUNCTION void compute_dry_volume(
-    int imode,                 // in
-    const VectorType &state_q, // in
-    const VectorType &qqcw,    // in
-    const Real inv_density[AeroConfig::num_modes()]
-                          [AeroConfig::num_aerosol_ids()],             // in
-    const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()], // in
-    Real &dryvol_i,                                                    // out
-    Real &dryvol_c)                                                    // out
+KOKKOS_INLINE_FUNCTION void
+compute_dry_volume(int imode,                 // in
+                   const VectorType &state_q, // in
+                   const VectorType &qqcw,    // in
+                   const Real inv_density[AeroConfig::num_modes()]
+                                         [AeroConfig::num_aerosol_ids()], // in
+                   Real &dryvol_i,                                        // out
+                   Real &dryvol_c)                                        // out
 {
   constexpr Real zero = 0.0;
   dryvol_i = zero;
@@ -422,7 +420,7 @@ KOKKOS_INLINE_FUNCTION void compute_dry_volume(
   const auto n_spec = num_species_mode(imode);
   for (int ispec = 0; ispec < n_spec; ispec++) {
     // Fortran to C++ indexing
-    const int idx = lmassptr_amode[ispec][imode] - 1;
+    const int idx = AeroConfig::lmassptr_amode(ispec, imode) - 1;
     dryvol_i += mam4::max(zero, state_q[idx]) * inv_density[imode][ispec];
     dryvol_c += mam4::max(zero, qqcw[idx]) * inv_density[imode][ispec];
   } // end ispec
@@ -569,9 +567,8 @@ KOKKOS_INLINE_FUNCTION void aitken_accum_exchange(
       accum_idx, num2vol_ratio_geomean, adj_tscale_inv, state_q, qqcw,
       drv_i_accsv, drv_c_accsv, num_i_accsv, num_c_accsv,
       calcsizedata.noxf_acc2ait, voltonum_ait, calcsizedata.inv_density,
-      calcsizedata.num2vol_ratio_max_nmodes, AeroConfig::lmassptr_amode,
-      drv_i_noxf, drv_c_noxf, acc2_ait_index, xfercoef_num_acc2ait,
-      xfercoef_vol_acc2ait, xfertend_num);
+      calcsizedata.num2vol_ratio_max_nmodes, drv_i_noxf, drv_c_noxf,
+      acc2_ait_index, xfercoef_num_acc2ait, xfercoef_vol_acc2ait, xfertend_num);
 
   // jump to end of loop if no transfer is needed
   if (ait2acc_index + acc2_ait_index > 0) {
@@ -857,8 +854,7 @@ modal_aero_calcsize_sub(const VectorType &state_q, // in
                        state_q,                  // in
                        qqcw,                     // in
                        calcsizedata.inv_density, // in
-                       AeroConfig::lmassptr_amode,
-                       dryvol_i, // out
+                       dryvol_i,                 // out
                        dryvol_c);
 
     // do size adjustment based on computed dry diameter values and update the
@@ -868,10 +864,10 @@ modal_aero_calcsize_sub(const VectorType &state_q, // in
     // Both num_mode_idx and num_cldbrn_mode_idx should be exactly same and
     // should be same for both prognostic and diagnostic radiation lists
     // Fortran to C++ indexing
-    const int num_mode_idx = AeroConfig::numptr_amode[imode] - 1;
+    const int num_mode_idx = AeroConfig::numptr_amode(imode) - 1;
     // Fortran to C++ indexing
     const int num_cldbrn_mode_idx =
-        AeroConfig::numptr_amode[imode] - 1;          // numptrcw_amode[imode];
+        AeroConfig::numptr_amode(imode) - 1;          // numptrcw_amode[imode];
     const Real n_i_imode = state_q[num_mode_idx];     // from state_q
     const Real n_c_imode = qqcw[num_cldbrn_mode_idx]; // from qqcw
     // const bool update_mmr

--- a/src/mam4xx/modal_aero_calcsize.hpp
+++ b/src/mam4xx/modal_aero_calcsize.hpp
@@ -193,7 +193,7 @@ KOKKOS_INLINE_FUNCTION void compute_coef_acc_ait_transfer(
           // need qmass*invdens = (kg/kg-air) * [1/(kg/m3)] = m3/kg-air
           ; // !get mmr
           // Fortran to C++ indexing
-          const int idx = AeroConfig::lmassptr_amode(ispec, iacc) - 1;
+          const int idx = AeroConfig::lmassptr_amode(ispec, iacc);
           drv_i_noxf +=
               mam4::max(zero, state_q[idx]) * inv_density[iacc][ispec];
           drv_c_noxf += mam4::max(zero, qqcw[idx]) * inv_density[iacc][ispec];
@@ -420,7 +420,7 @@ compute_dry_volume(int imode,                 // in
   const auto n_spec = num_species_mode(imode);
   for (int ispec = 0; ispec < n_spec; ispec++) {
     // Fortran to C++ indexing
-    const int idx = AeroConfig::lmassptr_amode(ispec, imode) - 1;
+    const int idx = AeroConfig::lmassptr_amode(ispec, imode);
     dryvol_i += mam4::max(zero, state_q[idx]) * inv_density[imode][ispec];
     dryvol_c += mam4::max(zero, qqcw[idx]) * inv_density[imode][ispec];
   } // end ispec
@@ -864,10 +864,10 @@ modal_aero_calcsize_sub(const VectorType &state_q, // in
     // Both num_mode_idx and num_cldbrn_mode_idx should be exactly same and
     // should be same for both prognostic and diagnostic radiation lists
     // Fortran to C++ indexing
-    const int num_mode_idx = AeroConfig::numptr_amode(imode) - 1;
+    const int num_mode_idx = AeroConfig::numptr_amode(imode);
     // Fortran to C++ indexing
     const int num_cldbrn_mode_idx =
-        AeroConfig::numptr_amode(imode) - 1;          // numptrcw_amode[imode];
+        AeroConfig::numptr_amode(imode);              // numptrcw_amode[imode];
     const Real n_i_imode = state_q[num_mode_idx];     // from state_q
     const Real n_c_imode = qqcw[num_cldbrn_mode_idx]; // from qqcw
     // const bool update_mmr

--- a/src/mam4xx/modal_aero_opt.hpp
+++ b/src/mam4xx/modal_aero_opt.hpp
@@ -160,26 +160,13 @@ inline void set_device_specrefindex(
   ComplexView2D::host_mirror_type specrefindex_host(view_name, max_nspec,
                                                     nbands);
 
-  int nspec_amode[ntot_amode];
-  int lspectype_amode[ndrop::maxd_aspectype][ntot_amode];
-  int lmassptr_amode[ndrop::maxd_aspectype][ntot_amode];
-  Real specdens_amode[ndrop::maxd_aspectype];
-  Real spechygro[ndrop::maxd_aspectype];
-  int numptr_amode[ntot_amode];
-  int mam_idx[ntot_amode][ndrop::nspec_max];
-  int mam_cnst_idx[ntot_amode][ndrop::nspec_max];
-
-  ndrop::get_e3sm_parameters(nspec_amode, lspectype_amode, lmassptr_amode,
-                             numptr_amode, specdens_amode, spechygro, mam_idx,
-                             mam_cnst_idx);
-
   for (int mm = 0; mm < ntot_amode; ++mm) {
-    const int nspec = nspec_amode[mm];
+    const int nspec = AeroConfig::nspec_amode[mm];
     for (int ibands = 0; ibands < nbands; ++ibands) {
       // // Fortran to C++ indexing
       for (int ll = 0; ll < nspec; ++ll) {
         specrefindex_host(ll, ibands) =
-            specrefndx_host(ibands, lspectype_amode[ll][mm] - 1);
+            specrefndx_host(ibands, AeroConfig::lspectype_amode[ll][mm] - 1);
       } // ll
     }   // ibands
     Kokkos::deep_copy(specrefindex[mm], specrefindex_host);
@@ -527,8 +514,8 @@ KOKKOS_INLINE_FUNCTION void compute_calcsize_and_water_uptake_dr(
                                                dgncur_c_kk, ptend, dqqcwdt);
 
   mam4::water_uptake::modal_aero_water_uptake_dr(
-      calcsizedata.nspec_amode, calcsizedata.specdens_amode,
-      calcsizedata.spechygro, calcsizedata.lspectype_amode, state_q_kk,
+      AeroConfig::nspec_amode, AeroConfig::specdens_amode,
+      AeroConfig::spechygro, AeroConfig::lspectype_amode, state_q_kk,
       temperature, pmid, cldn, dgnumdry_m_kk, dgnumwet_m_kk, qaerwat_m_kk);
 } // compute_calcsize_water_uptake_dr
 
@@ -613,7 +600,7 @@ KOKKOS_INLINE_FUNCTION void modal_aero_sw_wo_diagnostics_k(
 
   for (int mm = 0; mm < ntot_amode; ++mm) {
     //  get mode info
-    const int nspec = calcsizedata.nspec_amode[mm];
+    const int nspec = AeroConfig::nspec_amode[mm];
     // const Real sigma_logr_aer = sigmag_amode[mm];
     // CHECK if mean_std_dev_nmodes is equivalent to sigmag_amode
     const Real sigma_logr_aer = calcsizedata.mean_std_dev_nmodes[mm];
@@ -629,12 +616,11 @@ KOKKOS_INLINE_FUNCTION void modal_aero_sw_wo_diagnostics_k(
 
         // get aerosol properties and save for each species
         // Fortran to C++ indexing
-        auto specmmr = state_q_kk[calcsizedata.lmassptr_amode[ll][mm] - 1];
+        auto specmmr = state_q_kk[AeroConfig::lmassptr_amode[ll][mm] - 1];
         // FIXME: move specdens to init
         //  Fortran to C++ indexing
         const Real specdens =
-            calcsizedata
-                .specdens_amode[calcsizedata.lspectype_amode[ll][mm] - 1];
+            AeroConfig::specdens_amode[AeroConfig::lspectype_amode[ll][mm] - 1];
 
         // allocate(specvol(pcols,nspec),stat=istat)
         specvol[ll] = specmmr / specdens;
@@ -908,7 +894,7 @@ KOKKOS_INLINE_FUNCTION void modal_aero_lw_k(
   for (int mm = 0; mm < ntot_amode; ++mm) {
 
     // get mode info
-    const int nspec = calcsizedata.nspec_amode[mm];
+    const int nspec = AeroConfig::nspec_amode[mm];
     // const Real sigma_logr_aer = sigmag_amode[mm];
     // CHECK if mean_std_dev_nmodes is equivalent to sigmag_amode
     const Real sigma_logr_aer = calcsizedata.mean_std_dev_nmodes[mm];
@@ -925,12 +911,11 @@ KOKKOS_INLINE_FUNCTION void modal_aero_lw_k(
 
       for (int ll = 0; ll < nspec; ++ll) {
         // Fortran to C++ indexing
-        auto specmmr = state_q_kk[calcsizedata.lmassptr_amode[ll][mm] - 1];
+        auto specmmr = state_q_kk[AeroConfig::lmassptr_amode[ll][mm] - 1];
         // FIXME: move specdens to int
         //  Fortran to C++ indexing
         const Real specdens =
-            calcsizedata
-                .specdens_amode[calcsizedata.lspectype_amode[ll][mm] - 1];
+            AeroConfig::specdens_amode[AeroConfig::lspectype_amode[ll][mm] - 1];
 
         specvol[ll] = specmmr / specdens;
       } // ll

--- a/src/mam4xx/modal_aero_opt.hpp
+++ b/src/mam4xx/modal_aero_opt.hpp
@@ -161,12 +161,12 @@ inline void set_device_specrefindex(
                                                     nbands);
 
   for (int mm = 0; mm < ntot_amode; ++mm) {
-    const int nspec = AeroConfig::nspec_amode[mm];
+    const int nspec = AeroConfig::nspec_amode(mm);
     for (int ibands = 0; ibands < nbands; ++ibands) {
       // // Fortran to C++ indexing
       for (int ll = 0; ll < nspec; ++ll) {
         specrefindex_host(ll, ibands) =
-            specrefndx_host(ibands, AeroConfig::lspectype_amode[ll][mm] - 1);
+            specrefndx_host(ibands, AeroConfig::lspectype_amode(ll, mm) - 1);
       } // ll
     }   // ibands
     Kokkos::deep_copy(specrefindex[mm], specrefindex_host);
@@ -513,10 +513,9 @@ KOKKOS_INLINE_FUNCTION void compute_calcsize_and_water_uptake_dr(
                                                dt, calcsizedata, dgnumdry_m_kk,
                                                dgncur_c_kk, ptend, dqqcwdt);
 
-  mam4::water_uptake::modal_aero_water_uptake_dr(
-      AeroConfig::nspec_amode, AeroConfig::specdens_amode,
-      AeroConfig::spechygro, AeroConfig::lspectype_amode, state_q_kk,
-      temperature, pmid, cldn, dgnumdry_m_kk, dgnumwet_m_kk, qaerwat_m_kk);
+  mam4::water_uptake::modal_aero_water_uptake_dr(state_q_kk, temperature, pmid,
+                                                 cldn, dgnumdry_m_kk,
+                                                 dgnumwet_m_kk, qaerwat_m_kk);
 } // compute_calcsize_water_uptake_dr
 
 template <typename VectorType>
@@ -600,7 +599,7 @@ KOKKOS_INLINE_FUNCTION void modal_aero_sw_wo_diagnostics_k(
 
   for (int mm = 0; mm < ntot_amode; ++mm) {
     //  get mode info
-    const int nspec = AeroConfig::nspec_amode[mm];
+    const int nspec = AeroConfig::nspec_amode(mm);
     // const Real sigma_logr_aer = sigmag_amode[mm];
     // CHECK if mean_std_dev_nmodes is equivalent to sigmag_amode
     const Real sigma_logr_aer = calcsizedata.mean_std_dev_nmodes[mm];
@@ -616,11 +615,11 @@ KOKKOS_INLINE_FUNCTION void modal_aero_sw_wo_diagnostics_k(
 
         // get aerosol properties and save for each species
         // Fortran to C++ indexing
-        auto specmmr = state_q_kk[AeroConfig::lmassptr_amode[ll][mm] - 1];
+        auto specmmr = state_q_kk[AeroConfig::lmassptr_amode(ll, mm) - 1];
         // FIXME: move specdens to init
         //  Fortran to C++ indexing
         const Real specdens =
-            AeroConfig::specdens_amode[AeroConfig::lspectype_amode[ll][mm] - 1];
+            AeroConfig::specdens_amode(AeroConfig::lspectype_amode(ll, mm) - 1);
 
         // allocate(specvol(pcols,nspec),stat=istat)
         specvol[ll] = specmmr / specdens;
@@ -894,7 +893,7 @@ KOKKOS_INLINE_FUNCTION void modal_aero_lw_k(
   for (int mm = 0; mm < ntot_amode; ++mm) {
 
     // get mode info
-    const int nspec = AeroConfig::nspec_amode[mm];
+    const int nspec = AeroConfig::nspec_amode(mm);
     // const Real sigma_logr_aer = sigmag_amode[mm];
     // CHECK if mean_std_dev_nmodes is equivalent to sigmag_amode
     const Real sigma_logr_aer = calcsizedata.mean_std_dev_nmodes[mm];
@@ -911,11 +910,11 @@ KOKKOS_INLINE_FUNCTION void modal_aero_lw_k(
 
       for (int ll = 0; ll < nspec; ++ll) {
         // Fortran to C++ indexing
-        auto specmmr = state_q_kk[AeroConfig::lmassptr_amode[ll][mm] - 1];
+        auto specmmr = state_q_kk[AeroConfig::lmassptr_amode(ll, mm) - 1];
         // FIXME: move specdens to int
         //  Fortran to C++ indexing
         const Real specdens =
-            AeroConfig::specdens_amode[AeroConfig::lspectype_amode[ll][mm] - 1];
+            AeroConfig::specdens_amode(AeroConfig::lspectype_amode(ll, mm) - 1);
 
         specvol[ll] = specmmr / specdens;
       } // ll

--- a/src/mam4xx/modal_aero_opt.hpp
+++ b/src/mam4xx/modal_aero_opt.hpp
@@ -166,7 +166,7 @@ inline void set_device_specrefindex(
       // // Fortran to C++ indexing
       for (int ll = 0; ll < nspec; ++ll) {
         specrefindex_host(ll, ibands) =
-            specrefndx_host(ibands, AeroConfig::lspectype_amode(ll, mm) - 1);
+            specrefndx_host(ibands, AeroConfig::lspectype_amode(ll, mm));
       } // ll
     }   // ibands
     Kokkos::deep_copy(specrefindex[mm], specrefindex_host);
@@ -615,11 +615,11 @@ KOKKOS_INLINE_FUNCTION void modal_aero_sw_wo_diagnostics_k(
 
         // get aerosol properties and save for each species
         // Fortran to C++ indexing
-        auto specmmr = state_q_kk[AeroConfig::lmassptr_amode(ll, mm) - 1];
+        auto specmmr = state_q_kk[AeroConfig::lmassptr_amode(ll, mm)];
         // FIXME: move specdens to init
         //  Fortran to C++ indexing
         const Real specdens =
-            AeroConfig::specdens_amode(AeroConfig::lspectype_amode(ll, mm) - 1);
+            AeroConfig::specdens_amode(AeroConfig::lspectype_amode(ll, mm));
 
         // allocate(specvol(pcols,nspec),stat=istat)
         specvol[ll] = specmmr / specdens;
@@ -910,11 +910,11 @@ KOKKOS_INLINE_FUNCTION void modal_aero_lw_k(
 
       for (int ll = 0; ll < nspec; ++ll) {
         // Fortran to C++ indexing
-        auto specmmr = state_q_kk[AeroConfig::lmassptr_amode(ll, mm) - 1];
+        auto specmmr = state_q_kk[AeroConfig::lmassptr_amode(ll, mm)];
         // FIXME: move specdens to int
         //  Fortran to C++ indexing
         const Real specdens =
-            AeroConfig::specdens_amode(AeroConfig::lspectype_amode(ll, mm) - 1);
+            AeroConfig::specdens_amode(AeroConfig::lspectype_amode(ll, mm));
 
         specvol[ll] = specmmr / specdens;
       } // ll

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -41,76 +41,6 @@ constexpr int ncnst_tot = 25;
 constexpr int nspec_max = 8;
 
 KOKKOS_INLINE_FUNCTION
-void get_e3sm_parameters(
-    int nspec_amode[AeroConfig::num_modes()],
-    int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
-    int numptr_amode[AeroConfig::num_modes()],
-    Real specdens_amode[maxd_aspectype], Real spechygro[maxd_aspectype],
-    int mam_idx[AeroConfig::num_modes()][nspec_max],
-    int mam_cnst_idx[AeroConfig::num_modes()][nspec_max]) {
-
-  const int ntot_amode = AeroConfig::num_modes();
-
-  int nspec_amode_temp[ntot_amode] = {7, 4, 7, 3};
-  int numptr_amode_temp[AeroConfig::num_modes()] = {23, 28, 36, 40};
-
-  for (int i = 0; i < ntot_amode; ++i) {
-    nspec_amode[i] = nspec_amode_temp[i];
-    numptr_amode[i] = numptr_amode_temp[i];
-  }
-  Real specdens_amode_temp[maxd_aspectype] = {
-      0.1770000000E+04, -999.0,           -999.0,           0.1000000000E+04,
-      0.1000000000E+04, 0.1700000000E+04, 0.1900000000E+04, 0.2600000000E+04,
-      0.1601000000E+04, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
-      0.0000000000E+00, 0.0000000000E+00};
-  Real spechygro_temp[maxd_aspectype] = {
-      0.5070000000E+00, -999.0,           -999.0,           0.1000000083E-09,
-      0.1400000000E+00, 0.1000000013E-09, 0.1160000000E+01, 0.6800000000E-01,
-      0.1000000015E+00, 0.0000000000E+00, 0.0000000000E+00, 0.0000000000E+00,
-      0.0000000000E+00, 0.0000000000E+00};
-  for (int i = 0; i < maxd_aspectype; ++i) {
-    specdens_amode[i] = specdens_amode_temp[i];
-    spechygro[i] = spechygro_temp[i];
-  }
-
-  const int lspectype_amode_1d[ntot_amode * maxd_aspectype] = {
-      1, 4, 5, 6, 8, 7, 9, 0, 0, 0, 0, 0, 0, 0, 1, 5, 7, 9, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 7, 1, 6, 4, 5, 9, 0, 0, 0,
-      0, 0, 0, 0, 4, 6, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  const int lmassptr_amode_1d[ntot_amode * maxd_aspectype] = {
-      16, 17, 18, 19, 20, 21, 22, 0, 0, 0,  0,  0,  0,  0,  24, 25, 26, 27, 0,
-      0,  0,  0,  0,  0,  0,  0,  0, 0, 29, 30, 31, 32, 33, 34, 35, 0,  0,  0,
-      0,  0,  0,  0,  37, 38, 39, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0};
-
-  int count = 0;
-  for (int i = 0; i < ntot_amode; ++i) {
-    for (int j = 0; j < maxd_aspectype; ++j) {
-      lspectype_amode[j][i] = lspectype_amode_1d[count];
-      lmassptr_amode[j][i] = lmassptr_amode_1d[count];
-      count++;
-    }
-  }
-
-  int mam_idx_temp[ntot_amode * nspec_max] = {
-      1, 9,  14, 22, 2, 10, 15, 23, 3, 11, 16, 24, 4, 12, 17, 25,
-      5, 13, 18, 0,  6, 0,  19, 0,  7, 0,  20, 0,  8, 0,  21, 0};
-  int mam_cnst_idx_temp[ntot_amode * nspec_max] = {
-      23, 28, 36, 40, 16, 24, 29, 37, 17, 25, 30, 38, 18, 26, 31, 39,
-      19, 27, 32, 0,  20, 0,  33, 0,  21, 0,  34, 0,  22, 0,  35, 0};
-
-  count = 0;
-  for (int i = 0; i < nspec_max; ++i) {
-    for (int j = 0; j < ntot_amode; ++j) {
-      mam_idx[j][i] = mam_idx_temp[count];
-      mam_cnst_idx[j][i] = mam_cnst_idx_temp[count];
-      count++;
-    } // j
-  }   // i
-
-} // get_e3sm_parameters
-
-KOKKOS_INLINE_FUNCTION
 void get_aer_mmr_sum(
     const int imode, const int nspec, const Real state_q[aero_model::pcnst],
     const Real qcldbrn1d[maxd_aspectype],
@@ -297,15 +227,15 @@ void loadaer(const Real state_q[aero_model::pcnst],
   for (int imode = 0; imode < nmodes; ++imode) {
     Real vaerosolsum = zero;
     Real hygrosum = zero;
-    const Real nspec = nspec_amode[imode];
+    const Real nspec = AeroConfig::nspec_amode[imode];
 
     for (int ispec = 0; ispec < nspec; ++ispec) {
       qcldbrn1d_imode[ispec] = qcldbrn1d[ispec][imode];
     }
 
     get_aer_mmr_sum(imode, nspec, state_q, qcldbrn1d_imode, lspectype_amode,
-                    specdens_amode, spechygro, lmassptr_amode, vaerosolsum,
-                    hygrosum);
+                    specdens_amode, spechygro, AeroConfig::lmassptr_amode,
+                    vaerosolsum, hygrosum);
 
     //  Finalize computation of bulk hygroscopicity and volume conc
     // NOTE: maybe use safe_denominator()?
@@ -319,7 +249,7 @@ void loadaer(const Real state_q[aero_model::pcnst],
 
     // Compute aerosol number concentration
     // Fortran indexing to C++
-    const int num_idx = numptr_amode[imode] - 1;
+    const int num_idx = AeroConfig::numptr_amode[imode] - 1;
     get_aer_num(voltonumbhi_amode[imode], voltonumblo_amode[imode], num_idx,
                 state_q, air_density, vaerosol[imode], qcldbrn1d_num[imode],
                 naerosol[imode]);
@@ -405,10 +335,10 @@ void ccncalc(const Real state_q[aero_model::pcnst], const Real tair,
   Real vaerosol[AeroConfig::num_modes()] = {zero};
   Real hygro[AeroConfig::num_modes()] = {zero};
 
-  loadaer(state_q, nspec_amode, air_density, phase, lspectype_amode,
-          specdens_amode, spechygro, lmassptr_amode, voltonumbhi_amode,
-          voltonumblo_amode, numptr_amode, qcldbrn, qcldbrn_num, naerosol,
-          vaerosol, hygro);
+  loadaer(state_q, AeroConfig::nspec_amode, air_density, phase, lspectype_amode,
+          AeroConfig::specdens_amode, spechygro, AeroConfig::lmassptr_amode,
+          voltonumbhi_amode, voltonumblo_amode, numptr_amode, qcldbrn,
+          qcldbrn_num, naerosol, vaerosol, hygro);
 
   for (int lsat = 0; lsat < psat; ++lsat) {
     ccn[lsat] = {zero};
@@ -747,10 +677,10 @@ void get_activate_frac(
   Real hygro[nmodes] = {zero}; // hygroscopicity of aerosol mode [dimensionless]
 
   // load aerosol properties, assuming external mixtures
-  loadaer(state_q_kload, nspec_amode, air_density_kload, phase, lspectype_amode,
-          specdens_amode, spechygro, lmassptr_amode, voltonumbhi_amode,
-          voltonumblo_amode, numptr_amode, qcldbrn, qcldbrn_num, naermod,
-          vaerosol, hygro);
+  loadaer(state_q_kload, AeroConfig::nspec_amode, air_density_kload, phase,
+          lspectype_amode, specdens_amode, spechygro,
+          AeroConfig::lmassptr_amode, voltonumbhi_amode, voltonumblo_amode,
+          numptr_amode, qcldbrn, qcldbrn_num, naermod, vaerosol, hygro);
 
   // BAD CONSTANT
   const Real wmax = 10.0;
@@ -857,9 +787,10 @@ void update_from_cldn_profile(
       get_activate_frac(
           state_q_col_in_kp1, air_density_kp1, air_density, wtke_col_in,
           temp_col_in, // in
-          lspectype_amode, specdens_amode, spechygro, lmassptr_amode,
-          voltonumbhi_amode, voltonumblo_amode, numptr_amode, nspec_amode,
-          exp45logsig, alogsig, aten, factnum_col, fm, fluxn, fluxm, // out
+          lspectype_amode, specdens_amode, spechygro,
+          AeroConfig::lmassptr_amode, voltonumbhi_amode, voltonumblo_amode,
+          numptr_amode, AeroConfig::nspec_amode, exp45logsig, alogsig, aten,
+          factnum_col, fm, fluxn, fluxm, // out
           flux_fullact);
 
       //  store for output activation fraction of aerosol
@@ -909,7 +840,7 @@ void update_from_cldn_profile(
       for (int imode = 0; imode < ntot_amode; ++imode) {
         // local array index for MAM number, species
         // Fortran indexing to C++ indexing
-        const int mm = mam_idx[imode][0] - 1;
+        const int mm = AeroConfig::mam_idx[imode][0] - 1;
         nact[imode] += fluxn[imode] * crdz * delz_cld;
         mact[imode] += fluxm[imode] * crdz * delz_cld;
         // note that kp1 is used here
@@ -934,12 +865,12 @@ void update_from_cldn_profile(
     for (int imode = 0; imode < ntot_amode; ++imode) {
       // local array index for MAM number, species
       // Fortran indexing to C++ indexing
-      int mm = mam_idx[imode][0] - 1;
+      int mm = AeroConfig::mam_idx[imode][0] - 1;
       raercol_nsav[mm] += raercol_cw_nsav[mm]; // cloud-borne aerosol
       raercol_cw_nsav[mm] = zero;
 
-      for (int lspec = 1; lspec < nspec_amode[imode] + 1; ++lspec) {
-        mm = mam_idx[imode][lspec] - 1;
+      for (int lspec = 1; lspec < AeroConfig::nspec_amode[imode] + 1; ++lspec) {
+        mm = AeroConfig::mam_idx[imode][lspec] - 1;
         raercol_nsav[mm] += raercol_cw_nsav[mm]; // cloud-borne aerosol
         raercol_cw_nsav[mm] = zero;
       }
@@ -1016,14 +947,14 @@ void update_from_newcld(
 
     for (int imode = 0; imode < ntot_amode; ++imode) {
       // Fortran indexing to C++ indexing
-      const int mm = mam_idx[imode][0] - 1;
+      const int mm = AeroConfig::mam_idx[imode][0] - 1;
       // cloud-borne aerosol tendency due to cloud frac tendency [#/kg or kg/kg]
       const Real dact = raercol_cw_nsav[mm] * frac_delt_cld;
       raercol_cw_nsav[mm] += dact; // cloud-borne aerosol
       raercol_nsav[mm] -= dact;
-      for (int lspec = 1; lspec < nspec_amode[imode] + 1; ++lspec) {
+      for (int lspec = 1; lspec < AeroConfig::nspec_amode[imode] + 1; ++lspec) {
         // Fortran indexing to C++ indexing
-        const int mm = mam_idx[imode][lspec] - 1;
+        const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
         const Real dact = raercol_cw_nsav[mm] * frac_delt_cld;
         raercol_cw_nsav[mm] += dact; // cloud-borne aerosol
         raercol_nsav[mm] -= dact;
@@ -1049,15 +980,15 @@ void update_from_newcld(
                       temp_col_in, // in
                       lspectype_amode, specdens_amode, spechygro,
                       lmassptr_amode, voltonumbhi_amode, voltonumblo_amode,
-                      numptr_amode, nspec_amode, exp45logsig, alogsig, aten,
-                      factnum_col_out, fm, fluxn, fluxm, // out
+                      numptr_amode, AeroConfig::nspec_amode, exp45logsig,
+                      alogsig, aten, factnum_col_out, fm, fluxn, fluxm, // out
                       flux_fullact);
 
     for (int imode = 0; imode < ntot_amode; ++imode) {
       // Fortran indexing to C++ indexing
-      const int mm = mam_idx[imode][0] - 1;
+      const int mm = AeroConfig::mam_idx[imode][0] - 1;
       // Fortran indexing to C++ indexing
-      const int num_idx = numptr_amode[imode] - 1;
+      const int num_idx = AeroConfig::numptr_amode[imode] - 1;
       const Real dact = delt_cld * factnum_col_out[imode] *
                         state_q_col_in[num_idx]; // interstitial only
       qcld += dact;
@@ -1067,9 +998,9 @@ void update_from_newcld(
       // fm change from fractional change in cloud fraction [fraction]
       const Real fm_delt_cld = delt_cld * fm[imode];
 
-      for (int lspec = 1; lspec < nspec_amode[imode] + 1; ++lspec) {
+      for (int lspec = 1; lspec < AeroConfig::nspec_amode[imode] + 1; ++lspec) {
         // Fortran indexing to C++ indexing
-        const int mm = mam_idx[imode][lspec] - 1;
+        const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
         // Fortran indexing to C++ indexing
         const int spc_idx = lmassptr_amode[lspec - 1][imode] - 1;
         // interstitial only
@@ -1306,7 +1237,7 @@ void update_from_explmix(
           //         srcn(:)=srcn(:)+nact(:,m)*(raercol(:,mm,nsav))
           Real srcn = zero;
           for (int imode = 0; imode < ntot_amode; imode++) {
-            const int mm = mam_idx[imode][0] - 1;
+            const int mm = AeroConfig::mam_idx[imode][0] - 1;
             srcn += nact(k, imode) * raercol_kp1_nsav(mm);
             if (k == pver_loc - 1) {
               // rce-comment- new formulation for k=pver
@@ -1332,8 +1263,9 @@ void update_from_explmix(
               explmix(qncld(km1), qncld(k), qncld(kp1), srcn, eddy_diff_kp(k),
                       eddy_diff_km(k), overlapp(k), overlapm(k), dtmix);
           for (int imode = 0; imode < ntot_amode; imode++) {
-            for (int lspec = 0; lspec < nspec_amode[imode] + 1; lspec++) {
-              const int mm = mam_idx[imode][lspec] - 1;
+            for (int lspec = 0; lspec < AeroConfig::nspec_amode[imode] + 1;
+                 lspec++) {
+              const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
               Real source = 0;
               if (k < pver_loc - 1) {
                 const Real act = lspec ? mact(k, imode) : nact(k, imode);
@@ -1368,12 +1300,13 @@ void update_from_explmix(
 
           // convert activated aerosol to interstitial in decaying cloud
           for (int imode = 0; imode < ntot_amode; imode++) {
-            const int mm = mam_idx[imode][0] - 1;
+            const int mm = AeroConfig::mam_idx[imode][0] - 1;
             raercol(k, nnew, mm) += raercol_cw(k, nnew, mm);
             raercol_cw(k, nnew, mm) = zero;
 
-            for (int lspec = 1; lspec < nspec_amode[imode] + 1; lspec++) {
-              const int mm = mam_idx[imode][lspec] - 1;
+            for (int lspec = 1; lspec < AeroConfig::nspec_amode[imode] + 1;
+                 lspec++) {
+              const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
               raercol(k, nnew, mm) += raercol_cw(k, nnew, mm);
               raercol_cw(k, nnew, mm) = zero;
             } // lspec
@@ -1390,18 +1323,10 @@ void dropmixnuc(
     const ConstColumnView &zm, const ConstView2D &state_q,
     const ConstColumnView &ncldwtr, const ConstColumnView &v_diffusivity,
     const ConstColumnView &cldn,
-    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const Real specdens_amode[maxd_aspectype],
-    const Real spechygro[maxd_aspectype],
-    const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
     const Real voltonumbhi_amode[AeroConfig::num_modes()],
     const Real voltonumblo_amode[AeroConfig::num_modes()],
-    const int numptr_amode[AeroConfig::num_modes()],
-    const int nspec_amode[maxd_aspectype],
     const Real exp45logsig[AeroConfig::num_modes()],
-    const Real alogsig[AeroConfig::num_modes()], const Real aten,
-    const int mam_idx[AeroConfig::num_modes()][nspec_max],
-    const int mam_cnst_idx[AeroConfig::num_modes()][nspec_max], const bool &,
+    const Real alogsig[AeroConfig::num_modes()], const Real aten, const bool &,
     const ColumnView &qcld, const ColumnView &wsub,
     const ColumnView &cldo, // in
     const View2D qqcw_fld,  // inout
@@ -1533,18 +1458,20 @@ void dropmixnuc(
       Kokkos::TeamVectorRange(team, top_lev, pver_loc), [&](int k) {
         for (int imode = 0; imode < ntot_amode; ++imode) {
           // Fortran indexing to C++ indexing
-          const int mm = mam_idx[imode][0] - 1;
+          const int mm = AeroConfig::mam_idx[imode][0] - 1;
           raercol_cw(k, nsav, mm) = qqcw_fld(mm, k);
           // Fortran indexing to C++ indexing
-          const int num_idx = numptr_amode[imode] - 1;
+          const int num_idx = AeroConfig::numptr_amode[imode] - 1;
           raercol(k, nsav, mm) = state_q(k, num_idx);
-          for (int lspec = 1; lspec < nspec_amode[imode] + 1; ++lspec) {
+          for (int lspec = 1; lspec < AeroConfig::nspec_amode[imode] + 1;
+               ++lspec) {
             // Fortran indexing to C++ indexing
-            const int mm = mam_idx[imode][lspec] - 1;
+            const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
 
             raercol_cw(k, nsav, mm) = qqcw_fld(mm, k);
             // Fortran indexing to C++ indexing
-            const int spc_idx = lmassptr_amode[lspec - 1][imode] - 1;
+            const int spc_idx =
+                AeroConfig::lmassptr_amode[lspec - 1][imode] - 1;
             raercol(k, nsav, mm) = state_q(k, spc_idx);
           } // lspec
         }   // imode
@@ -1565,10 +1492,12 @@ void dropmixnuc(
                            wtke(k), temp(k),
                            conversions::density_of_ideal_gas(temp(k), pmid(k)),
                            state_q_k.data(), // in
-                           lspectype_amode, specdens_amode, spechygro,
-                           lmassptr_amode, voltonumbhi_amode, voltonumblo_amode,
-                           numptr_amode, nspec_amode, exp45logsig, alogsig,
-                           aten, mam_idx, qcld(k),
+                           AeroConfig::lspectype_amode,
+                           AeroConfig::specdens_amode, AeroConfig::spechygro,
+                           AeroConfig::lmassptr_amode, voltonumbhi_amode,
+                           voltonumblo_amode, AeroConfig::numptr_amode,
+                           AeroConfig::nspec_amode, exp45logsig, alogsig, aten,
+                           AeroConfig::mam_idx, qcld(k),
                            ekat::subview(raercol, k, nsav),    // inout
                            ekat::subview(raercol_cw, k, nsav), // inout
                            nsource(k), factnum_k);             // inout
@@ -1598,10 +1527,12 @@ void dropmixnuc(
             conversions::density_of_ideal_gas(temp(kp1), pmid(kp1)),
             csbot_cscen(k),
             state_q_kp1.data(), // in
-            lspectype_amode, specdens_amode, spechygro, lmassptr_amode,
-            voltonumbhi_amode, voltonumblo_amode, numptr_amode, nspec_amode,
-            exp45logsig, alogsig, aten, mam_idx,
-            ekat::subview(raercol, k, nsav), ekat::subview(raercol, kp1, nsav),
+            AeroConfig::lspectype_amode, AeroConfig::specdens_amode,
+            AeroConfig::spechygro, AeroConfig::lmassptr_amode,
+            voltonumbhi_amode, voltonumblo_amode, AeroConfig::numptr_amode,
+            AeroConfig::nspec_amode, exp45logsig, alogsig, aten,
+            AeroConfig::mam_idx, ekat::subview(raercol, k, nsav),
+            ekat::subview(raercol, kp1, nsav),
             ekat::subview(raercol_cw, k, nsav),
             nsource(k), // inout
             qcld(k), factnum_k,
@@ -1617,8 +1548,8 @@ void dropmixnuc(
 
   int nnew = 1;
   update_from_explmix(team, dtmicro, csbot, cldn, zn, zs, eddy_diff, nact, mact,
-                      qcld, raercol, raercol_cw, nsav, nnew, nspec_amode,
-                      mam_idx, top_lev,
+                      qcld, raercol, raercol_cw, nsav, nnew,
+                      AeroConfig::nspec_amode, AeroConfig::mam_idx, top_lev,
                       // work vars
                       overlapp, overlapm, eddy_diff_kp, eddy_diff_km, qncld);
 
@@ -1653,25 +1584,27 @@ void dropmixnuc(
 
         for (int imode = 0; imode < ntot_amode; ++imode) {
           // species index for given mode
-          for (int lspec = 0; lspec < nspec_amode[imode] + 1; ++lspec) {
+          for (int lspec = 0; lspec < AeroConfig::nspec_amode[imode] + 1;
+               ++lspec) {
             // local array index for MAM number, species
             // Fortran indexing to C++ indexing
-            const int mm = mam_idx[imode][lspec] - 1;
+            const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
             // Fortran indexing to C++ indexing
-            const int lptr = mam_cnst_idx[imode][lspec] - 1;
+            const int lptr = AeroConfig::mam_cnst_idx[imode][lspec] - 1;
             qqcwtend(k) = (raercol_cw(k, nnew, mm) - qqcw_fld(mm, k)) * dtinv;
             qqcw_fld(mm, k) = mam4::max(raercol_cw(k, nnew, mm),
                                         zero); // update cloud-borne aerosol
 
             if (lspec == 0) {
               // Fortran indexing to C++ indexing
-              const int num_idx = numptr_amode[imode] - 1;
+              const int num_idx = AeroConfig::numptr_amode[imode] - 1;
               raertend(k) =
                   (raercol(k, nnew, mm) - state_q(k, num_idx)) * dtinv;
               qcldbrn_num[imode] = qqcw_fld(mm, k);
             } else {
               // Fortran indexing to C++ indexing
-              const int spc_idx = lmassptr_amode[lspec - 1][imode] - 1;
+              const int spc_idx =
+                  AeroConfig::lmassptr_amode[lspec - 1][imode] - 1;
               raertend(k) =
                   (raercol(k, nnew, mm) - state_q(k, spc_idx)) * dtinv;
               // Extract cloud borne MMRs from qqcw pointer
@@ -1694,9 +1627,10 @@ void dropmixnuc(
         // ccn fields.
         ccncalc(state_q_k.data(), temp(k), qcldbrn, qcldbrn_num,
                 conversions::density_of_ideal_gas(temp(k), pmid(k)),
-                lspectype_amode, specdens_amode, spechygro, lmassptr_amode,
-                voltonumbhi_amode, voltonumblo_amode, numptr_amode, nspec_amode,
-                exp45logsig, alogsig, ccn_k.data());
+                AeroConfig::lspectype_amode, AeroConfig::specdens_amode,
+                AeroConfig::spechygro, AeroConfig::lmassptr_amode,
+                voltonumbhi_amode, voltonumblo_amode, AeroConfig::numptr_amode,
+                AeroConfig::nspec_amode, exp45logsig, alogsig, ccn_k.data());
       }); // end parfor(k)
   team.team_barrier();
 } // dropmixnuc

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -1326,9 +1326,8 @@ void dropmixnuc(
     const Real voltonumbhi_amode[AeroConfig::num_modes()],
     const Real voltonumblo_amode[AeroConfig::num_modes()],
     const Real exp45logsig[AeroConfig::num_modes()],
-    const Real alogsig[AeroConfig::num_modes()], const Real aten,
-    const bool &, const ColumnView &qcld,
-    const ColumnView &wsub,
+    const Real alogsig[AeroConfig::num_modes()], const Real aten, const bool &,
+    const ColumnView &qcld, const ColumnView &wsub,
     const ColumnView &cldo, // in
     const View2D qqcw_fld,  // inout
     const View2D ptend_q, const ColumnView &tendnd, const View2D &factnum,

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -1326,8 +1326,9 @@ void dropmixnuc(
     const Real voltonumbhi_amode[AeroConfig::num_modes()],
     const Real voltonumblo_amode[AeroConfig::num_modes()],
     const Real exp45logsig[AeroConfig::num_modes()],
-    const Real alogsig[AeroConfig::num_modes()], const Real aten, const bool &,
-    const ColumnView &qcld, const ColumnView &wsub,
+    const Real alogsig[AeroConfig::num_modes()], const Real aten,
+    const bool &, const ColumnView &qcld,
+    const ColumnView &wsub,
     const ColumnView &cldo, // in
     const View2D qqcw_fld,  // inout
     const View2D ptend_q, const ColumnView &tendnd, const View2D &factnum,

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -61,7 +61,7 @@ void get_aer_mmr_sum(const int imode, const int nspec,
   // per mode.
   for (int lspec = 0; lspec < nspec; ++lspec) {
     // Fortran indexing to C++
-    const int type_idx = AeroConfig::lspectype_amode(lspec, imode) - 1;
+    const int type_idx = AeroConfig::lspectype_amode(lspec, imode);
     // density at species / mode indices [kg/m3]
     const Real density_sp =
         AeroConfig::specdens_amode(type_idx); // species density
@@ -70,7 +70,7 @@ void get_aer_mmr_sum(const int imode, const int nspec,
         AeroConfig::spechygro(type_idx); // species hygroscopicity
     // Fortran indexing to C++
     // index of species in state_q array
-    const int spc_idx = AeroConfig::lmassptr_amode(lspec, imode) - 1;
+    const int spc_idx = AeroConfig::lmassptr_amode(lspec, imode);
     // aerosol volume mixing ratio [m3/kg]
     const Real vol = mam4::max(state_q[spc_idx] + qcldbrn1d[lspec], zero) /
                      density_sp; // volume = mmr/density
@@ -240,7 +240,7 @@ void loadaer(const Real state_q[aero_model::pcnst], Real air_density,
 
     // Compute aerosol number concentration
     // Fortran indexing to C++
-    const int num_idx = AeroConfig::numptr_amode(imode) - 1;
+    const int num_idx = AeroConfig::numptr_amode(imode);
     get_aer_num(voltonumbhi_amode[imode], voltonumblo_amode[imode], num_idx,
                 state_q, air_density, vaerosol[imode], qcldbrn1d_num[imode],
                 naerosol[imode]);
@@ -808,7 +808,7 @@ void update_from_cldn_profile(
       for (int imode = 0; imode < ntot_amode; ++imode) {
         // local array index for MAM number, species
         // Fortran indexing to C++ indexing
-        const int mm = AeroConfig::mam_idx(imode, 0) - 1;
+        const int mm = AeroConfig::mam_idx(imode, 0);
         nact[imode] += fluxn[imode] * crdz * delz_cld;
         mact[imode] += fluxm[imode] * crdz * delz_cld;
         // note that kp1 is used here
@@ -833,12 +833,12 @@ void update_from_cldn_profile(
     for (int imode = 0; imode < ntot_amode; ++imode) {
       // local array index for MAM number, species
       // Fortran indexing to C++ indexing
-      int mm = AeroConfig::mam_idx(imode, 0) - 1;
+      int mm = AeroConfig::mam_idx(imode, 0);
       raercol_nsav[mm] += raercol_cw_nsav[mm]; // cloud-borne aerosol
       raercol_cw_nsav[mm] = zero;
 
       for (int lspec = 1; lspec < AeroConfig::nspec_amode(imode) + 1; ++lspec) {
-        mm = AeroConfig::mam_idx(imode, lspec) - 1;
+        mm = AeroConfig::mam_idx(imode, lspec);
         raercol_nsav[mm] += raercol_cw_nsav[mm]; // cloud-borne aerosol
         raercol_cw_nsav[mm] = zero;
       }
@@ -909,14 +909,14 @@ void update_from_newcld(const Real cldn_col_in, const Real cldo_col_in,
 
     for (int imode = 0; imode < ntot_amode; ++imode) {
       // Fortran indexing to C++ indexing
-      const int mm = AeroConfig::mam_idx(imode, 0) - 1;
+      const int mm = AeroConfig::mam_idx(imode, 0);
       // cloud-borne aerosol tendency due to cloud frac tendency [#/kg or kg/kg]
       const Real dact = raercol_cw_nsav[mm] * frac_delt_cld;
       raercol_cw_nsav[mm] += dact; // cloud-borne aerosol
       raercol_nsav[mm] -= dact;
       for (int lspec = 1; lspec < AeroConfig::nspec_amode(imode) + 1; ++lspec) {
         // Fortran indexing to C++ indexing
-        const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
+        const int mm = AeroConfig::mam_idx(imode, lspec);
         const Real dact = raercol_cw_nsav[mm] * frac_delt_cld;
         raercol_cw_nsav[mm] += dact; // cloud-borne aerosol
         raercol_nsav[mm] -= dact;
@@ -946,9 +946,9 @@ void update_from_newcld(const Real cldn_col_in, const Real cldo_col_in,
 
     for (int imode = 0; imode < ntot_amode; ++imode) {
       // Fortran indexing to C++ indexing
-      const int mm = AeroConfig::mam_idx(imode, 0) - 1;
+      const int mm = AeroConfig::mam_idx(imode, 0);
       // Fortran indexing to C++ indexing
-      const int num_idx = AeroConfig::numptr_amode(imode) - 1;
+      const int num_idx = AeroConfig::numptr_amode(imode);
       const Real dact = delt_cld * factnum_col_out[imode] *
                         state_q_col_in[num_idx]; // interstitial only
       qcld += dact;
@@ -960,9 +960,9 @@ void update_from_newcld(const Real cldn_col_in, const Real cldo_col_in,
 
       for (int lspec = 1; lspec < AeroConfig::nspec_amode(imode) + 1; ++lspec) {
         // Fortran indexing to C++ indexing
-        const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
+        const int mm = AeroConfig::mam_idx(imode, lspec);
         // Fortran indexing to C++ indexing
-        const int spc_idx = AeroConfig::lmassptr_amode(lspec - 1, imode) - 1;
+        const int spc_idx = AeroConfig::lmassptr_amode(lspec - 1, imode);
         // interstitial only
         const Real dact = fm_delt_cld * state_q_col_in[spc_idx];
         raercol_cw_nsav[mm] += dact; //  cloud-borne aerosol
@@ -1196,7 +1196,7 @@ void update_from_explmix(
           //         srcn(:)=srcn(:)+nact(:,m)*(raercol(:,mm,nsav))
           Real srcn = zero;
           for (int imode = 0; imode < ntot_amode; imode++) {
-            const int mm = AeroConfig::mam_idx(imode, 0) - 1;
+            const int mm = AeroConfig::mam_idx(imode, 0);
             srcn += nact(k, imode) * raercol_kp1_nsav(mm);
             if (k == pver_loc - 1) {
               // rce-comment- new formulation for k=pver
@@ -1224,7 +1224,7 @@ void update_from_explmix(
           for (int imode = 0; imode < ntot_amode; imode++) {
             for (int lspec = 0; lspec < AeroConfig::nspec_amode(imode) + 1;
                  lspec++) {
-              const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
+              const int mm = AeroConfig::mam_idx(imode, lspec);
               Real source = 0;
               if (k < pver_loc - 1) {
                 const Real act = lspec ? mact(k, imode) : nact(k, imode);
@@ -1259,13 +1259,13 @@ void update_from_explmix(
 
           // convert activated aerosol to interstitial in decaying cloud
           for (int imode = 0; imode < ntot_amode; imode++) {
-            const int mm = AeroConfig::mam_idx(imode, 0) - 1;
+            const int mm = AeroConfig::mam_idx(imode, 0);
             raercol(k, nnew, mm) += raercol_cw(k, nnew, mm);
             raercol_cw(k, nnew, mm) = zero;
 
             for (int lspec = 1; lspec < AeroConfig::nspec_amode(imode) + 1;
                  lspec++) {
-              const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
+              const int mm = AeroConfig::mam_idx(imode, lspec);
               raercol(k, nnew, mm) += raercol_cw(k, nnew, mm);
               raercol_cw(k, nnew, mm) = zero;
             } // lspec
@@ -1417,20 +1417,19 @@ void dropmixnuc(
       Kokkos::TeamVectorRange(team, top_lev, pver_loc), [&](int k) {
         for (int imode = 0; imode < ntot_amode; ++imode) {
           // Fortran indexing to C++ indexing
-          const int mm = AeroConfig::mam_idx(imode, 0) - 1;
+          const int mm = AeroConfig::mam_idx(imode, 0);
           raercol_cw(k, nsav, mm) = qqcw_fld(mm, k);
           // Fortran indexing to C++ indexing
-          const int num_idx = AeroConfig::numptr_amode(imode) - 1;
+          const int num_idx = AeroConfig::numptr_amode(imode);
           raercol(k, nsav, mm) = state_q(k, num_idx);
           for (int lspec = 1; lspec < AeroConfig::nspec_amode(imode) + 1;
                ++lspec) {
             // Fortran indexing to C++ indexing
-            const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
+            const int mm = AeroConfig::mam_idx(imode, lspec);
 
             raercol_cw(k, nsav, mm) = qqcw_fld(mm, k);
             // Fortran indexing to C++ indexing
-            const int spc_idx =
-                AeroConfig::lmassptr_amode(lspec - 1, imode) - 1;
+            const int spc_idx = AeroConfig::lmassptr_amode(lspec - 1, imode);
             raercol(k, nsav, mm) = state_q(k, spc_idx);
           } // lspec
         }   // imode
@@ -1538,23 +1537,22 @@ void dropmixnuc(
                ++lspec) {
             // local array index for MAM number, species
             // Fortran indexing to C++ indexing
-            const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
+            const int mm = AeroConfig::mam_idx(imode, lspec);
             // Fortran indexing to C++ indexing
-            const int lptr = AeroConfig::mam_cnst_idx(imode, lspec) - 1;
+            const int lptr = AeroConfig::mam_cnst_idx(imode, lspec);
             qqcwtend(k) = (raercol_cw(k, nnew, mm) - qqcw_fld(mm, k)) * dtinv;
             qqcw_fld(mm, k) = mam4::max(raercol_cw(k, nnew, mm),
                                         zero); // update cloud-borne aerosol
 
             if (lspec == 0) {
               // Fortran indexing to C++ indexing
-              const int num_idx = AeroConfig::numptr_amode(imode) - 1;
+              const int num_idx = AeroConfig::numptr_amode(imode);
               raertend(k) =
                   (raercol(k, nnew, mm) - state_q(k, num_idx)) * dtinv;
               qcldbrn_num[imode] = qqcw_fld(mm, k);
             } else {
               // Fortran indexing to C++ indexing
-              const int spc_idx =
-                  AeroConfig::lmassptr_amode(lspec - 1, imode) - 1;
+              const int spc_idx = AeroConfig::lmassptr_amode(lspec - 1, imode);
               raertend(k) =
                   (raercol(k, nnew, mm) - state_q(k, spc_idx)) * dtinv;
               // Extract cloud borne MMRs from qqcw pointer

--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -41,14 +41,10 @@ constexpr int ncnst_tot = 25;
 constexpr int nspec_max = 8;
 
 KOKKOS_INLINE_FUNCTION
-void get_aer_mmr_sum(
-    const int imode, const int nspec, const Real state_q[aero_model::pcnst],
-    const Real qcldbrn1d[maxd_aspectype],
-    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const Real specdens_amode[maxd_aspectype],
-    const Real spechygro[maxd_aspectype],
-    const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
-    Real &vaerosolsum_icol, Real &hygrosum_icol) {
+void get_aer_mmr_sum(const int imode, const int nspec,
+                     const Real state_q[aero_model::pcnst],
+                     const Real qcldbrn1d[maxd_aspectype],
+                     Real &vaerosolsum_icol, Real &hygrosum_icol) {
 
   // @param[in] imode  mode index
   // @param[in] nspec  total # of species in mode imode
@@ -65,14 +61,16 @@ void get_aer_mmr_sum(
   // per mode.
   for (int lspec = 0; lspec < nspec; ++lspec) {
     // Fortran indexing to C++
-    const int type_idx = lspectype_amode[lspec][imode] - 1;
+    const int type_idx = AeroConfig::lspectype_amode(lspec, imode) - 1;
     // density at species / mode indices [kg/m3]
-    const Real density_sp = specdens_amode[type_idx]; // species density
+    const Real density_sp =
+        AeroConfig::specdens_amode(type_idx); // species density
     // hygroscopicity at species / mode indices [dimensionless]
-    const Real hygro_sp = spechygro[type_idx]; // species hygroscopicity
+    const Real hygro_sp =
+        AeroConfig::spechygro(type_idx); // species hygroscopicity
     // Fortran indexing to C++
     // index of species in state_q array
-    const int spc_idx = lmassptr_amode[lspec][imode] - 1;
+    const int spc_idx = AeroConfig::lmassptr_amode(lspec, imode) - 1;
     // aerosol volume mixing ratio [m3/kg]
     const Real vol = mam4::max(state_q[spc_idx] + qcldbrn1d[lspec], zero) /
                      density_sp; // volume = mmr/density
@@ -169,16 +167,10 @@ void maxsat(
 } // end maxsat
 
 KOKKOS_INLINE_FUNCTION
-void loadaer(const Real state_q[aero_model::pcnst],
-             const int nspec_amode[AeroConfig::num_modes()], Real air_density,
+void loadaer(const Real state_q[aero_model::pcnst], Real air_density,
              const int phase,
-             const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-             const Real specdens_amode[maxd_aspectype],
-             const Real spechygro[maxd_aspectype],
-             const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
              const Real voltonumbhi_amode[AeroConfig::num_modes()],
              const Real voltonumblo_amode[AeroConfig::num_modes()],
-             const int numptr_amode[AeroConfig::num_modes()],
              const Real qcldbrn1d[maxd_aspectype][AeroConfig::num_modes()],
              const Real qcldbrn1d_num[AeroConfig::num_modes()],
              Real naerosol[AeroConfig::num_modes()],
@@ -227,15 +219,14 @@ void loadaer(const Real state_q[aero_model::pcnst],
   for (int imode = 0; imode < nmodes; ++imode) {
     Real vaerosolsum = zero;
     Real hygrosum = zero;
-    const Real nspec = AeroConfig::nspec_amode[imode];
+    const Real nspec = AeroConfig::nspec_amode(imode);
 
     for (int ispec = 0; ispec < nspec; ++ispec) {
       qcldbrn1d_imode[ispec] = qcldbrn1d[ispec][imode];
     }
 
-    get_aer_mmr_sum(imode, nspec, state_q, qcldbrn1d_imode, lspectype_amode,
-                    specdens_amode, spechygro, AeroConfig::lmassptr_amode,
-                    vaerosolsum, hygrosum);
+    get_aer_mmr_sum(imode, nspec, state_q, qcldbrn1d_imode, vaerosolsum,
+                    hygrosum);
 
     //  Finalize computation of bulk hygroscopicity and volume conc
     // NOTE: maybe use safe_denominator()?
@@ -249,7 +240,7 @@ void loadaer(const Real state_q[aero_model::pcnst],
 
     // Compute aerosol number concentration
     // Fortran indexing to C++
-    const int num_idx = AeroConfig::numptr_amode[imode] - 1;
+    const int num_idx = AeroConfig::numptr_amode(imode) - 1;
     get_aer_num(voltonumbhi_amode[imode], voltonumblo_amode[imode], num_idx,
                 state_q, air_density, vaerosol[imode], qcldbrn1d_num[imode],
                 naerosol[imode]);
@@ -262,14 +253,8 @@ void ccncalc(const Real state_q[aero_model::pcnst], const Real tair,
              const Real qcldbrn[maxd_aspectype][AeroConfig::num_modes()],
              const Real qcldbrn_num[AeroConfig::num_modes()],
              const Real air_density,
-             const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-             const Real specdens_amode[maxd_aspectype],
-             const Real spechygro[maxd_aspectype],
-             const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
              const Real voltonumbhi_amode[AeroConfig::num_modes()],
              const Real voltonumblo_amode[AeroConfig::num_modes()],
-             const int numptr_amode[AeroConfig::num_modes()],
-             const int nspec_amode[AeroConfig::num_modes()],
              const Real exp45logsig[AeroConfig::num_modes()],
              const Real alogsig[AeroConfig::num_modes()], Real ccn[psat]) {
 
@@ -335,10 +320,8 @@ void ccncalc(const Real state_q[aero_model::pcnst], const Real tair,
   Real vaerosol[AeroConfig::num_modes()] = {zero};
   Real hygro[AeroConfig::num_modes()] = {zero};
 
-  loadaer(state_q, AeroConfig::nspec_amode, air_density, phase, lspectype_amode,
-          AeroConfig::specdens_amode, spechygro, AeroConfig::lmassptr_amode,
-          voltonumbhi_amode, voltonumblo_amode, numptr_amode, qcldbrn,
-          qcldbrn_num, naerosol, vaerosol, hygro);
+  loadaer(state_q, air_density, phase, voltonumbhi_amode, voltonumblo_amode,
+          qcldbrn, qcldbrn_num, naerosol, vaerosol, hygro);
 
   for (int lsat = 0; lsat < psat; ++lsat) {
     ccn[lsat] = {zero};
@@ -624,23 +607,19 @@ void activate_modal(const Real w_in, const Real wmaxf, const Real tair,
 } // activate_modal
 
 KOKKOS_INLINE_FUNCTION
-void get_activate_frac(
-    const Real state_q_kload[aero_model::pcnst], const Real air_density_kload,
-    const Real air_density_kk, const Real wtke,
-    const Real tair, // in
-    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const Real specdens_amode[maxd_aspectype],
-    const Real spechygro[maxd_aspectype],
-    const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const Real voltonumbhi_amode[AeroConfig::num_modes()],
-    const Real voltonumblo_amode[AeroConfig::num_modes()],
-    const int numptr_amode[AeroConfig::num_modes()],
-    const int nspec_amode[maxd_aspectype],
-    const Real exp45logsig[AeroConfig::num_modes()],
-    const Real alogsig[AeroConfig::num_modes()], const Real aten,
-    Real fn[AeroConfig::num_modes()], Real fm[AeroConfig::num_modes()],
-    Real fluxn[AeroConfig::num_modes()], Real fluxm[AeroConfig::num_modes()],
-    Real &flux_fullact) {
+void get_activate_frac(const Real state_q_kload[aero_model::pcnst],
+                       const Real air_density_kload, const Real air_density_kk,
+                       const Real wtke,
+                       const Real tair, // in
+                       const Real voltonumbhi_amode[AeroConfig::num_modes()],
+                       const Real voltonumblo_amode[AeroConfig::num_modes()],
+                       const Real exp45logsig[AeroConfig::num_modes()],
+                       const Real alogsig[AeroConfig::num_modes()],
+                       const Real aten, Real fn[AeroConfig::num_modes()],
+                       Real fm[AeroConfig::num_modes()],
+                       Real fluxn[AeroConfig::num_modes()],
+                       Real fluxm[AeroConfig::num_modes()],
+                       Real &flux_fullact) {
 
   // input arguments
   //  @param [in] state_q_kload(:)         aerosol mmrs at level from which to
@@ -677,10 +656,8 @@ void get_activate_frac(
   Real hygro[nmodes] = {zero}; // hygroscopicity of aerosol mode [dimensionless]
 
   // load aerosol properties, assuming external mixtures
-  loadaer(state_q_kload, AeroConfig::nspec_amode, air_density_kload, phase,
-          lspectype_amode, specdens_amode, spechygro,
-          AeroConfig::lmassptr_amode, voltonumbhi_amode, voltonumblo_amode,
-          numptr_amode, qcldbrn, qcldbrn_num, naermod, vaerosol, hygro);
+  loadaer(state_q_kload, air_density_kload, phase, voltonumbhi_amode,
+          voltonumblo_amode, qcldbrn, qcldbrn_num, naermod, vaerosol, hygro);
 
   // BAD CONSTANT
   const Real wmax = 10.0;
@@ -699,18 +676,11 @@ void update_from_cldn_profile(
     const Real temp_col_in, const Real air_density, const Real air_density_kp1,
     const Real csbot_cscen,
     const Real state_q_col_in_kp1[aero_model::pcnst], // in
-    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const Real specdens_amode[maxd_aspectype],
-    const Real spechygro[maxd_aspectype],
-    const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
     const Real voltonumbhi_amode[AeroConfig::num_modes()],
     const Real voltonumblo_amode[AeroConfig::num_modes()],
-    const int numptr_amode[AeroConfig::num_modes()],
-    const int nspec_amode[maxd_aspectype],
     const Real exp45logsig[AeroConfig::num_modes()],
     const Real alogsig[AeroConfig::num_modes()], const Real aten,
-    const int mam_idx[AeroConfig::num_modes()][nspec_max], View1D raercol_nsav,
-    View1D raercol_nsav_kp1, View1D raercol_cw_nsav,
+    View1D raercol_nsav, View1D raercol_nsav_kp1, View1D raercol_cw_nsav,
     Real &nsource_col, // inout
     Real &qcld, Real factnum_col[AeroConfig::num_modes()],
     Real &eddy_diff, // out
@@ -784,14 +754,12 @@ void update_from_cldn_profile(
       Real fluxn[ntot_amode] = {};
       Real flux_fullact = zero;
       // flux of activated aerosol fraction assuming 100% activation [m/s]
-      get_activate_frac(
-          state_q_col_in_kp1, air_density_kp1, air_density, wtke_col_in,
-          temp_col_in, // in
-          lspectype_amode, specdens_amode, spechygro,
-          AeroConfig::lmassptr_amode, voltonumbhi_amode, voltonumblo_amode,
-          numptr_amode, AeroConfig::nspec_amode, exp45logsig, alogsig, aten,
-          factnum_col, fm, fluxn, fluxm, // out
-          flux_fullact);
+      get_activate_frac(state_q_col_in_kp1, air_density_kp1, air_density,
+                        wtke_col_in,
+                        temp_col_in, // in
+                        voltonumbhi_amode, voltonumblo_amode, exp45logsig,
+                        alogsig, aten, factnum_col, fm, fluxn, fluxm, // out
+                        flux_fullact);
 
       //  store for output activation fraction of aerosol
       // factnum_col(kk,:) = fn
@@ -840,7 +808,7 @@ void update_from_cldn_profile(
       for (int imode = 0; imode < ntot_amode; ++imode) {
         // local array index for MAM number, species
         // Fortran indexing to C++ indexing
-        const int mm = AeroConfig::mam_idx[imode][0] - 1;
+        const int mm = AeroConfig::mam_idx(imode, 0) - 1;
         nact[imode] += fluxn[imode] * crdz * delz_cld;
         mact[imode] += fluxm[imode] * crdz * delz_cld;
         // note that kp1 is used here
@@ -865,12 +833,12 @@ void update_from_cldn_profile(
     for (int imode = 0; imode < ntot_amode; ++imode) {
       // local array index for MAM number, species
       // Fortran indexing to C++ indexing
-      int mm = AeroConfig::mam_idx[imode][0] - 1;
+      int mm = AeroConfig::mam_idx(imode, 0) - 1;
       raercol_nsav[mm] += raercol_cw_nsav[mm]; // cloud-borne aerosol
       raercol_cw_nsav[mm] = zero;
 
-      for (int lspec = 1; lspec < AeroConfig::nspec_amode[imode] + 1; ++lspec) {
-        mm = AeroConfig::mam_idx[imode][lspec] - 1;
+      for (int lspec = 1; lspec < AeroConfig::nspec_amode(imode) + 1; ++lspec) {
+        mm = AeroConfig::mam_idx(imode, lspec) - 1;
         raercol_nsav[mm] += raercol_cw_nsav[mm]; // cloud-borne aerosol
         raercol_cw_nsav[mm] = zero;
       }
@@ -880,25 +848,19 @@ void update_from_cldn_profile(
 } // end update_from_cldn_profile
 
 KOKKOS_INLINE_FUNCTION
-void update_from_newcld(
-    const Real cldn_col_in, const Real cldo_col_in,
-    const Real dtinv, // in
-    const Real wtke_col_in, const Real temp_col_in, const Real air_density,
-    const Real state_q_col_in[aero_model::pcnst], // in
-    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const Real specdens_amode[maxd_aspectype],
-    const Real spechygro[maxd_aspectype],
-    const int lmassptr_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const Real voltonumbhi_amode[AeroConfig::num_modes()],
-    const Real voltonumblo_amode[AeroConfig::num_modes()],
-    const int numptr_amode[AeroConfig::num_modes()],
-    const int nspec_amode[maxd_aspectype],
-    const Real exp45logsig[AeroConfig::num_modes()],
-    const Real alogsig[AeroConfig::num_modes()], const Real aten,
-    const int mam_idx[AeroConfig::num_modes()][nspec_max], Real &qcld,
-    View1D raercol_nsav,
-    View1D raercol_cw_nsav, // inout
-    Real &nsource_col_out, Real factnum_col_out[AeroConfig::num_modes()]) {
+void update_from_newcld(const Real cldn_col_in, const Real cldo_col_in,
+                        const Real dtinv, // in
+                        const Real wtke_col_in, const Real temp_col_in,
+                        const Real air_density,
+                        const Real state_q_col_in[aero_model::pcnst], // in
+                        const Real voltonumbhi_amode[AeroConfig::num_modes()],
+                        const Real voltonumblo_amode[AeroConfig::num_modes()],
+                        const Real exp45logsig[AeroConfig::num_modes()],
+                        const Real alogsig[AeroConfig::num_modes()],
+                        const Real aten, Real &qcld, View1D raercol_nsav,
+                        View1D raercol_cw_nsav, // inout
+                        Real &nsource_col_out,
+                        Real factnum_col_out[AeroConfig::num_modes()]) {
 
   // input arguments
   // real(r8), intent(in) :: cldn_col_in       cloud fraction [fraction]
@@ -947,14 +909,14 @@ void update_from_newcld(
 
     for (int imode = 0; imode < ntot_amode; ++imode) {
       // Fortran indexing to C++ indexing
-      const int mm = AeroConfig::mam_idx[imode][0] - 1;
+      const int mm = AeroConfig::mam_idx(imode, 0) - 1;
       // cloud-borne aerosol tendency due to cloud frac tendency [#/kg or kg/kg]
       const Real dact = raercol_cw_nsav[mm] * frac_delt_cld;
       raercol_cw_nsav[mm] += dact; // cloud-borne aerosol
       raercol_nsav[mm] -= dact;
-      for (int lspec = 1; lspec < AeroConfig::nspec_amode[imode] + 1; ++lspec) {
+      for (int lspec = 1; lspec < AeroConfig::nspec_amode(imode) + 1; ++lspec) {
         // Fortran indexing to C++ indexing
-        const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
+        const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
         const Real dact = raercol_cw_nsav[mm] * frac_delt_cld;
         raercol_cw_nsav[mm] += dact; // cloud-borne aerosol
         raercol_nsav[mm] -= dact;
@@ -978,17 +940,15 @@ void update_from_newcld(
 
     get_activate_frac(state_q_col_in, air_density, air_density, wtke_col_in,
                       temp_col_in, // in
-                      lspectype_amode, specdens_amode, spechygro,
-                      lmassptr_amode, voltonumbhi_amode, voltonumblo_amode,
-                      numptr_amode, AeroConfig::nspec_amode, exp45logsig,
+                      voltonumbhi_amode, voltonumblo_amode, exp45logsig,
                       alogsig, aten, factnum_col_out, fm, fluxn, fluxm, // out
                       flux_fullact);
 
     for (int imode = 0; imode < ntot_amode; ++imode) {
       // Fortran indexing to C++ indexing
-      const int mm = AeroConfig::mam_idx[imode][0] - 1;
+      const int mm = AeroConfig::mam_idx(imode, 0) - 1;
       // Fortran indexing to C++ indexing
-      const int num_idx = AeroConfig::numptr_amode[imode] - 1;
+      const int num_idx = AeroConfig::numptr_amode(imode) - 1;
       const Real dact = delt_cld * factnum_col_out[imode] *
                         state_q_col_in[num_idx]; // interstitial only
       qcld += dact;
@@ -998,11 +958,11 @@ void update_from_newcld(
       // fm change from fractional change in cloud fraction [fraction]
       const Real fm_delt_cld = delt_cld * fm[imode];
 
-      for (int lspec = 1; lspec < AeroConfig::nspec_amode[imode] + 1; ++lspec) {
+      for (int lspec = 1; lspec < AeroConfig::nspec_amode(imode) + 1; ++lspec) {
         // Fortran indexing to C++ indexing
-        const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
+        const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
         // Fortran indexing to C++ indexing
-        const int spc_idx = lmassptr_amode[lspec - 1][imode] - 1;
+        const int spc_idx = AeroConfig::lmassptr_amode(lspec - 1, imode) - 1;
         // interstitial only
         const Real dact = fm_delt_cld * state_q_col_in[spc_idx];
         raercol_cw_nsav[mm] += dact; //  cloud-borne aerosol
@@ -1108,8 +1068,7 @@ void update_from_explmix(
     const View3D raercol_cw,
     int &nsav, // indices for old, new time levels in substepping
     int &nnew, // indices for old, new time levels in substepping
-    const int nspec_amode[AeroConfig::num_modes()],
-    const int mam_idx[AeroConfig::num_modes()][nspec_max], const int top_lev,
+    const int top_lev,
     // work vars
     const ColumnView &overlapp, // cloud overlap involving level kk+1 [fraction]
     const ColumnView &overlapm, // cloud overlap involving level kk-1 [fraction]
@@ -1237,7 +1196,7 @@ void update_from_explmix(
           //         srcn(:)=srcn(:)+nact(:,m)*(raercol(:,mm,nsav))
           Real srcn = zero;
           for (int imode = 0; imode < ntot_amode; imode++) {
-            const int mm = AeroConfig::mam_idx[imode][0] - 1;
+            const int mm = AeroConfig::mam_idx(imode, 0) - 1;
             srcn += nact(k, imode) * raercol_kp1_nsav(mm);
             if (k == pver_loc - 1) {
               // rce-comment- new formulation for k=pver
@@ -1263,9 +1222,9 @@ void update_from_explmix(
               explmix(qncld(km1), qncld(k), qncld(kp1), srcn, eddy_diff_kp(k),
                       eddy_diff_km(k), overlapp(k), overlapm(k), dtmix);
           for (int imode = 0; imode < ntot_amode; imode++) {
-            for (int lspec = 0; lspec < AeroConfig::nspec_amode[imode] + 1;
+            for (int lspec = 0; lspec < AeroConfig::nspec_amode(imode) + 1;
                  lspec++) {
-              const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
+              const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
               Real source = 0;
               if (k < pver_loc - 1) {
                 const Real act = lspec ? mact(k, imode) : nact(k, imode);
@@ -1300,13 +1259,13 @@ void update_from_explmix(
 
           // convert activated aerosol to interstitial in decaying cloud
           for (int imode = 0; imode < ntot_amode; imode++) {
-            const int mm = AeroConfig::mam_idx[imode][0] - 1;
+            const int mm = AeroConfig::mam_idx(imode, 0) - 1;
             raercol(k, nnew, mm) += raercol_cw(k, nnew, mm);
             raercol_cw(k, nnew, mm) = zero;
 
-            for (int lspec = 1; lspec < AeroConfig::nspec_amode[imode] + 1;
+            for (int lspec = 1; lspec < AeroConfig::nspec_amode(imode) + 1;
                  lspec++) {
-              const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
+              const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
               raercol(k, nnew, mm) += raercol_cw(k, nnew, mm);
               raercol_cw(k, nnew, mm) = zero;
             } // lspec
@@ -1458,20 +1417,20 @@ void dropmixnuc(
       Kokkos::TeamVectorRange(team, top_lev, pver_loc), [&](int k) {
         for (int imode = 0; imode < ntot_amode; ++imode) {
           // Fortran indexing to C++ indexing
-          const int mm = AeroConfig::mam_idx[imode][0] - 1;
+          const int mm = AeroConfig::mam_idx(imode, 0) - 1;
           raercol_cw(k, nsav, mm) = qqcw_fld(mm, k);
           // Fortran indexing to C++ indexing
-          const int num_idx = AeroConfig::numptr_amode[imode] - 1;
+          const int num_idx = AeroConfig::numptr_amode(imode) - 1;
           raercol(k, nsav, mm) = state_q(k, num_idx);
-          for (int lspec = 1; lspec < AeroConfig::nspec_amode[imode] + 1;
+          for (int lspec = 1; lspec < AeroConfig::nspec_amode(imode) + 1;
                ++lspec) {
             // Fortran indexing to C++ indexing
-            const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
+            const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
 
             raercol_cw(k, nsav, mm) = qqcw_fld(mm, k);
             // Fortran indexing to C++ indexing
             const int spc_idx =
-                AeroConfig::lmassptr_amode[lspec - 1][imode] - 1;
+                AeroConfig::lmassptr_amode(lspec - 1, imode) - 1;
             raercol(k, nsav, mm) = state_q(k, spc_idx);
           } // lspec
         }   // imode
@@ -1492,12 +1451,8 @@ void dropmixnuc(
                            wtke(k), temp(k),
                            conversions::density_of_ideal_gas(temp(k), pmid(k)),
                            state_q_k.data(), // in
-                           AeroConfig::lspectype_amode,
-                           AeroConfig::specdens_amode, AeroConfig::spechygro,
-                           AeroConfig::lmassptr_amode, voltonumbhi_amode,
-                           voltonumblo_amode, AeroConfig::numptr_amode,
-                           AeroConfig::nspec_amode, exp45logsig, alogsig, aten,
-                           AeroConfig::mam_idx, qcld(k),
+                           voltonumbhi_amode, voltonumblo_amode, exp45logsig,
+                           alogsig, aten, qcld(k),
                            ekat::subview(raercol, k, nsav),    // inout
                            ekat::subview(raercol_cw, k, nsav), // inout
                            nsource(k), factnum_k);             // inout
@@ -1527,12 +1482,8 @@ void dropmixnuc(
             conversions::density_of_ideal_gas(temp(kp1), pmid(kp1)),
             csbot_cscen(k),
             state_q_kp1.data(), // in
-            AeroConfig::lspectype_amode, AeroConfig::specdens_amode,
-            AeroConfig::spechygro, AeroConfig::lmassptr_amode,
-            voltonumbhi_amode, voltonumblo_amode, AeroConfig::numptr_amode,
-            AeroConfig::nspec_amode, exp45logsig, alogsig, aten,
-            AeroConfig::mam_idx, ekat::subview(raercol, k, nsav),
-            ekat::subview(raercol, kp1, nsav),
+            voltonumbhi_amode, voltonumblo_amode, exp45logsig, alogsig, aten,
+            ekat::subview(raercol, k, nsav), ekat::subview(raercol, kp1, nsav),
             ekat::subview(raercol_cw, k, nsav),
             nsource(k), // inout
             qcld(k), factnum_k,
@@ -1548,8 +1499,7 @@ void dropmixnuc(
 
   int nnew = 1;
   update_from_explmix(team, dtmicro, csbot, cldn, zn, zs, eddy_diff, nact, mact,
-                      qcld, raercol, raercol_cw, nsav, nnew,
-                      AeroConfig::nspec_amode, AeroConfig::mam_idx, top_lev,
+                      qcld, raercol, raercol_cw, nsav, nnew, top_lev,
                       // work vars
                       overlapp, overlapm, eddy_diff_kp, eddy_diff_km, qncld);
 
@@ -1584,27 +1534,27 @@ void dropmixnuc(
 
         for (int imode = 0; imode < ntot_amode; ++imode) {
           // species index for given mode
-          for (int lspec = 0; lspec < AeroConfig::nspec_amode[imode] + 1;
+          for (int lspec = 0; lspec < AeroConfig::nspec_amode(imode) + 1;
                ++lspec) {
             // local array index for MAM number, species
             // Fortran indexing to C++ indexing
-            const int mm = AeroConfig::mam_idx[imode][lspec] - 1;
+            const int mm = AeroConfig::mam_idx(imode, lspec) - 1;
             // Fortran indexing to C++ indexing
-            const int lptr = AeroConfig::mam_cnst_idx[imode][lspec] - 1;
+            const int lptr = AeroConfig::mam_cnst_idx(imode, lspec) - 1;
             qqcwtend(k) = (raercol_cw(k, nnew, mm) - qqcw_fld(mm, k)) * dtinv;
             qqcw_fld(mm, k) = mam4::max(raercol_cw(k, nnew, mm),
                                         zero); // update cloud-borne aerosol
 
             if (lspec == 0) {
               // Fortran indexing to C++ indexing
-              const int num_idx = AeroConfig::numptr_amode[imode] - 1;
+              const int num_idx = AeroConfig::numptr_amode(imode) - 1;
               raertend(k) =
                   (raercol(k, nnew, mm) - state_q(k, num_idx)) * dtinv;
               qcldbrn_num[imode] = qqcw_fld(mm, k);
             } else {
               // Fortran indexing to C++ indexing
               const int spc_idx =
-                  AeroConfig::lmassptr_amode[lspec - 1][imode] - 1;
+                  AeroConfig::lmassptr_amode(lspec - 1, imode) - 1;
               raertend(k) =
                   (raercol(k, nnew, mm) - state_q(k, spc_idx)) * dtinv;
               // Extract cloud borne MMRs from qqcw pointer
@@ -1627,10 +1577,8 @@ void dropmixnuc(
         // ccn fields.
         ccncalc(state_q_k.data(), temp(k), qcldbrn, qcldbrn_num,
                 conversions::density_of_ideal_gas(temp(k), pmid(k)),
-                AeroConfig::lspectype_amode, AeroConfig::specdens_amode,
-                AeroConfig::spechygro, AeroConfig::lmassptr_amode,
-                voltonumbhi_amode, voltonumblo_amode, AeroConfig::numptr_amode,
-                AeroConfig::nspec_amode, exp45logsig, alogsig, ccn_k.data());
+                voltonumbhi_amode, voltonumblo_amode, exp45logsig, alogsig,
+                ccn_k.data());
       }); // end parfor(k)
   team.team_barrier();
 } // dropmixnuc

--- a/src/mam4xx/water_uptake.hpp
+++ b/src/mam4xx/water_uptake.hpp
@@ -334,14 +334,14 @@ KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dryaer(
     rhdeliques[imode] = modes(imode).deliquescence_pt;
     const int nspec = AeroConfig::nspec_amode(imode);
     int type_idx =
-        AeroConfig::lspectype_amode(0, imode) - 1; // Fortran to C++ indexing
+        AeroConfig::lspectype_amode(0, imode); // Fortran to C++ indexing
     specdens_1[imode] = AeroConfig::specdens_amode(type_idx);
     const Real spechygro_1 = AeroConfig::spechygro(type_idx);
 
     const Real alnsg = mam4::log(sigmag);
 
     for (int ispec = 0; ispec < nspec; ++ispec) {
-      type_idx = AeroConfig::lspectype_amode(ispec, imode) - 1;
+      type_idx = AeroConfig::lspectype_amode(ispec, imode);
       const Real spechygro_i = AeroConfig::spechygro(type_idx);
       const Real specdens = AeroConfig::specdens_amode(type_idx);
 

--- a/src/mam4xx/water_uptake.hpp
+++ b/src/mam4xx/water_uptake.hpp
@@ -315,10 +315,6 @@ void modal_aero_water_uptake_rh_clearair(const Real temperature,
 
 template <typename VectorType>
 KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dryaer(
-    const int nspec_amode[AeroConfig::num_modes()],
-    const Real specdens_amode[maxd_aspectype],
-    const Real spechygro[maxd_aspectype],
-    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
     const VectorType &state_q, Real dgncur_a[AeroConfig::num_modes()],
     Real hygro[AeroConfig::num_modes()], Real naer[AeroConfig::num_modes()],
     Real dryrad[AeroConfig::num_modes()], Real dryvol[AeroConfig::num_modes()],
@@ -336,17 +332,18 @@ KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dryaer(
     const Real sigmag = modes(imode).mean_std_dev;
     rhcrystal[imode] = modes(imode).crystallization_pt;
     rhdeliques[imode] = modes(imode).deliquescence_pt;
-    const int nspec = nspec_amode[imode];
-    int type_idx = lspectype_amode[0][imode] - 1; // Fortran to C++ indexing
-    specdens_1[imode] = specdens_amode[type_idx];
-    const Real spechygro_1 = spechygro[type_idx];
+    const int nspec = AeroConfig::nspec_amode(imode);
+    int type_idx =
+        AeroConfig::lspectype_amode(0, imode) - 1; // Fortran to C++ indexing
+    specdens_1[imode] = AeroConfig::specdens_amode(type_idx);
+    const Real spechygro_1 = AeroConfig::spechygro(type_idx);
 
     const Real alnsg = mam4::log(sigmag);
 
     for (int ispec = 0; ispec < nspec; ++ispec) {
-      type_idx = lspectype_amode[ispec][imode] - 1;
-      const Real spechygro_i = spechygro[type_idx];
-      const Real specdens = specdens_amode[type_idx];
+      type_idx = AeroConfig::lspectype_amode(ispec, imode) - 1;
+      const Real spechygro_i = AeroConfig::spechygro(type_idx);
+      const Real specdens = AeroConfig::specdens_amode(type_idx);
 
       int la, lc;
       convproc::assign_la_lc(imode, ispec, la, lc);
@@ -392,10 +389,6 @@ KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dryaer(
 }
 template <typename VectorType>
 KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dr_b4_wetdens(
-    const int nspec_amode[AeroConfig::num_modes()],
-    const Real specdens_amode[maxd_aspectype],
-    const Real spechygro[maxd_aspectype],
-    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
     const VectorType &state_q, Real temperature, Real pmid, Real cldn,
     Real dgncur_a[AeroConfig::num_modes()],
     Real dgncur_awet[AeroConfig::num_modes()],
@@ -413,10 +406,8 @@ KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dr_b4_wetdens(
   Real rhcrystal[AeroConfig::num_modes()];
   Real rhdeliques[AeroConfig::num_modes()];
 
-  modal_aero_water_uptake_dryaer(nspec_amode, specdens_amode, spechygro,
-                                 lspectype_amode, state_q, dgncur_a, hygro,
-                                 naer, dryrad, dryvol, drymass, rhcrystal,
-                                 rhdeliques, specdens_1);
+  modal_aero_water_uptake_dryaer(state_q, dgncur_a, hygro, naer, dryrad, dryvol,
+                                 drymass, rhcrystal, rhdeliques, specdens_1);
 
   // ----------------------------------------------------------------------------
   // estimate clear air relative humidity using cloud fraction
@@ -433,16 +424,13 @@ KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dr_b4_wetdens(
                                  dgncur_awet, qaerwat);
 }
 template <typename VectorType>
-KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dr(
-    const int nspec_amode[AeroConfig::num_modes()],
-    const Real specdens_amode[maxd_aspectype],
-    const Real spechygro[maxd_aspectype],
-    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const VectorType &state_q, Real temperature, Real pmid, Real cldn,
-    Real dgncur_a[AeroConfig::num_modes()],
-    Real dgncur_awet[AeroConfig::num_modes()],
-    Real qaerwat[AeroConfig::num_modes()],
-    Real wetdens[AeroConfig::num_modes()]) {
+KOKKOS_INLINE_FUNCTION void
+modal_aero_water_uptake_dr(const VectorType &state_q, Real temperature,
+                           Real pmid, Real cldn,
+                           Real dgncur_a[AeroConfig::num_modes()],
+                           Real dgncur_awet[AeroConfig::num_modes()],
+                           Real qaerwat[AeroConfig::num_modes()],
+                           Real wetdens[AeroConfig::num_modes()]) {
 
   // This function is a port modal_aero_wateruptake_dr
   // with the optional computation of the wetdensity.
@@ -452,24 +440,20 @@ KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dr(
   Real wetvol[AeroConfig::num_modes()];
   Real wtrvol[AeroConfig::num_modes()];
 
-  modal_aero_water_uptake_dr_b4_wetdens(
-      nspec_amode, specdens_amode, spechygro, lspectype_amode, state_q,
-      temperature, pmid, cldn, dgncur_a, dgncur_awet, qaerwat, wetvol, wtrvol,
-      drymass, specdens_1);
+  modal_aero_water_uptake_dr_b4_wetdens(state_q, temperature, pmid, cldn,
+                                        dgncur_a, dgncur_awet, qaerwat, wetvol,
+                                        wtrvol, drymass, specdens_1);
 
   // compute wet aerosol density
   modal_aero_water_uptake_wetdens(wetvol, wtrvol, drymass, specdens_1, wetdens);
 }
 template <typename VectorType>
-KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dr(
-    const int nspec_amode[AeroConfig::num_modes()],
-    const Real specdens_amode[maxd_aspectype],
-    const Real spechygro[maxd_aspectype],
-    const int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    const VectorType &state_q, Real temperature, Real pmid, Real cldn,
-    Real dgncur_a[AeroConfig::num_modes()],
-    Real dgncur_awet[AeroConfig::num_modes()],
-    Real qaerwat[AeroConfig::num_modes()]) {
+KOKKOS_INLINE_FUNCTION void
+modal_aero_water_uptake_dr(const VectorType &state_q, Real temperature,
+                           Real pmid, Real cldn,
+                           Real dgncur_a[AeroConfig::num_modes()],
+                           Real dgncur_awet[AeroConfig::num_modes()],
+                           Real qaerwat[AeroConfig::num_modes()]) {
 
   // This function is a port modal_aero_wateruptake_dr
   // without the computation of the wetdensity.
@@ -479,10 +463,9 @@ KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dr(
   Real wetvol[AeroConfig::num_modes()];
   Real wtrvol[AeroConfig::num_modes()];
 
-  modal_aero_water_uptake_dr_b4_wetdens(
-      nspec_amode, specdens_amode, spechygro, lspectype_amode, state_q,
-      temperature, pmid, cldn, dgncur_a, dgncur_awet, qaerwat, wetvol, wtrvol,
-      drymass, specdens_1);
+  modal_aero_water_uptake_dr_b4_wetdens(state_q, temperature, pmid, cldn,
+                                        dgncur_a, dgncur_awet, qaerwat, wetvol,
+                                        wtrvol, drymass, specdens_1);
 }
 
 }; // namespace water_uptake

--- a/src/mam4xx/water_uptake.hpp
+++ b/src/mam4xx/water_uptake.hpp
@@ -313,51 +313,6 @@ void modal_aero_water_uptake_rh_clearair(const Real temperature,
   rh = mam4::max(rh, 0.0);
 }
 
-KOKKOS_INLINE_FUNCTION
-void get_e3sm_parameters(
-    int nspec_amode[AeroConfig::num_modes()],
-    int lspectype_amode[maxd_aspectype][AeroConfig::num_modes()],
-    Real specdens_amode[maxd_aspectype], Real spechygro[maxd_aspectype]) {
-
-  const int ntot_amode = AeroConfig::num_modes();
-  int nspec_amode_temp[ntot_amode] = {7, 4, 7, 3};
-
-  for (int i = 0; i < ntot_amode; ++i) {
-    nspec_amode[i] = nspec_amode_temp[i];
-  }
-
-  Real specdens_amode_temp[maxd_aspectype] = {
-      0.1770000000E+04, 0.1797693135 + 309, 0.1797693135 + 309,
-      0.1000000000E+04, 0.1000000000E+04,   0.1700000000E+04,
-      0.1900000000E+04, 0.2600000000E+04,   0.1601000000E+04,
-      0.0000000000E+00, 0.0000000000E+00,   0.0000000000E+00,
-      0.0000000000E+00, 0.0000000000E+00};
-  Real spechygro_temp[maxd_aspectype] = {
-      0.5070000000E+00, 0.1797693135 + 309, 0.1797693135 + 309,
-      0.1000000083E-09, 0.1400000000E+00,   0.1000000013E-09,
-      0.1160000000E+01, 0.6800000000E-01,   0.1000000015E+00,
-      0.0000000000E+00, 0.0000000000E+00,   0.0000000000E+00,
-      0.0000000000E+00, 0.0000000000E+00};
-
-  for (int i = 0; i < maxd_aspectype; ++i) {
-    specdens_amode[i] = specdens_amode_temp[i];
-    spechygro[i] = spechygro_temp[i];
-  }
-
-  const int lspectype_amode_1d[ntot_amode * maxd_aspectype] = {
-      1, 4, 5, 6, 8, 7, 9, 0, 0, 0, 0, 0, 0, 0, 1, 5, 7, 9, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 7, 1, 6, 4, 5, 9, 0, 0, 0,
-      0, 0, 0, 0, 4, 6, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-
-  int count = 0;
-  for (int i = 0; i < ntot_amode; ++i) {
-    for (int j = 0; j < maxd_aspectype; ++j) {
-      lspectype_amode[j][i] = lspectype_amode_1d[count];
-      count++;
-    }
-  }
-}
-
 template <typename VectorType>
 KOKKOS_INLINE_FUNCTION void modal_aero_water_uptake_dryaer(
     const int nspec_amode[AeroConfig::num_modes()],

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -2083,9 +2083,9 @@ void aero_model_wetdep(
 
       mam4::water_uptake::modal_aero_water_uptake_dr(
           // inputs
-          calcsizedata.nspec_amode, calcsizedata.specdens_amode,
-          calcsizedata.spechygro, calcsizedata.lspectype_amode,
-          state_q_kk.data(), temperature(kk), pmid(kk), cldt(kk), dgnumdry_m_kk,
+          AeroConfig::nspec_amode, AeroConfig::specdens_amode,
+          AeroConfig::spechygro, AeroConfig::lspectype_amode, state_q_kk.data(),
+          temperature(kk), pmid(kk), cldt(kk), dgnumdry_m_kk,
           // outputs
           dgnumwet_m_kk, qaerwat_m_kk, wetdens_kk);
     }

--- a/src/mam4xx/wet_dep.hpp
+++ b/src/mam4xx/wet_dep.hpp
@@ -2083,9 +2083,7 @@ void aero_model_wetdep(
 
       mam4::water_uptake::modal_aero_water_uptake_dr(
           // inputs
-          AeroConfig::nspec_amode, AeroConfig::specdens_amode,
-          AeroConfig::spechygro, AeroConfig::lspectype_amode, state_q_kk.data(),
-          temperature(kk), pmid(kk), cldt(kk), dgnumdry_m_kk,
+          state_q_kk.data(), temperature(kk), pmid(kk), cldt(kk), dgnumdry_m_kk,
           // outputs
           dgnumwet_m_kk, qaerwat_m_kk, wetdens_kk);
     }

--- a/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
+++ b/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
@@ -104,12 +104,9 @@ void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
                     Kokkos::subview(wetdens, kk, Kokkos::ALL());
 
                 mam4::water_uptake::modal_aero_water_uptake_dr(
-                    mam4::AeroConfig::nspec_amode,
-                    mam4::AeroConfig::specdens_amode,
-                    mam4::AeroConfig::spechygro,
-                    mam4::AeroConfig::lspectype_amode, state_q_k,
-                    temperature(kk), pmid(kk), cldn(kk), dgncur_i.data(),
-                    dgnumwet_kk.data(), qaerwat_kk.data(), wetdens_kk.data());
+                    state_q_k, temperature(kk), pmid(kk), cldn(kk),
+                    dgncur_i.data(), dgnumwet_kk.data(), qaerwat_kk.data(),
+                    wetdens_kk.data());
 
                 if (update_mmr) {
                   // Note: it only needs to update aerosol variables.

--- a/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
+++ b/src/validation/aero_model/aero_model_calcsize_water_uptake_dr.cpp
@@ -104,8 +104,10 @@ void aero_model_calcsize_water_uptake_dr(Ensemble *ensemble) {
                     Kokkos::subview(wetdens, kk, Kokkos::ALL());
 
                 mam4::water_uptake::modal_aero_water_uptake_dr(
-                    cal_data.nspec_amode, cal_data.specdens_amode,
-                    cal_data.spechygro, cal_data.lspectype_amode, state_q_k,
+                    mam4::AeroConfig::nspec_amode,
+                    mam4::AeroConfig::specdens_amode,
+                    mam4::AeroConfig::spechygro,
+                    mam4::AeroConfig::lspectype_amode, state_q_k,
                     temperature(kk), pmid(kk), cldn(kk), dgncur_i.data(),
                     dgnumwet_kk.data(), qaerwat_kk.data(), wetdens_kk.data());
 

--- a/src/validation/hetfrz/hetfrz_calculate_hetfrz_immersion_nucleation.cpp
+++ b/src/validation/hetfrz/hetfrz_calculate_hetfrz_immersion_nucleation.cpp
@@ -60,12 +60,6 @@ void calculate_hetfrz_immersion_nucleation(Ensemble *ensemble) {
       exit(1);
     }
 
-    if (!input.has("eswtr")) {
-      std::cerr << "Required name: "
-                << "eswtr" << std::endl;
-      exit(1);
-    }
-
     if (!input.has("vwice")) {
       std::cerr << "Required name: "
                 << "vwice" << std::endl;
@@ -136,7 +130,6 @@ void calculate_hetfrz_immersion_nucleation(Ensemble *ensemble) {
     auto dim_theta = input.get_array("dim_theta");
     auto pdf_imm_theta = input.get_array("pdf_imm_theta");
     auto sigma_iw = input.get("sigma_iw");
-    auto eswtr = input.get("eswtr");
     auto vwice = input.get("vwice");
     auto r_bc = input.get("r_bc");
     auto r_dust_a1 = input.get("r_dust_a1");

--- a/src/validation/ndrop/ccncalc.cpp
+++ b/src/validation/ndrop/ccncalc.cpp
@@ -68,19 +68,6 @@ void ccncalc(Ensemble *ensemble) {
           const Real air_density =
               mam4::conversions::density_of_ideal_gas(tair(kk), pmid(kk));
 
-          int nspec_amode[ntot_amode];
-          int lspectype_amode[maxd_aspectype][ntot_amode];
-          int lmassptr_amode[maxd_aspectype][ntot_amode];
-          Real specdens_amode[maxd_aspectype];
-          Real spechygro[maxd_aspectype];
-          int numptr_amode[ntot_amode];
-          int mam_idx[ntot_amode][nspec_max];
-          int mam_cnst_idx[ntot_amode][nspec_max];
-
-          mam4::ndrop::get_e3sm_parameters(
-              nspec_amode, lspectype_amode, lmassptr_amode, numptr_amode,
-              specdens_amode, spechygro, mam_idx, mam_cnst_idx);
-
           Real exp45logsig[mam4::AeroConfig::num_modes()],
               alogsig[mam4::AeroConfig::num_modes()],
               num2vol_ratio_min_nmodes[mam4::AeroConfig::num_modes()],
@@ -96,9 +83,12 @@ void ccncalc(Ensemble *ensemble) {
           const auto ccn_k = Kokkos::subview(ccn, kk, Kokkos::ALL());
           mam4::ndrop::ccncalc(
               state_q_k.data(), tair(kk), qcldbrn, qcldbrn_num, air_density,
-              lspectype_amode, specdens_amode, spechygro, lmassptr_amode,
-              num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes, numptr_amode,
-              nspec_amode, exp45logsig, alogsig, ccn_k.data());
+              mam4::AeroConfig::lspectype_amode,
+              mam4::AeroConfig::specdens_amode, mam4::AeroConfig::spechygro,
+              mam4::AeroConfig::lmassptr_amode, num2vol_ratio_min_nmodes,
+              num2vol_ratio_max_nmodes, mam4::AeroConfig::numptr_amode,
+              mam4::AeroConfig::nspec_amode, exp45logsig, alogsig,
+              ccn_k.data());
         });
 
     auto ccn_host = Kokkos::create_mirror_view(ccn);

--- a/src/validation/ndrop/ccncalc.cpp
+++ b/src/validation/ndrop/ccncalc.cpp
@@ -26,8 +26,6 @@ void ccncalc(Ensemble *ensemble) {
 
     const int top_lev = 6;
 
-    const int nspec_max = mam4::ndrop::nspec_max;
-
     using View2D = mam4::ndrop::View2D;
     using View1DHost = typename mam4::HostType::view_1d<Real>;
 
@@ -81,14 +79,10 @@ void ccncalc(Ensemble *ensemble) {
               num2vol_ratio_max_nmodes); // voltonumblo_amode
 
           const auto ccn_k = Kokkos::subview(ccn, kk, Kokkos::ALL());
-          mam4::ndrop::ccncalc(
-              state_q_k.data(), tair(kk), qcldbrn, qcldbrn_num, air_density,
-              mam4::AeroConfig::lspectype_amode,
-              mam4::AeroConfig::specdens_amode, mam4::AeroConfig::spechygro,
-              mam4::AeroConfig::lmassptr_amode, num2vol_ratio_min_nmodes,
-              num2vol_ratio_max_nmodes, mam4::AeroConfig::numptr_amode,
-              mam4::AeroConfig::nspec_amode, exp45logsig, alogsig,
-              ccn_k.data());
+          mam4::ndrop::ccncalc(state_q_k.data(), tair(kk), qcldbrn, qcldbrn_num,
+                               air_density, num2vol_ratio_min_nmodes,
+                               num2vol_ratio_max_nmodes, exp45logsig, alogsig,
+                               ccn_k.data());
         });
 
     auto ccn_host = Kokkos::create_mirror_view(ccn);

--- a/src/validation/ndrop/ccncalc_single_cell.cpp
+++ b/src/validation/ndrop/ccncalc_single_cell.cpp
@@ -43,12 +43,6 @@ void ccncalc_single_cell(Ensemble *ensemble) {
     }
     const Real air_density = input.get_array("cs")[0];
 
-    const auto specdens_amode_db = input.get_array("specdens_amode");
-    const auto spechygro_db = input.get_array("spechygro");
-
-    const auto specdens_amode = specdens_amode_db.data();
-    const auto spechygro = spechygro_db.data();
-
     const auto numptr_amode_db = input.get_array("numptr_amode");
     const auto nspec_amode_db = input.get_array("nspec_amode");
 
@@ -71,10 +65,9 @@ void ccncalc_single_cell(Ensemble *ensemble) {
     }
     std::vector<Real> ccn(psat, zero);
     mam4::ndrop::ccncalc(state_q.data(), tair, qcldbrn, qcldbrn_num.data(),
-                         air_density, lspectype_amode, specdens_amode,
-                         spechygro, lmassptr_amode, num2vol_ratio_min_nmodes,
-                         num2vol_ratio_max_nmodes, numptr_amode, nspec_amode,
-                         exp45logsig, alogsig, ccn.data());
+                         air_density, num2vol_ratio_min_nmodes,
+                         num2vol_ratio_max_nmodes, exp45logsig, alogsig,
+                         ccn.data());
 
     output.set("ccn", ccn);
   });

--- a/src/validation/ndrop/dropmixnuc.cpp
+++ b/src/validation/ndrop/dropmixnuc.cpp
@@ -11,12 +11,10 @@ using namespace skywalker;
 void dropmixnuc(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
     const Real zero = 0;
-    const int maxd_aspectype = mam4::ndrop::maxd_aspectype;
     const int ntot_amode = mam4::AeroConfig::num_modes();
     const int pcnst = mam4::aero_model::pcnst;
     const int psat = mam4::ndrop::psat;
     const int ncnst_tot = mam4::ndrop::ncnst_tot;
-    const int nspec_max = mam4::ndrop::nspec_max;
 
     const int pver = mam4::ndrop::pver;
 

--- a/src/validation/ndrop/dropmixnuc.cpp
+++ b/src/validation/ndrop/dropmixnuc.cpp
@@ -172,19 +172,6 @@ void dropmixnuc(Ensemble *ensemble) {
     auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
-          int nspec_amode[ntot_amode];
-          int lspectype_amode[maxd_aspectype][ntot_amode];
-          int lmassptr_amode[maxd_aspectype][ntot_amode];
-          Real specdens_amode[maxd_aspectype];
-          Real spechygro[maxd_aspectype];
-          int numptr_amode[ntot_amode];
-          int mam_idx[ntot_amode][nspec_max];
-          int mam_cnst_idx[ntot_amode][nspec_max];
-
-          mam4::ndrop::get_e3sm_parameters(
-              nspec_amode, lspectype_amode, lmassptr_amode, numptr_amode,
-              specdens_amode, spechygro, mam_idx, mam_cnst_idx);
-
           Real exp45logsig[mam4::AeroConfig::num_modes()],
               alogsig[mam4::AeroConfig::num_modes()],
               num2vol_ratio_min_nmodes[mam4::AeroConfig::num_modes()],
@@ -201,10 +188,8 @@ void dropmixnuc(Ensemble *ensemble) {
               zm, //  ! in zm[kk] - zm[kk+1], for pver zm[kk-1] - zm[kk]
               state_q, ncldwtr,
               kvh, // kvh[kk+1]
-              cldn, lspectype_amode, specdens_amode, spechygro, lmassptr_amode,
-              num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes, numptr_amode,
-              nspec_amode, exp45logsig, alogsig, aten, mam_idx, mam_cnst_idx,
-              true,
+              cldn, num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes,
+              exp45logsig, alogsig, aten, true,
               qcld, //
               wsub,
               cldo, // in

--- a/src/validation/ndrop/get_activate_frac.cpp
+++ b/src/validation/ndrop/get_activate_frac.cpp
@@ -11,10 +11,8 @@ using namespace skywalker;
 void get_activate_frac(Ensemble *ensemble) {
   ensemble->process([=](const Input &input, Output &output) {
     const Real zero = 0;
-    const int maxd_aspectype = mam4::ndrop::maxd_aspectype;
     const int ntot_amode = mam4::AeroConfig::num_modes();
     const int pcnst = mam4::aero_model::pcnst;
-    const int nspec_max = mam4::ndrop::nspec_max;
 
     const int pver = mam4::ndrop::pver;
     const auto state_q_db = input.get_array("state_q");
@@ -93,13 +91,9 @@ void get_activate_frac(Ensemble *ensemble) {
           mam4::ndrop::get_activate_frac(
               state_q_k.data(), air_density, air_density, wsub(kk),
               tair(kk), // in
-              mam4::AeroConfig::lspectype_amode,
-              mam4::AeroConfig::specdens_amode, mam4::AeroConfig::spechygro,
-              mam4::AeroConfig::lmassptr_amode, num2vol_ratio_min_nmodes,
-              num2vol_ratio_max_nmodes, mam4::AeroConfig::numptr_amode,
-              mam4::AeroConfig::nspec_amode, exp45logsig, alogsig, aten_testing,
-              fn_k.data(), fm_k.data(), fluxn_k.data(), fluxm_k.data(),
-              flux_fullact(kk));
+              num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes, exp45logsig,
+              alogsig, aten_testing, fn_k.data(), fm_k.data(), fluxn_k.data(),
+              fluxm_k.data(), flux_fullact(kk));
         });
 
     auto fn_host = Kokkos::create_mirror_view(fn);

--- a/src/validation/ndrop/get_activate_frac.cpp
+++ b/src/validation/ndrop/get_activate_frac.cpp
@@ -72,19 +72,6 @@ void get_activate_frac(Ensemble *ensemble) {
           // aten from validation data only for testing proposes.
           Real aten_testing = 0.1206437615E-08;
 
-          int nspec_amode[ntot_amode];
-          int lspectype_amode[maxd_aspectype][ntot_amode];
-          int lmassptr_amode[maxd_aspectype][ntot_amode];
-          Real specdens_amode[maxd_aspectype];
-          Real spechygro[maxd_aspectype];
-          int numptr_amode[ntot_amode];
-          int mam_idx[ntot_amode][nspec_max];
-          int mam_cnst_idx[ntot_amode][nspec_max];
-
-          mam4::ndrop::get_e3sm_parameters(
-              nspec_amode, lspectype_amode, lmassptr_amode, numptr_amode,
-              specdens_amode, spechygro, mam_idx, mam_cnst_idx);
-
           Real exp45logsig[mam4::AeroConfig::num_modes()],
               alogsig[mam4::AeroConfig::num_modes()],
               num2vol_ratio_min_nmodes[mam4::AeroConfig::num_modes()],
@@ -106,10 +93,13 @@ void get_activate_frac(Ensemble *ensemble) {
           mam4::ndrop::get_activate_frac(
               state_q_k.data(), air_density, air_density, wsub(kk),
               tair(kk), // in
-              lspectype_amode, specdens_amode, spechygro, lmassptr_amode,
-              num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes, numptr_amode,
-              nspec_amode, exp45logsig, alogsig, aten_testing, fn_k.data(),
-              fm_k.data(), fluxn_k.data(), fluxm_k.data(), flux_fullact(kk));
+              mam4::AeroConfig::lspectype_amode,
+              mam4::AeroConfig::specdens_amode, mam4::AeroConfig::spechygro,
+              mam4::AeroConfig::lmassptr_amode, num2vol_ratio_min_nmodes,
+              num2vol_ratio_max_nmodes, mam4::AeroConfig::numptr_amode,
+              mam4::AeroConfig::nspec_amode, exp45logsig, alogsig, aten_testing,
+              fn_k.data(), fm_k.data(), fluxn_k.data(), fluxm_k.data(),
+              flux_fullact(kk));
         });
 
     auto fn_host = Kokkos::create_mirror_view(fn);

--- a/src/validation/ndrop/loadaer.cpp
+++ b/src/validation/ndrop/loadaer.cpp
@@ -13,7 +13,6 @@ void loadaer(Ensemble *ensemble) {
     const Real zero = 0;
     const int ntot_amode = mam4::AeroConfig::num_modes();
     const int maxd_aspectype = mam4::ndrop::maxd_aspectype;
-    const int nspec_max = mam4::ndrop::nspec_max;
 
     const auto state_q = input.get_array("state_q");
     const Real air_density = input.get_array("cs")[0];
@@ -51,13 +50,10 @@ void loadaer(Ensemble *ensemble) {
                             num2vol_ratio_min_nmodes,  // voltonumbhi_amode
                             num2vol_ratio_max_nmodes); // voltonumblo_amode
 
-    mam4::ndrop::loadaer(
-        state_q.data(), mam4::AeroConfig::nspec_amode, air_density, phase,
-        mam4::AeroConfig::lspectype_amode, mam4::AeroConfig::specdens_amode,
-        mam4::AeroConfig::spechygro, mam4::AeroConfig::lmassptr_amode,
-        num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes,
-        mam4::AeroConfig::numptr_amode, qcldbrn, qcldbrn1d_num.data(),
-        naerosol.data(), vaerosol.data(), hygro.data());
+    mam4::ndrop::loadaer(state_q.data(), air_density, phase,
+                         num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes,
+                         qcldbrn, qcldbrn1d_num.data(), naerosol.data(),
+                         vaerosol.data(), hygro.data());
 
     output.set("naerosol", naerosol);
     output.set("vaerosol", vaerosol);

--- a/src/validation/ndrop/loadaer.cpp
+++ b/src/validation/ndrop/loadaer.cpp
@@ -40,18 +40,6 @@ void loadaer(Ensemble *ensemble) {
     }
     std::vector<Real> naerosol(ntot_amode, zero), vaerosol(ntot_amode, zero),
         hygro(ntot_amode, zero);
-    int nspec_amode[ntot_amode];
-    int lspectype_amode[maxd_aspectype][ntot_amode];
-    int lmassptr_amode[maxd_aspectype][ntot_amode];
-    Real specdens_amode[maxd_aspectype];
-    Real spechygro[maxd_aspectype];
-    int numptr_amode[ntot_amode];
-    int mam_idx[ntot_amode][nspec_max];
-    int mam_cnst_idx[ntot_amode][nspec_max];
-
-    mam4::ndrop::get_e3sm_parameters(
-        nspec_amode, lspectype_amode, lmassptr_amode, numptr_amode,
-        specdens_amode, spechygro, mam_idx, mam_cnst_idx);
     Real exp45logsig[mam4::AeroConfig::num_modes()],
         alogsig[mam4::AeroConfig::num_modes()],
         num2vol_ratio_min_nmodes[mam4::AeroConfig::num_modes()],
@@ -64,9 +52,11 @@ void loadaer(Ensemble *ensemble) {
                             num2vol_ratio_max_nmodes); // voltonumblo_amode
 
     mam4::ndrop::loadaer(
-        state_q.data(), nspec_amode, air_density, phase, lspectype_amode,
-        specdens_amode, spechygro, lmassptr_amode, num2vol_ratio_min_nmodes,
-        num2vol_ratio_max_nmodes, numptr_amode, qcldbrn, qcldbrn1d_num.data(),
+        state_q.data(), mam4::AeroConfig::nspec_amode, air_density, phase,
+        mam4::AeroConfig::lspectype_amode, mam4::AeroConfig::specdens_amode,
+        mam4::AeroConfig::spechygro, mam4::AeroConfig::lmassptr_amode,
+        num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes,
+        mam4::AeroConfig::numptr_amode, qcldbrn, qcldbrn1d_num.data(),
         naerosol.data(), vaerosol.data(), hygro.data());
 
     output.set("naerosol", naerosol);

--- a/src/validation/ndrop/update_from_cldn_profile.cpp
+++ b/src/validation/ndrop/update_from_cldn_profile.cpp
@@ -25,7 +25,7 @@ void update_from_cldn_profile(Ensemble *ensemble) {
     const Real air_density = input.get_array("cs_col_in_kk")[0];
     const Real air_density_kp1 = input.get_array("cs_col_in_kp1")[0];
 
-    const auto state_q_col_in_kp1 = input.get_array("state_q_col_in_kp1");
+    auto state_q_col_in_kp1 = input.get_array("state_q_col_in_kp1");
     Real qcld = input.get_array("qcld")[0];
 
     Real exp45logsig[mam4::AeroConfig::num_modes()],
@@ -86,13 +86,18 @@ void update_from_cldn_profile(Ensemble *ensemble) {
     View1D mact_view("mact_view", ntot_amode);
     Kokkos::deep_copy(mact_view, mact_host);
 
+    const int pcnst = mam4::aero_model::pcnst;
+    View1DHost state_q_col_in_kp1_host(state_q_col_in_kp1.data(), pcnst);
+    View1D state_q_col_in_kp1_view("state_q_col_in_kp1_view", pcnst);
+    Kokkos::deep_copy(state_q_col_in_kp1_view, state_q_col_in_kp1_host);
+
     Kokkos::parallel_for(
         "update_from_cldn_profile", 1, KOKKOS_LAMBDA(int) {
           mam4::ndrop::update_from_cldn_profile(
               cldn_col_in, cldn_col_in_kp1, dtinv, wtke_col_in, zs,
               dz, // ! in
               temp_col_in, air_density, air_density_kp1, csbot_cscen,
-              state_q_col_in_kp1.data(), // ! in
+              state_q_col_in_kp1_view.data(), // ! in
               num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes, exp45logsig,
               alogsig, aten, raercol_nsav_view, raercol_nsav_kp1_view,
               raercol_cw_nsav_view,

--- a/src/validation/ndrop/update_from_cldn_profile.cpp
+++ b/src/validation/ndrop/update_from_cldn_profile.cpp
@@ -93,13 +93,9 @@ void update_from_cldn_profile(Ensemble *ensemble) {
               dz, // ! in
               temp_col_in, air_density, air_density_kp1, csbot_cscen,
               state_q_col_in_kp1.data(), // ! in
-              mam4::AeroConfig::lspectype_amode,
-              mam4::AeroConfig::specdens_amode, mam4::AeroConfig::spechygro,
-              mam4::AeroConfig::lmassptr_amode, num2vol_ratio_min_nmodes,
-              num2vol_ratio_max_nmodes, mam4::AeroConfig::numptr_amode,
-              mam4::AeroConfig::nspec_amode, exp45logsig, alogsig, aten,
-              mam4::AeroConfig::mam_idx, raercol_nsav_view,
-              raercol_nsav_kp1_view, raercol_cw_nsav_view,
+              num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes, exp45logsig,
+              alogsig, aten, raercol_nsav_view, raercol_nsav_kp1_view,
+              raercol_cw_nsav_view,
               nsource_col_view[0], // inout
               qcld_view[0], factnum_col_view.data(),
               ekd_view[0], // out

--- a/src/validation/ndrop/update_from_cldn_profile.cpp
+++ b/src/validation/ndrop/update_from_cldn_profile.cpp
@@ -52,18 +52,6 @@ void update_from_cldn_profile(Ensemble *ensemble) {
     auto dz = input.get_array("dz")[0];
     auto zs = input.get_array("zs")[0];
 
-    int nspec_amode[ntot_amode];
-    int lspectype_amode[maxd_aspectype][ntot_amode];
-    int lmassptr_amode[maxd_aspectype][ntot_amode];
-    Real specdens_amode[maxd_aspectype];
-    Real spechygro[maxd_aspectype];
-    int numptr_amode[ntot_amode];
-    int mam_idx[ntot_amode][nspec_max];
-    int mam_cnst_idx[ntot_amode][nspec_max];
-    mam4::ndrop::get_e3sm_parameters(
-        nspec_amode, lspectype_amode, lmassptr_amode, numptr_amode,
-        specdens_amode, spechygro, mam_idx, mam_cnst_idx);
-
     View1DHost raercol_nsav_host(raercol_nsav.data(), ncnst_tot);
     View1DHost raercol_nsav_kp1_host(raercol_nsav_kp1.data(), ncnst_tot);
     View1DHost raercol_cw_nsav_host(raercol_cw_nsav.data(), ncnst_tot);
@@ -105,10 +93,13 @@ void update_from_cldn_profile(Ensemble *ensemble) {
               dz, // ! in
               temp_col_in, air_density, air_density_kp1, csbot_cscen,
               state_q_col_in_kp1.data(), // ! in
-              lspectype_amode, specdens_amode, spechygro, lmassptr_amode,
-              num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes, numptr_amode,
-              nspec_amode, exp45logsig, alogsig, aten, mam_idx,
-              raercol_nsav_view, raercol_nsav_kp1_view, raercol_cw_nsav_view,
+              mam4::AeroConfig::lspectype_amode,
+              mam4::AeroConfig::specdens_amode, mam4::AeroConfig::spechygro,
+              mam4::AeroConfig::lmassptr_amode, num2vol_ratio_min_nmodes,
+              num2vol_ratio_max_nmodes, mam4::AeroConfig::numptr_amode,
+              mam4::AeroConfig::nspec_amode, exp45logsig, alogsig, aten,
+              mam4::AeroConfig::mam_idx, raercol_nsav_view,
+              raercol_nsav_kp1_view, raercol_cw_nsav_view,
               nsource_col_view[0], // inout
               qcld_view[0], factnum_col_view.data(),
               ekd_view[0], // out

--- a/src/validation/ndrop/update_from_explmix.cpp
+++ b/src/validation/ndrop/update_from_explmix.cpp
@@ -147,8 +147,8 @@ void update_from_explmix(Ensemble *ensemble) {
           int nsav = 0;
           mam4::ndrop::update_from_explmix(
               team, dtmicro, csbot, cldn, zn, zs, ekd, nact, mact, qcld,
-              raercol, raercol_cw, nsav, nnew, nspec_amode, mam_idx, top_lev,
-              overlapp, overlapm, ekkp, ekkm, qncld);
+              raercol, raercol_cw, nsav, nnew, top_lev, overlapp, overlapm,
+              ekkp, ekkm, qncld);
           indexes(0) = nnew;
           indexes(1) = nsav;
         });

--- a/src/validation/ndrop/update_from_explmix.cpp
+++ b/src/validation/ndrop/update_from_explmix.cpp
@@ -14,8 +14,6 @@ void update_from_explmix(Ensemble *ensemble) {
     const int ntot_amode = mam4::AeroConfig::num_modes();
     const int pver = mam4::ndrop::pver;
     const int top_lev = 6;
-    const auto mam_idx_db = input.get_array("mam_idx");
-    const auto nspec_amode_db = input.get_array("nspec_amode");
 
     static_cast<void>(input.get_array("nnew")[0]);
     static_cast<void>(input.get_array("nsav")[0]);
@@ -39,7 +37,6 @@ void update_from_explmix(Ensemble *ensemble) {
     const Real zero = 0.0;
     const int nmodes = mam4::AeroConfig::num_modes();
     const int ncnst_tot = 25;
-    const int nspec_max = 8;
     int raer_len = pver * ncnst_tot;
     int act_len = pver * nmodes;
 
@@ -128,17 +125,6 @@ void update_from_explmix(Ensemble *ensemble) {
 
     Kokkos::deep_copy(nact, nact_host);
     Kokkos::deep_copy(mact, mact_host);
-
-    int nspec_amode[nmodes];
-    int mam_idx[nmodes][nspec_max];
-    for (int m = 0; m < nmodes; m++) {
-      nspec_amode[m] = nspec_amode_db[m];
-    }
-    for (int n = 0, counter = 0; n < nspec_max; n++) {
-      for (int m = 0; m < nmodes; m++, ++counter) {
-        mam_idx[m][n] = mam_idx_db[counter];
-      }
-    }
 
     auto team_policy = mam4::ThreadTeamPolicy(1u, mam4::testing::team_size);
     Kokkos::parallel_for(

--- a/src/validation/ndrop/update_from_newcld.cpp
+++ b/src/validation/ndrop/update_from_newcld.cpp
@@ -69,12 +69,8 @@ void update_from_newcld(Ensemble *ensemble) {
               cldn_col_in, cldo_col_in, dtinv, //& ! in
               wtke_col_in, temp_col_in, air_density,
               state_q.data(), //& ! in
-              mam4::AeroConfig::lspectype_amode,
-              mam4::AeroConfig::specdens_amode, mam4::AeroConfig::spechygro,
-              mam4::AeroConfig::lmassptr_amode, num2vol_ratio_min_nmodes,
-              num2vol_ratio_max_nmodes, mam4::AeroConfig::numptr_amode,
-              mam4::AeroConfig::nspec_amode, exp45logsig, alogsig, aten,
-              mam4::AeroConfig::mam_idx, qcld_view[0], raercol_nsav_view,
+              num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes, exp45logsig,
+              alogsig, aten, qcld_view[0], raercol_nsav_view,
               raercol_cw_nsav_view, //&      ! inout
               nsource_col_out_view[0], factnum_col_out_view.data());
         });

--- a/src/validation/ndrop/update_from_newcld.cpp
+++ b/src/validation/ndrop/update_from_newcld.cpp
@@ -39,19 +39,6 @@ void update_from_newcld(Ensemble *ensemble) {
                num2vol_ratio_min_nmodes,  // voltonumbhi_amode
                num2vol_ratio_max_nmodes); // voltonumblo_amode
 
-    int nspec_amode[ntot_amode];
-    int lspectype_amode[maxd_aspectype][ntot_amode];
-    int lmassptr_amode[maxd_aspectype][ntot_amode];
-    Real specdens_amode[maxd_aspectype];
-    Real spechygro[maxd_aspectype];
-    int numptr_amode[ntot_amode];
-    int mam_idx[ntot_amode][nspec_max];
-    int mam_cnst_idx[ntot_amode][nspec_max];
-
-    get_e3sm_parameters(nspec_amode, lspectype_amode, lmassptr_amode,
-                        numptr_amode, specdens_amode, spechygro, mam_idx,
-                        mam_cnst_idx);
-
     auto raercol_nsav = input.get_array("raercol_nsav");
     auto raercol_cw_nsav = input.get_array("raercol_cw_nsav");
     auto nsource_col_out = input.get_array("nsource_col_out")[0];
@@ -82,10 +69,12 @@ void update_from_newcld(Ensemble *ensemble) {
               cldn_col_in, cldo_col_in, dtinv, //& ! in
               wtke_col_in, temp_col_in, air_density,
               state_q.data(), //& ! in
-              lspectype_amode, specdens_amode, spechygro, lmassptr_amode,
-              num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes, numptr_amode,
-              nspec_amode, exp45logsig, alogsig, aten, mam_idx, qcld_view[0],
-              raercol_nsav_view,
+              mam4::AeroConfig::lspectype_amode,
+              mam4::AeroConfig::specdens_amode, mam4::AeroConfig::spechygro,
+              mam4::AeroConfig::lmassptr_amode, num2vol_ratio_min_nmodes,
+              num2vol_ratio_max_nmodes, mam4::AeroConfig::numptr_amode,
+              mam4::AeroConfig::nspec_amode, exp45logsig, alogsig, aten,
+              mam4::AeroConfig::mam_idx, qcld_view[0], raercol_nsav_view,
               raercol_cw_nsav_view, //&      ! inout
               nsource_col_out_view[0], factnum_col_out_view.data());
         });

--- a/src/validation/ndrop/update_from_newcld.cpp
+++ b/src/validation/ndrop/update_from_newcld.cpp
@@ -25,7 +25,7 @@ void update_from_newcld(Ensemble *ensemble) {
     const Real wtke_col_in = input.get_array("wtke_col_in")[0];
     const Real temp_col_in = input.get_array("temp_col_in")[0];
     const Real air_density = input.get_array("cs_col_in")[0];
-    const auto state_q = input.get_array("state_q_col_in");
+    auto state_q = input.get_array("state_q_col_in");
     Real qcld = input.get_array("qcld")[0];
 
     Real exp45logsig[mam4::AeroConfig::num_modes()],
@@ -63,12 +63,17 @@ void update_from_newcld(Ensemble *ensemble) {
     View1D factnum_col_out_view("factnum_col_out_view", ntot_amode);
     Kokkos::deep_copy(factnum_col_out_view, factnum_col_out_host);
 
+    const int pcnst = mam4::aero_model::pcnst;
+    View1DHost state_q_host(state_q.data(), pcnst);
+    View1D state_q_view("state_q_view", pcnst);
+    Kokkos::deep_copy(state_q_view, state_q_host);
+
     Kokkos::parallel_for(
         "update_from_newcld", 1, KOKKOS_LAMBDA(int) {
           update_from_newcld(
               cldn_col_in, cldo_col_in, dtinv, //& ! in
               wtke_col_in, temp_col_in, air_density,
-              state_q.data(), //& ! in
+              state_q_view.data(), //& ! in
               num2vol_ratio_min_nmodes, num2vol_ratio_max_nmodes, exp45logsig,
               alogsig, aten, qcld_view[0], raercol_nsav_view,
               raercol_cw_nsav_view, //&      ! inout

--- a/src/validation/water_uptake/modal_aero_water_uptake_dr.cpp
+++ b/src/validation/water_uptake/modal_aero_water_uptake_dr.cpp
@@ -30,19 +30,11 @@ void modal_aero_water_uptake_dr(Ensemble *ensemble) {
     auto dgncur_awet = input.get_array("dgncur_awet");
     auto qaerwat = input.get_array("qaerwat");
 
-    int nspec_amode[mam4::AeroConfig::num_modes()];
-    int lspectype_amode[mam4::water_uptake::maxd_aspectype]
-                       [mam4::AeroConfig::num_modes()];
-    Real specdens_amode[mam4::water_uptake::maxd_aspectype];
-    Real spechygro[mam4::water_uptake::maxd_aspectype];
-
-    mam4::water_uptake::get_e3sm_parameters(nspec_amode, lspectype_amode,
-                                            specdens_amode, spechygro);
-
     mam4::water_uptake::modal_aero_water_uptake_dr(
-        nspec_amode, specdens_amode, spechygro, lspectype_amode, state_q.data(),
-        temperature, pmid, cldn, dgncur_a.data(), dgncur_awet.data(),
-        qaerwat.data());
+        mam4::AeroConfig::nspec_amode, mam4::AeroConfig::specdens_amode,
+        mam4::AeroConfig::spechygro, mam4::AeroConfig::lspectype_amode,
+        state_q.data(), temperature, pmid, cldn, dgncur_a.data(),
+        dgncur_awet.data(), qaerwat.data());
 
     output.set("dgncur_awet", dgncur_awet);
     output.set("qaerwat", qaerwat);

--- a/src/validation/water_uptake/modal_aero_water_uptake_dr.cpp
+++ b/src/validation/water_uptake/modal_aero_water_uptake_dr.cpp
@@ -31,8 +31,6 @@ void modal_aero_water_uptake_dr(Ensemble *ensemble) {
     auto qaerwat = input.get_array("qaerwat");
 
     mam4::water_uptake::modal_aero_water_uptake_dr(
-        mam4::AeroConfig::nspec_amode, mam4::AeroConfig::specdens_amode,
-        mam4::AeroConfig::spechygro, mam4::AeroConfig::lspectype_amode,
         state_q.data(), temperature, pmid, cldn, dgncur_a.data(),
         dgncur_awet.data(), qaerwat.data());
 

--- a/src/validation/water_uptake/modal_aero_water_uptake_dr_col.cpp
+++ b/src/validation/water_uptake/modal_aero_water_uptake_dr_col.cpp
@@ -83,11 +83,9 @@ void modal_aero_water_uptake_dr_col(Ensemble *ensemble) {
               const auto qaerwat_m_kk =
                   Kokkos::subview(qaerwat, kk, Kokkos::ALL());
               mam4::water_uptake::modal_aero_water_uptake_dr(
-                  mam4::AeroConfig::nspec_amode,
-                  mam4::AeroConfig::specdens_amode, mam4::AeroConfig::spechygro,
-                  mam4::AeroConfig::lspectype_amode, state_q_kk.data(),
-                  temperature(kk), pmid(kk), cldn(kk), dgnumdry_m_kk.data(),
-                  dgnumwet_m_kk.data(), qaerwat_m_kk.data());
+                  state_q_kk.data(), temperature(kk), pmid(kk), cldn(kk),
+                  dgnumdry_m_kk.data(), dgnumwet_m_kk.data(),
+                  qaerwat_m_kk.data());
 
             } // kk
           });

--- a/src/validation/water_uptake/modal_aero_water_uptake_dr_col.cpp
+++ b/src/validation/water_uptake/modal_aero_water_uptake_dr_col.cpp
@@ -74,16 +74,6 @@ void modal_aero_water_uptake_dr_col(Ensemble *ensemble) {
       Kokkos::parallel_for(
           team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
             for (int kk = top_lev; kk < pver; ++kk) {
-
-              int nspec_amode[mam4::AeroConfig::num_modes()];
-              int lspectype_amode[mam4::water_uptake::maxd_aspectype]
-                                 [mam4::AeroConfig::num_modes()];
-              Real specdens_amode[mam4::water_uptake::maxd_aspectype];
-              Real spechygro[mam4::water_uptake::maxd_aspectype];
-
-              mam4::water_uptake::get_e3sm_parameters(
-                  nspec_amode, lspectype_amode, specdens_amode, spechygro);
-
               const auto state_q_kk =
                   Kokkos::subview(state_q, kk, Kokkos::ALL());
               const auto dgnumdry_m_kk =
@@ -93,10 +83,11 @@ void modal_aero_water_uptake_dr_col(Ensemble *ensemble) {
               const auto qaerwat_m_kk =
                   Kokkos::subview(qaerwat, kk, Kokkos::ALL());
               mam4::water_uptake::modal_aero_water_uptake_dr(
-                  nspec_amode, specdens_amode, spechygro, lspectype_amode,
-                  state_q_kk.data(), temperature(kk), pmid(kk), cldn(kk),
-                  dgnumdry_m_kk.data(), dgnumwet_m_kk.data(),
-                  qaerwat_m_kk.data());
+                  mam4::AeroConfig::nspec_amode,
+                  mam4::AeroConfig::specdens_amode, mam4::AeroConfig::spechygro,
+                  mam4::AeroConfig::lspectype_amode, state_q_kk.data(),
+                  temperature(kk), pmid(kk), cldn(kk), dgnumdry_m_kk.data(),
+                  dgnumwet_m_kk.data(), qaerwat_m_kk.data());
 
             } // kk
           });

--- a/src/validation/water_uptake/modal_aero_water_uptake_dr_wetdens.cpp
+++ b/src/validation/water_uptake/modal_aero_water_uptake_dr_wetdens.cpp
@@ -32,8 +32,6 @@ void modal_aero_water_uptake_dr_wetdens(Ensemble *ensemble) {
 
     std::vector<Real> wetdens(mam4::AeroConfig::num_modes(), 0.0);
     mam4::water_uptake::modal_aero_water_uptake_dr(
-        mam4::AeroConfig::nspec_amode, mam4::AeroConfig::specdens_amode,
-        mam4::AeroConfig::spechygro, mam4::AeroConfig::lspectype_amode,
         state_q.data(), temperature, pmid, cldn, dgncur_a.data(),
         dgncur_awet.data(), qaerwat.data(), wetdens.data());
 

--- a/src/validation/water_uptake/modal_aero_water_uptake_dr_wetdens.cpp
+++ b/src/validation/water_uptake/modal_aero_water_uptake_dr_wetdens.cpp
@@ -30,20 +30,12 @@ void modal_aero_water_uptake_dr_wetdens(Ensemble *ensemble) {
     auto dgncur_awet = input.get_array("dgncur_awet");
     auto qaerwat = input.get_array("qaerwat");
 
-    int nspec_amode[mam4::AeroConfig::num_modes()];
-    int lspectype_amode[mam4::water_uptake::maxd_aspectype]
-                       [mam4::AeroConfig::num_modes()];
-    Real specdens_amode[mam4::water_uptake::maxd_aspectype];
-    Real spechygro[mam4::water_uptake::maxd_aspectype];
-
-    mam4::water_uptake::get_e3sm_parameters(nspec_amode, lspectype_amode,
-                                            specdens_amode, spechygro);
-
     std::vector<Real> wetdens(mam4::AeroConfig::num_modes(), 0.0);
     mam4::water_uptake::modal_aero_water_uptake_dr(
-        nspec_amode, specdens_amode, spechygro, lspectype_amode, state_q.data(),
-        temperature, pmid, cldn, dgncur_a.data(), dgncur_awet.data(),
-        qaerwat.data(), wetdens.data());
+        mam4::AeroConfig::nspec_amode, mam4::AeroConfig::specdens_amode,
+        mam4::AeroConfig::spechygro, mam4::AeroConfig::lspectype_amode,
+        state_q.data(), temperature, pmid, cldn, dgncur_a.data(),
+        dgncur_awet.data(), qaerwat.data(), wetdens.data());
 
     output.set("dgncur_awet", dgncur_awet);
     output.set("qaerwat", qaerwat);

--- a/src/validation/water_uptake/modal_aero_water_uptake_dryaer.cpp
+++ b/src/validation/water_uptake/modal_aero_water_uptake_dryaer.cpp
@@ -17,15 +17,6 @@ void modal_aero_water_uptake_dryaer(Ensemble *ensemble) {
     auto dgncur_a = input.get_array("dgncur_a");
     auto state_q = input.get_array("state_q");
 
-    int nspec_amode[mam4::AeroConfig::num_modes()];
-    int lspectype_amode[mam4::water_uptake::maxd_aspectype]
-                       [mam4::AeroConfig::num_modes()];
-    Real specdens_amode[mam4::water_uptake::maxd_aspectype];
-    Real spechygro[mam4::water_uptake::maxd_aspectype];
-
-    mam4::water_uptake::get_e3sm_parameters(nspec_amode, lspectype_amode,
-                                            specdens_amode, spechygro);
-
     std::vector<Real> hygro(mam4::AeroConfig::num_modes(), 0.0);
     std::vector<Real> naer(mam4::AeroConfig::num_modes(), 0.0);
     std::vector<Real> dryrad(mam4::AeroConfig::num_modes(), 0.0);
@@ -36,10 +27,11 @@ void modal_aero_water_uptake_dryaer(Ensemble *ensemble) {
     std::vector<Real> specdens_1(mam4::AeroConfig::num_modes(), 0.0);
 
     mam4::water_uptake::modal_aero_water_uptake_dryaer(
-        nspec_amode, specdens_amode, spechygro, lspectype_amode, state_q.data(),
-        dgncur_a.data(), hygro.data(), naer.data(), dryrad.data(),
-        dryvol.data(), drymass.data(), rhcrystal.data(), rhdeliques.data(),
-        specdens_1.data());
+        mam4::AeroConfig::nspec_amode, mam4::AeroConfig::specdens_amode,
+        mam4::AeroConfig::spechygro, mam4::AeroConfig::lspectype_amode,
+        state_q.data(), dgncur_a.data(), hygro.data(), naer.data(),
+        dryrad.data(), dryvol.data(), drymass.data(), rhcrystal.data(),
+        rhdeliques.data(), specdens_1.data());
 
     output.set("hygro", hygro);
     output.set("naer", naer);

--- a/src/validation/water_uptake/modal_aero_water_uptake_dryaer.cpp
+++ b/src/validation/water_uptake/modal_aero_water_uptake_dryaer.cpp
@@ -27,8 +27,6 @@ void modal_aero_water_uptake_dryaer(Ensemble *ensemble) {
     std::vector<Real> specdens_1(mam4::AeroConfig::num_modes(), 0.0);
 
     mam4::water_uptake::modal_aero_water_uptake_dryaer(
-        mam4::AeroConfig::nspec_amode, mam4::AeroConfig::specdens_amode,
-        mam4::AeroConfig::spechygro, mam4::AeroConfig::lspectype_amode,
         state_q.data(), dgncur_a.data(), hygro.data(), naer.data(),
         dryrad.data(), dryvol.data(), drymass.data(), rhcrystal.data(),
         rhdeliques.data(), specdens_1.data());


### PR DESCRIPTION
These functions only copied constant 1D arrays into 2D  arrays.  Just create const static 2D arrays and remove these functions. The new arrays are in aero_config.hpp.

What I thought would be a quick fix became much more extensive.  These static arrays were passed down through multiple layers of functions and on the GPU const static are not allowed to be used this way.  Anyway, there is no need to pass around const static data when the values can just be fetched when needed from anywhere.  

There are lots of files touched but also function signatures simplified and I think the code is a bit cleaner now.

Since just changed how const static data is fetched:
[BFB]
