### PR TITLE
Expose ndrop mixing substep count

### DIFF
--- a/src/mam4xx/ndrop.hpp
+++ b/src/mam4xx/ndrop.hpp
@@ -1068,6 +1068,7 @@ void update_from_explmix(
     const View3D raercol_cw,
     int &nsav, // indices for old, new time levels in substepping
     int &nnew, // indices for old, new time levels in substepping
+    int &nsubmix, // number of explicit vertical-mixing substeps [count]
     const int top_lev,
     // work vars
     const ColumnView &overlapp, // cloud overlap involving level kk+1 [fraction]
@@ -1153,7 +1154,7 @@ void update_from_explmix(
   //  BAD CONSTANT
   Real dtmix = 0.9 * dtmin;
   // number of substeps and bound
-  const int nsubmix = dtmicro / dtmix + 1;
+  nsubmix = dtmicro / dtmix + 1;
 
   dtmix = dtmicro / nsubmix;
 
@@ -1291,8 +1292,9 @@ void dropmixnuc(
     const View2D qqcw_fld,  // inout
     const View2D ptend_q, const ColumnView &tendnd, const View2D &factnum,
     const ColumnView &ndropcol, const ColumnView &ndropmix,
-    const ColumnView &nsource, const ColumnView &wtke, const View2D &ccn,
-    const View2D coltend, const View2D coltend_cw, const int top_lev,
+    const ColumnView &nsource, int &nsubmix, const ColumnView &wtke,
+    const View2D &ccn, const View2D coltend, const View2D coltend_cw,
+    const int top_lev,
     // work arrays
     const View3D raercol_cw, const View3D raercol, const View2D &nact,
     const View2D &mact, const ColumnView &eddy_diff, const ColumnView &zn,
@@ -1334,6 +1336,7 @@ void dropmixnuc(
   // factnum(:,:,:)     activation fraction for aerosol number [fraction]
   // nsource            droplet number mixing ratio source tendency [#/kg/s]
   // ndropmix           droplet number mixing ratio tendency due to mixing [#/kg/s]
+  // nsubmix            explicit vertical-mixing substeps [count]
   // ccn                number conc of aerosols activated at supersat [#/m^3]
   //      note:  activation fraction fluxes are defined as
   //     fluxn = [flux of activated aero. number into cloud [#/m^2/s]]
@@ -1498,7 +1501,7 @@ void dropmixnuc(
 
   int nnew = 1;
   update_from_explmix(team, dtmicro, csbot, cldn, zn, zs, eddy_diff, nact, mact,
-                      qcld, raercol, raercol_cw, nsav, nnew, top_lev,
+                      qcld, raercol, raercol_cw, nsav, nnew, nsubmix, top_lev,
                       // work vars
                       overlapp, overlapm, eddy_diff_kp, eddy_diff_km, qncld);
 

--- a/src/tests/mam4_ndrop_unit_tests.cpp
+++ b/src/tests/mam4_ndrop_unit_tests.cpp
@@ -1,11 +1,19 @@
 #include <mam4xx/mam4.hpp>
 
+#include "testing.hpp"
+
 #include <catch2/catch.hpp>
 #include <ekat_comm.hpp>
 #include <ekat_logger.hpp>
 #include <ekat_pack_kokkos.hpp>
 
 using mam4::Real;
+
+#ifdef MAM4XX_ENABLE_GPU
+constexpr int team_size = mam4::nlev;
+#else
+constexpr int team_size = 1;
+#endif
 
 // NOTE: other than the nonnegative-ish requirements, this test is basically
 // vacuous, since it mostly does the same thing as the function, but I suppose
@@ -205,6 +213,61 @@ TEST_CASE("test_explmix", "mam4_ndrop") {
 
   logger.info("q = {}", q);
   REQUIRE(mam4::FloatingPoint<Real>::equiv(q, 0.9));
+}
+
+TEST_CASE("test_update_from_explmix_reports_nsubmix", "mam4_ndrop") {
+  constexpr int pver = mam4::ndrop::pver;
+  constexpr int nmodes = mam4::AeroConfig::num_modes();
+  constexpr int ncnst_tot = mam4::ndrop::ncnst_tot;
+  constexpr int top_lev = 1;
+
+  auto csbot = mam4::testing::create_column_view(pver);
+  auto cldn = mam4::testing::create_column_view(pver);
+  auto zn = mam4::testing::create_column_view(pver);
+  auto zs = mam4::testing::create_column_view(pver);
+  auto eddy_diff = mam4::testing::create_column_view(pver);
+  auto qcld = mam4::testing::create_column_view(pver);
+  auto overlapp = mam4::testing::create_column_view(pver);
+  auto overlapm = mam4::testing::create_column_view(pver);
+  auto eddy_diff_kp = mam4::testing::create_column_view(pver);
+  auto eddy_diff_km = mam4::testing::create_column_view(pver);
+  auto qncld = mam4::testing::create_column_view(pver);
+  mam4::ndrop::View2D nact("nact", pver, nmodes);
+  mam4::ndrop::View2D mact("mact", pver, nmodes);
+  mam4::ndrop::View3D raercol("raercol", pver, 2, ncnst_tot);
+  mam4::ndrop::View3D raercol_cw("raercol_cw", pver, 2, ncnst_tot);
+  mam4::DeviceType::view_1d<int> nsubmix_device("nsubmix", 1);
+
+  Kokkos::deep_copy(csbot, 1.0);
+  Kokkos::deep_copy(cldn, 1.0);
+  Kokkos::deep_copy(zn, 1.0);
+  Kokkos::deep_copy(zs, 1.0);
+  Kokkos::deep_copy(eddy_diff, 0.01);
+  Kokkos::deep_copy(qcld, 0.0);
+  Kokkos::deep_copy(nact, 0.0);
+  Kokkos::deep_copy(mact, 0.0);
+  Kokkos::deep_copy(raercol, 0.0);
+  Kokkos::deep_copy(raercol_cw, 0.0);
+
+  const Real dtmicro = 100.0;
+  auto team_policy = mam4::ThreadTeamPolicy(1u, team_size);
+  Kokkos::parallel_for(
+      "update_from_explmix_nsubmix", team_policy,
+      KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
+        int nsav = 0;
+        int nnew = 1;
+        int nsubmix = 0;
+        mam4::ndrop::update_from_explmix(
+            team, dtmicro, csbot, cldn, zn, zs, eddy_diff, nact, mact, qcld,
+            raercol, raercol_cw, nsav, nnew, nsubmix, top_lev, overlapp,
+            overlapm, eddy_diff_kp, eddy_diff_km, qncld);
+        Kokkos::single(Kokkos::PerTeam(team),
+                       [&]() { nsubmix_device(0) = nsubmix; });
+      });
+
+  auto nsubmix_host = Kokkos::create_mirror_view(nsubmix_device);
+  Kokkos::deep_copy(nsubmix_host, nsubmix_device);
+  REQUIRE(nsubmix_host(0) == 3);
 }
 
 TEST_CASE("test_maxsat", "mam4_ndrop") {

--- a/src/validation/ndrop/dropmixnuc.cpp
+++ b/src/validation/ndrop/dropmixnuc.cpp
@@ -176,6 +176,7 @@ void dropmixnuc(Ensemble *ensemble) {
               num2vol_ratio_max_nmodes[mam4::AeroConfig::num_modes()] = {};
 
           Real aten = zero;
+          int nsubmix = 0;
 
           mam4::ndrop::ndrop_init(
               exp45logsig, alogsig, aten,
@@ -192,9 +193,9 @@ void dropmixnuc(Ensemble *ensemble) {
               wsub,
               cldo, // in
               qqcw, // inout
-              ptend_q, tendnd, factnum, ndropcol, ndropmix, nsource, wtke, ccn,
-              coltend, coltend_cw, top_lev, raercol_cw, raercol, nact, mact,
-              ekd,
+              ptend_q, tendnd, factnum, ndropcol, ndropmix, nsource, nsubmix,
+              wtke, ccn, coltend, coltend_cw, top_lev, raercol_cw, raercol,
+              nact, mact, ekd,
               // work arrays
               zn, csbot, zs, overlapp, overlapm, ekkp, ekkm, qncld, srcn,
               source, dz, csbot_cscen, raertend, qqcwtend);

--- a/src/validation/ndrop/update_from_explmix.cpp
+++ b/src/validation/ndrop/update_from_explmix.cpp
@@ -131,10 +131,11 @@ void update_from_explmix(Ensemble *ensemble) {
         team_policy, KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
           int nnew = 1;
           int nsav = 0;
+          int nsubmix = 0;
           mam4::ndrop::update_from_explmix(
               team, dtmicro, csbot, cldn, zn, zs, ekd, nact, mact, qcld,
-              raercol, raercol_cw, nsav, nnew, top_lev, overlapp, overlapm,
-              ekkp, ekkm, qncld);
+              raercol, raercol_cw, nsav, nnew, nsubmix, top_lev, overlapp,
+              overlapm, ekkp, ekkm, qncld);
           indexes(0) = nnew;
           indexes(1) = nsav;
         });


### PR DESCRIPTION
Expose the exact ndrop explicit mixing substep count without changing the physics.

## Summary

- Add an `int& nsubmix` output to `update_from_explmix` and `dropmixnuc`.
- Return the same integer that directly controls the existing explicit mixing loop.
- Update all in-tree validation call sites with local sink variables, leaving their external schemas unchanged.
- Add a deterministic Kokkos device test for the returned count.

## Validation

- `ctest -R '^mam4_ndrop_unit_tests$' --output-on-failure`: 1/1 passed.
- Complete `ndrop`-label suite: 78 passed and 2 existing max-saturation comparisons were skipped by their configured tolerance rule; no numerical failures.
- Independent review: PASS for draft-PR readiness.

## Scope

This change does not alter the computed substep count, loop bounds, equations, limiters, state updates, or production physics.