### PR TITLE
Alternative to PR 565 that fixes only aerosol property accesses.

### DIFF
--- a/src/mam4xx/mode_dry_particle_size.hpp
+++ b/src/mam4xx/mode_dry_particle_size.hpp
@@ -40,10 +40,10 @@ void mode_avg_dry_particle_diam(const AeroSpeciesView &aero_species,
                                          static_cast<AeroId>(aid));
     if (s >= 0) {
       volume_mixing_ratio_i +=
-          progs.q_aero_i[mode_idx][s](k) / aero_species(s).density;
+          progs.q_aero_i[mode_idx][s](k) / aero_species(aid).density;
 
       volume_mixing_ratio_c +=
-          progs.q_aero_c[mode_idx][s](k) / aero_species(s).density;
+          progs.q_aero_c[mode_idx][s](k) / aero_species(aid).density;
     }
   }
   const Real mean_vol_i = volume_mixing_ratio_i / progs.n_mode_i[mode_idx](k);

--- a/src/mam4xx/mode_hygroscopicity.hpp
+++ b/src/mam4xx/mode_hygroscopicity.hpp
@@ -44,9 +44,9 @@ void mode_hygroscopicity_i(const AeroSpeciesView &aero_species,
                                          static_cast<AeroId>(aid));
     if (s >= 0) {
       const Real mass_mix_ratio = progs.q_aero_i[mode_idx][s](k);
-      volume_mixing_ratio += mass_mix_ratio / aero_species(s).density;
-      hyg += mass_mix_ratio * aero_species(s).hygroscopicity /
-             aero_species(s).density;
+      volume_mixing_ratio += mass_mix_ratio / aero_species(aid).density;
+      hyg += mass_mix_ratio * aero_species(aid).hygroscopicity /
+             aero_species(aid).density;
     }
   }
   diags.hygroscopicity[mode_idx](k) = hyg / volume_mixing_ratio;

--- a/src/mam4xx/mode_wet_particle_size.hpp
+++ b/src/mam4xx/mode_wet_particle_size.hpp
@@ -203,6 +203,7 @@ void mode_avg_wet_particle_diam_water_uptake(const Diagnostics &diags,
   }
 }
 
+/* TODO: remove or re-purpose the following unused function:
 // ------------------------------------------------------------------------
 //  Subroutine for calculating wet geometric mean diameter from
 //  the aerosol mass and number concentrations, using a prescribed
@@ -246,6 +247,7 @@ void diag_dgn_wet(
     dgn_awet[n] = pow(tmpb, (1.0 / 3.0) * dwet_ddry_ratio);
   }
 }
+*/
 
 } // namespace mam4
 #endif

--- a/src/mam4xx/rename.hpp
+++ b/src/mam4xx/rename.hpp
@@ -589,12 +589,12 @@ public:
     int iaer_so4 = aerosol_index_for_mode(ModeIndex::Accumulation, AeroId::SO4);
     int iaer_pom = aerosol_index_for_mode(ModeIndex::Accumulation, AeroId::POM);
 
-    _mass_2_vol[iaer_soa] =
-        config_._molecular_weight_soa / aero_species_h(iaer_soa).density;
-    _mass_2_vol[iaer_so4] =
-        config_._molecular_weight_so4 / aero_species_h(iaer_so4).density;
-    _mass_2_vol[iaer_pom] =
-        config_._molecular_weight_pom / aero_species_h(iaer_pom).density;
+    _mass_2_vol[iaer_soa] = config_._molecular_weight_soa /
+                            aero_species_h(int(AeroId::SOA)).density;
+    _mass_2_vol[iaer_so4] = config_._molecular_weight_so4 /
+                            aero_species_h(int(AeroId::SO4)).density;
+    _mass_2_vol[iaer_pom] = config_._molecular_weight_pom /
+                            aero_species_h(int(AeroId::POM)).density;
 
   } // end(init)
 

--- a/src/tests/mode_averages_unit_tests.cpp
+++ b/src/tests/mode_averages_unit_tests.cpp
@@ -77,7 +77,7 @@ TEST_CASE("modal_averages", "") {
         const int s = aerosol_index_for_mode(static_cast<mam4::ModeIndex>(m),
                                              static_cast<mam4::AeroId>(aid));
         if (s >= 0) {
-          dry_vol += mass_mixing_ratio / aero_species_h(s).density;
+          dry_vol += mass_mixing_ratio / aero_species_h(aid).density;
         }
       }
       const Real mean_vol = dry_vol / number_mixing_ratio;
@@ -156,9 +156,9 @@ TEST_CASE("modal_averages", "") {
         const int s = aerosol_index_for_mode(static_cast<mam4::ModeIndex>(m),
                                              static_cast<mam4::AeroId>(aid));
         if (s >= 0) {
-          dry_vol += mass_mixing_ratio / aero_species_h(s).density;
-          hyg += mass_mixing_ratio * aero_species_h(s).hygroscopicity /
-                 aero_species_h(s).density;
+          dry_vol += mass_mixing_ratio / aero_species_h(aid).density;
+          hyg += mass_mixing_ratio * aero_species_h(aid).hygroscopicity /
+                 aero_species_h(aid).density;
         }
       }
       hygro[m] = hyg / dry_vol;


### PR DESCRIPTION
This PR fixes invalid accesses to aerosol species properties. It also removes (well, comments out) an unused function.

Fixes #558 